### PR TITLE
remove sfp3_sync block

### DIFF
--- a/apps/PandABox-no-fmc-sfp2_udpontrig.app.ini
+++ b/apps/PandABox-no-fmc-sfp2_udpontrig.app.ini
@@ -3,7 +3,6 @@ description:
     Standard set of PandABox blocks with:
         - no FMC modules
         - udpontrig on SFP2
-        - PandA synchroniser on SFP3
 target: PandABox
 includes: common_soft_blocks.include.ini
 
@@ -11,7 +10,4 @@ includes: common_soft_blocks.include.ini
 module: sfp_udpontrig
 sfp_site: 2
 
-[SFP3_SYNC]
-module: sfp_panda_sync
-sfp_site : 3
 


### PR DESCRIPTION
commit 215da527cfb22864cb96aaefc6dc6bfe227da6ee remove sfp3_sync block 
Don't use this at Soleil

This should also contain :
commit b4fce3c95b8536e59e5d8401a27e7c7981820f66 adding in state on reset of failing APP_NAME = PandABox-fmc_24vio build

commit 096dc6c790d8b54a4e211363035165b8e843b158 Added false path timing constraints for udpontrig