### PR TITLE
Added sign extension to encoders.vhd to be coherent with ssi_sniffer.vhd

### DIFF
--- a/targets/PandABox/hdl/encoders.vhd
+++ b/targets/PandABox/hdl/encoders.vhd
@@ -235,7 +235,9 @@ begin
         lp_test: for i in 31 downto 0 loop
            -- Discard bits not being used and MSB and LSB and append zeros on to top bits
            if (i > 31 - bits_not_used - unsigned(MSB_DISCARD_i) - unsigned(LSB_DISCARD_i)) then
-               posn_o(i) <= '0';
+               --posn_o(i) <= '0';
+               -- sign extension
+               posn_o(i) <= posn(31 - to_integer(bits_not_used - unsigned(MSB_DISCARD_i)));
            -- Add the LSB_DISCARD on to posn index count and start there
            else
                posn_o(i) <= posn(i + to_integer(unsigned(LSB_DISCARD_i)));

--- a/targets/PandABox/hdl/encoders.vhd
+++ b/targets/PandABox/hdl/encoders.vhd
@@ -233,7 +233,7 @@ begin
         -- BITS not begin used
         bits_not_used <= 31 - (unsigned(INENC_BITS_i(4 downto 0))-1);
         lp_test: for i in 31 downto 0 loop
-           -- Discard bits not being used and MSB and LSB and append zeros on to top bits
+           -- Discard bits not being used and MSB and LSB and extend the sign
            if (i > 31 - bits_not_used - unsigned(MSB_DISCARD_i) - unsigned(LSB_DISCARD_i)) then
                --posn_o(i) <= '0';
                -- sign extension
@@ -546,5 +546,4 @@ clkin_filt : entity work.delay_filter port map (
     filt_o  => CLK_IN
 );
 end rtl;
-
 


### PR DESCRIPTION
Hi
   I have implemented sign extension in the encoders.vhd to see negative numbers when we have encoders with less than 32 bits; this makes it coherent with the sign extension code in ssi_sniffer.vhd
