### PR TITLE
Fix SlowFPGA compilation issue to take account the BUILD_DIR defined …

### DIFF
--- a/common/python/generate_app.py
+++ b/common/python/generate_app.py
@@ -201,7 +201,7 @@ class AppGenerator(object):
             "descriptions.jinja2", context, config_dir, "description")
         self.expand_template(
             "sim_server.jinja2", context, self.app_build_dir, "sim_server")
-        context = jinja_context(app=self.app_name)
+        context = jinja_context(app_dir=self.app_build_dir)
         self.expand_template(
             "slow_top.files.jinja2",
             context, self.app_build_dir, "slow_top.files")

--- a/common/templates/slow_top.files.jinja2
+++ b/common/templates/slow_top.files.jinja2
@@ -1,15 +1,15 @@
-common/hdl/defines/*.vhd
-targets/PandABox/hdl/defines/*.vhd
-build/apps/{{ app }}/autogen/hdl/addr_defines.vhd
-build/apps/{{ app }}/autogen/hdl/slow_version.vhd
-build/apps/{{ app }}/autogen/hdl/top_defines.vhd
-common/hdl/serial_engine_rx.vhd
-common/hdl/serial_engine_tx.vhd
-common/hdl/serial_engine.vhd
-common/hdl/serial_link_detect.vhd
-common/hdl/shifter_in.vhd
-common/hdl/ssi_clock_gen.vhd
-common/hdl/prescaler.vhd
-targets/PandABox/SlowFPGA/src/hdl/*.vhd
-targets/PandABox/SlowFPGA/src/hdl/zynq_interface.vhd
-targets/PandABox/SlowFPGA/src/hdl/slow_top.vhd
+top/common/hdl/defines/*.vhd
+top/targets/PandABox/hdl/defines/*.vhd
+{{ app_dir }}/hdl/addr_defines.vhd
+{{ app_dir }}/hdl/slow_version.vhd
+{{ app_dir }}/hdl/top_defines.vhd
+top/common/hdl/serial_engine_rx.vhd
+top/common/hdl/serial_engine_tx.vhd
+top/common/hdl/serial_engine.vhd
+top/common/hdl/serial_link_detect.vhd
+top/common/hdl/shifter_in.vhd
+top/common/hdl/ssi_clock_gen.vhd
+top/common/hdl/prescaler.vhd
+top/targets/PandABox/SlowFPGA/src/hdl/*.vhd
+top/targets/PandABox/SlowFPGA/src/hdl/zynq_interface.vhd
+top/targets/PandABox/SlowFPGA/src/hdl/slow_top.vhd

--- a/targets/PandABox/SlowFPGA/Makefile
+++ b/targets/PandABox/SlowFPGA/Makefile
@@ -49,7 +49,7 @@ VERSION :
 # xst can't cope with long file names.
 $(LIST_FILE): $(AUTOGEN)/slow_top.files
 	ln -sfn $(TOP) top
-	sed "s:^:vhdl work top/:" $< >$@
+	sed "s:^:vhdl work :" $< >$@
 
 MAP_FLAGS = -detail -w -ol high -pr b
 PAR_FLAGS = -w -ol high


### PR DESCRIPTION
One FPGA app compilation was failed due to a different BUILD_DIR defined to the default one (top/build) in CONFIG file. 

The vhdl working paths are currently fixed to “top/xxx” in “PandA-FPGA/targets/PandABox/SlowFPGA/Makefile” file @line 52.

The workaround solution is to use default BUILD_DIR. Otherwise “slow_top.files.jinjia2” might need to take account the BUILD_DIR defined in CONFIG file and “PandABox-FPGA/targets/PandABox/SlowFPGA/Makefile” not to impose “top/” to "$(LIST_FILE): $(AUTOGEN)/slow_top.files".
