### PR TITLE
Encoder gray + signed/unsigned

### DIFF
--- a/common/hdl/defines/support.vhd
+++ b/common/hdl/defines/support.vhd
@@ -4,6 +4,9 @@ use ieee.numeric_std.all;
 
 package support is
 
+constant c_BINARY_ENCODING  : std_logic_vector(0 downto 0) := "0";
+constant c_GRAY_ENCODING    : std_logic_vector(0 downto 0) := "1";
+
 --
 -- Functions
 --

--- a/common/hdl/defines/support.vhd
+++ b/common/hdl/defines/support.vhd
@@ -4,8 +4,10 @@ use ieee.numeric_std.all;
 
 package support is
 
-constant c_BINARY_ENCODING  : std_logic_vector(0 downto 0) := "0";
-constant c_GRAY_ENCODING    : std_logic_vector(0 downto 0) := "1";
+constant c_UNSIGNED_BINARY_ENCODING  : std_logic_vector(1 downto 0) := "00";
+constant c_UNSIGNED_GRAY_ENCODING    : std_logic_vector(1 downto 0) := "01";
+constant c_SIGNED_BINARY_ENCODING    : std_logic_vector(1 downto 0) := "10";
+constant c_SIGNED_GRAY_ENCODING      : std_logic_vector(1 downto 0) := "11";
 
 --
 -- Functions

--- a/common/hdl/serial_engine_rx.vhd
+++ b/common/hdl/serial_engine_rx.vhd
@@ -119,6 +119,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
+    ENCODING        => "0",
     enable_i        => shift_enabled,
     clock_i         => shift_clock,
     data_i          => shift_data,

--- a/common/hdl/serial_engine_rx.vhd
+++ b/common/hdl/serial_engine_rx.vhd
@@ -119,7 +119,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
-    ENCODING        => "0",
+    ENCODING        => "00",
     enable_i        => shift_enabled,
     clock_i         => shift_clock,
     data_i          => shift_data,

--- a/common/hdl/shifter_in.vhd
+++ b/common/hdl/shifter_in.vhd
@@ -66,12 +66,12 @@ begin
                 smpl_hold <= (others => '0');
             -- Shift data when enabled.
             elsif (enable_i = '1') then
-				if (clock_i = '1') then
-					if ((ENCODING=c_UNSIGNED_BINARY_ENCODING) or (ENCODING=c_SIGNED_BINARY_ENCODING)) then
-						smpl_hold <= smpl_hold(DW-2 downto 0) & data_i;
-					else
-						smpl_hold <= smpl_hold(DW-2 downto 0) & (data_i xor smpl_hold(0));
-					end if;
+                if (clock_i = '1') then
+                    if ((ENCODING=c_UNSIGNED_BINARY_ENCODING) or (ENCODING=c_SIGNED_BINARY_ENCODING)) then
+                        smpl_hold <= smpl_hold(DW-2 downto 0) & data_i;
+                    else
+                        smpl_hold <= smpl_hold(DW-2 downto 0) & (data_i xor smpl_hold(0));
+                    end if;
                 end if;
             end if;
         end if;

--- a/common/hdl/shifter_in.vhd
+++ b/common/hdl/shifter_in.vhd
@@ -4,6 +4,9 @@
 --      SOLEIL Synchrotron, GIF-sur-YVETTE, France
 --
 --  Author      : Dr. Isa Uzun (isa.uzun@diamond.ac.uk)
+--
+--  modified on aug 29, 2020 by Valerio Bassetti, MaxIV Lab, Unversity of Lund 
+--  (valerio.bassetti@maxiv.lu.se)
 --------------------------------------------------------------------------------
 --
 --  Description : 48-bit serial-to-paraller shifter with valid.
@@ -19,24 +22,25 @@ use work.support.all;
 
 entity shifter_in is
 generic (
-    DW              : natural := 48
+    DW               : natural := 48
 );
 port (
-    clk_i           : in  std_logic;
-    reset_i         : in  std_logic;
+    clk_i            : in  std_logic;
+    reset_i          : in  std_logic;
+    ENCODING         : in  std_logic_vector(0 downto 0);
     -- Physical SSI interface
-    enable_i        : in  std_logic;
-    clock_i         : in  std_logic;
-    data_i          : in  std_logic;
+    enable_i         : in  std_logic;
+    clock_i          : in  std_logic;
+    data_i           : in  std_logic;
     -- Block outputs
-    data_o          : out std_logic_vector(DW-1 downto 0);
-    data_valid_o    : out std_logic
+    data_o           : out std_logic_vector(DW-1 downto 0);
+    data_valid_o     : out std_logic
 );
 end shifter_in;
 
 architecture rtl of shifter_in is
 
-signal smpl_hold    : std_logic_vector(DW-1 downto 0);
+signal smpl_hold             : std_logic_vector(DW-1 downto 0);
 signal valid_prev  : std_logic;
 signal valid_fall  : std_logic;
 
@@ -65,8 +69,12 @@ begin
                 smpl_hold <= (others => '0');
             -- Shift data when enabled.
             elsif (enable_i = '1') then
-                if (clock_i = '1') then
-                    smpl_hold <= smpl_hold(DW-2 downto 0) & data_i;
+				if (clock_i = '1') then
+					if (ENCODING=c_BINARY_ENCODING) then
+						smpl_hold <= smpl_hold(DW-2 downto 0) & data_i;
+					else
+						smpl_hold <= smpl_hold(DW-2 downto 0) & (data_i xor smpl_hold(0));
+					end if;
                 end if;
             end if;
         end if;

--- a/common/hdl/shifter_in.vhd
+++ b/common/hdl/shifter_in.vhd
@@ -4,9 +4,6 @@
 --      SOLEIL Synchrotron, GIF-sur-YVETTE, France
 --
 --  Author      : Dr. Isa Uzun (isa.uzun@diamond.ac.uk)
---
---  modified on aug 29, 2020 by Valerio Bassetti, MaxIV Lab, Unversity of Lund 
---  (valerio.bassetti@maxiv.lu.se)
 --------------------------------------------------------------------------------
 --
 --  Description : 48-bit serial-to-paraller shifter with valid.
@@ -27,7 +24,7 @@ generic (
 port (
     clk_i            : in  std_logic;
     reset_i          : in  std_logic;
-    ENCODING         : in  std_logic_vector(0 downto 0);
+    ENCODING         : in  std_logic_vector(1 downto 0);
     -- Physical SSI interface
     enable_i         : in  std_logic;
     clock_i          : in  std_logic;
@@ -40,7 +37,7 @@ end shifter_in;
 
 architecture rtl of shifter_in is
 
-signal smpl_hold             : std_logic_vector(DW-1 downto 0);
+signal smpl_hold   : std_logic_vector(DW-1 downto 0);
 signal valid_prev  : std_logic;
 signal valid_fall  : std_logic;
 
@@ -70,7 +67,7 @@ begin
             -- Shift data when enabled.
             elsif (enable_i = '1') then
 				if (clock_i = '1') then
-					if (ENCODING=c_BINARY_ENCODING) then
+					if ((ENCODING=c_UNSIGNED_BINARY_ENCODING) or (ENCODING=c_SIGNED_BINARY_ENCODING)) then
 						smpl_hold <= smpl_hold(DW-2 downto 0) & data_i;
 					else
 						smpl_hold <= smpl_hold(DW-2 downto 0) & (data_i xor smpl_hold(0));

--- a/common/templates/block_wrapper.vhd.jinja2
+++ b/common/templates/block_wrapper.vhd.jinja2
@@ -109,7 +109,7 @@ begin
     {% elif field in filter_fields("pos_mux") %}
             {{ pad(field.name+"_from_bus") }} => {{ field.name }}(I),
     {% else %}
-		{% for register in field.numbered_registers() %}
+        {% for register in field.numbered_registers() %}
             {{ pad(register.name) }} => {{ register.name }}(I),
             {% if "read" not in field.type %}
             {{ pad(register.name + "_wstb") }} => {{ register.name }}_wstb(I),
@@ -133,11 +133,11 @@ begin
         {{ entity }} : entity work.{{ entity }}
         port map (
 {% for field in fields %}
-	{% if field in filter_fields("bit_mux") %}
+    {% if field in filter_fields("bit_mux") %}
             {{ pad(field.name +"_i") }} => {{ field.name }}(I)(0),
-	{% elif field in filter_fields("pos_mux") %}
+    {% elif field in filter_fields("pos_mux") %}
             {{ pad(field.name +"_i") }} => {{ field.name }}(I),
-	{% elif field in filter_fields(".*_out") %}
+    {% elif field in filter_fields(".*_out") %}
             {{ pad(field.name + "_o") }} => {{ field.name }}_o(I),
     {% else %}
         {% for register in field.numbered_registers() %}

--- a/common/templates/hdl_timing.v.jinja2
+++ b/common/templates/hdl_timing.v.jinja2
@@ -15,10 +15,10 @@ always #4 clk_i = ~clk_i;
     {% if field.type == "bit_mux" %}
 reg         {{ field.name }};
     {% else %}
-	    {% for register in field.numbered_registers() %}
+        {% for register in field.numbered_registers() %}
 reg  [31:0] {{ register.name }};
-	    {% endfor %}
-	{% endif %}
+        {% endfor %}
+    {% endif %}
 {% endfor %}
 
 // Outputs

--- a/common/templates/pcap_hdl_timing.v.jinja2
+++ b/common/templates/pcap_hdl_timing.v.jinja2
@@ -37,15 +37,15 @@ reg              reset = 1;
     {% if field.type == "bit_mux" %}
 reg         {{ field.name }};
     {% else %}
-	    {% for register in field.registers %}
-	        {% if register.number >= 0 %}
+        {% for register in field.registers %}
+            {% if register.number >= 0 %}
 reg  [31:0] {{ register.name }};
-			{% endif %}
-	    {% endfor %}
-	    {% if field.type == "time" %}
+            {% endif %}
+        {% endfor %}
+        {% if field.type == "time" %}
 wire [47:0] {{ field.name }};
-	    {% endif %}
-	{% endif %}
+        {% endif %}
+    {% endif %}
 {% endfor %}
 
 // Outputs
@@ -73,7 +73,7 @@ reg         {{ field.name }}_err;   //Error signal
         {% for register in field.registers %}
             {% if register.number >= 0 %}
 reg         {{ register.name }}_wstb;
-			{% endif %}
+            {% endif %}
         {% endfor %}
         {% if field.type == "time" %}
 wire        {{ field.name }}_wstb;

--- a/common/templates/top_defines.vhd.jinja2
+++ b/common/templates/top_defines.vhd.jinja2
@@ -115,7 +115,7 @@ type SFP_output_interface is
   record
     TXN_OUT     : std_logic;
     TXP_OUT     : std_logic;
-	EVR_REC_CLK : std_logic;
+    EVR_REC_CLK : std_logic;
     LINK_UP     : std_logic;
   end record SFP_output_interface;
 

--- a/etc/check_ipmi
+++ b/etc/check_ipmi
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 import sys
+import errno
 from i2c import ini_file, eeprom, parse_ipmi
 
 IPMI_INI = '/opt/share/panda-fpga/ipmi.ini'
@@ -27,6 +28,13 @@ if eeprom_key == 'ignore':
 try:
     allow_16bit = eeprom_key == '16-bit'
     image = eeprom.read_eeprom(allow_16bit)
+except OSError as e:
+    if e.errno == errno.ENXIO:  # No such device or address (i.e. no FMC EEPROM detected)
+        print('FMC was expected but none detected')
+        sys.exit(1)
+    else:
+        print('Unable to read FMC EEPROM:', e)
+        sys.exit(1)
 except Exception as e:
     print('Unable to read FMC EEPROM:', e)
     sys.exit(1)

--- a/modules/fmc_acq427/hdl/fmc_acq427_wrapper.vhd
+++ b/modules/fmc_acq427/hdl/fmc_acq427_wrapper.vhd
@@ -30,14 +30,14 @@ port (
     bit_bus_i           : in  bit_bus_t;
     pos_bus_i           : in  pos_bus_t;
     -- Outputs to PosBus from FMC
-	in_val1_o				: out std32_array(0 downto 0);
-	in_val2_o				: out std32_array(0 downto 0);
-	in_val3_o				: out std32_array(0 downto 0);
-	in_val4_o				: out std32_array(0 downto 0);
-	in_val5_o				: out std32_array(0 downto 0);
-	in_val6_o				: out std32_array(0 downto 0);
-	in_val7_o				: out std32_array(0 downto 0);
-	in_val8_o				: out std32_array(0 downto 0);
+    in_val1_o               : out std32_array(0 downto 0);
+    in_val2_o               : out std32_array(0 downto 0);
+    in_val3_o               : out std32_array(0 downto 0);
+    in_val4_o               : out std32_array(0 downto 0);
+    in_val5_o               : out std32_array(0 downto 0);
+    in_val6_o               : out std32_array(0 downto 0);
+    in_val7_o               : out std32_array(0 downto 0);
+    in_val8_o               : out std32_array(0 downto 0);
     -- Outputs to BitBus from FMC
     in_ttl_o               : out std_logic_vector(0 downto 0);
     -- Memory Bus Interface

--- a/modules/fmc_loopback/hdl/fmc_loopback_wrapper.vhd
+++ b/modules/fmc_loopback/hdl/fmc_loopback_wrapper.vhd
@@ -236,7 +236,7 @@ port map (
     FMC_CLK0            => FREQ_VAL(1),
     FMC_CLK1            => FREQ_VAL(2),
     EXT_CLK             => FREQ_VAL(3),
-	FMC_MAC_LO          => MAC_LO,
+    FMC_MAC_LO          => MAC_LO,
     FMC_MAC_HI          => MAC_HI,
     SOFT_RESET          => open,
     SOFT_RESET_WSTB     => SOFT_RESET,

--- a/modules/sfp_dls_eventr/hdl/sfp_dls_eventr_wrapper.vhd
+++ b/modules/sfp_dls_eventr/hdl/sfp_dls_eventr_wrapper.vhd
@@ -17,7 +17,7 @@ port (
     -- System Bus
     bit_bus_i           : in  bit_bus_t;
     pos_bus_i           : in  pos_bus_t;
-	-- Outputs to BitBus from FMC
+    -- Outputs to BitBus from FMC
     bit1_o              : out std_logic_vector(0 downto 0);
     bit2_o              : out std_logic_vector(0 downto 0);
     bit3_o              : out std_logic_vector(0 downto 0);

--- a/old/tests/sim/panda_biss/bench/glbl.v
+++ b/old/tests/sim/panda_biss/bench/glbl.v
@@ -50,17 +50,17 @@ module glbl ();
     assign (weak1, weak0) PRLD = PRLD_int;
 
     initial begin
-	GSR_int = 1'b1;
-	PRLD_int = 1'b1;
-	#(ROC_WIDTH)
-	GSR_int = 1'b0;
-	PRLD_int = 1'b0;
+    GSR_int = 1'b1;
+    PRLD_int = 1'b1;
+    #(ROC_WIDTH)
+    GSR_int = 1'b0;
+    PRLD_int = 1'b0;
     end
 
     initial begin
-	GTS_int = 1'b1;
-	#(TOC_WIDTH)
-	GTS_int = 1'b0;
+    GTS_int = 1'b1;
+    #(TOC_WIDTH)
+    GTS_int = 1'b0;
     end
 
 endmodule

--- a/old/tests/sim/panda_slowctrl/bench/glbl.v
+++ b/old/tests/sim/panda_slowctrl/bench/glbl.v
@@ -50,17 +50,17 @@ module glbl ();
     assign (weak1, weak0) PRLD = PRLD_int;
 
     initial begin
-	GSR_int = 1'b1;
-	PRLD_int = 1'b1;
-	#(ROC_WIDTH)
-	GSR_int = 1'b0;
-	PRLD_int = 1'b0;
+    GSR_int = 1'b1;
+    PRLD_int = 1'b1;
+    #(ROC_WIDTH)
+    GSR_int = 1'b0;
+    PRLD_int = 1'b0;
     end
 
     initial begin
-	GTS_int = 1'b1;
-	#(TOC_WIDTH)
-	GTS_int = 1'b0;
+    GTS_int = 1'b1;
+    #(TOC_WIDTH)
+    GTS_int = 1'b0;
     end
 
 endmodule

--- a/targets/PandABox/SlowFPGA/src/hdl/dcard_ctrl.vhd
+++ b/targets/PandABox/SlowFPGA/src/hdl/dcard_ctrl.vhd
@@ -70,8 +70,8 @@ begin
             return X"10";
         when "100"  => -- Pass
             return X"07";
-		when "101" => -- Data passthrough (same as SSI)
-			return X"28";
+        when "101" => -- Data passthrough (same as SSI)
+            return X"28";
         when others =>
             return X"00";
     end case;

--- a/targets/PandABox/blocks/inenc/inenc.block.ini
+++ b/targets/PandABox/blocks/inenc/inenc.block.ini
@@ -16,7 +16,7 @@ description: Type of absolute/incremental protocol
 
 [ENCODING]
 type: param enum
-description: Position encoding
+description: Position encoding (for absolute encoders)
 0: Unsigned Binary
 1: Unsigned Gray
 2: Signed Binary

--- a/targets/PandABox/blocks/inenc/inenc.block.ini
+++ b/targets/PandABox/blocks/inenc/inenc.block.ini
@@ -17,8 +17,10 @@ description: Type of absolute/incremental protocol
 [ENCODING]
 type: param enum
 description: Position encoding
-0: Binary
-1: Gray
+0: Unsigned Binary
+1: Unsigned Gray
+2: Signed Binary
+3: Signed Gray
 
 [CLK_SRC]
 type: param enum

--- a/targets/PandABox/blocks/inenc/inenc.block.ini
+++ b/targets/PandABox/blocks/inenc/inenc.block.ini
@@ -14,6 +14,12 @@ description: Type of absolute/incremental protocol
 2: BISS
 3: enDat
 
+[ENCODING]
+type: param enum
+description: Position encoding
+0: Binary
+1: Gray
+
 [CLK_SRC]
 type: param enum
 description: Bypass/Pass Through encoder signals

--- a/targets/PandABox/blocks/outenc/outenc.block.ini
+++ b/targets/PandABox/blocks/outenc/outenc.block.ini
@@ -38,6 +38,12 @@ description: Type of absolute/incremental protocol
 4: ABZ Passthrough
 5: DATA Passthrough
 
+[ENCODING]
+type: param enum
+description: Position encoding
+0: Binary
+1: Gray
+
 [BITS]
 type: param uint 32
 description: Number of bits

--- a/targets/PandABox/blocks/outenc/outenc.block.ini
+++ b/targets/PandABox/blocks/outenc/outenc.block.ini
@@ -40,7 +40,7 @@ description: Type of absolute/incremental protocol
 
 [ENCODING]
 type: param enum
-description: Position encoding
+description: Position encoding (for absolute encoders)
 0: Unsigned Binary
 1: Unsigned Gray
 2: Signed Binary

--- a/targets/PandABox/blocks/outenc/outenc.block.ini
+++ b/targets/PandABox/blocks/outenc/outenc.block.ini
@@ -41,8 +41,10 @@ description: Type of absolute/incremental protocol
 [ENCODING]
 type: param enum
 description: Position encoding
-0: Binary
-1: Gray
+0: Unsigned Binary
+1: Unsigned Gray
+2: Signed Binary
+3: Signed Gray
 
 [BITS]
 type: param uint 32

--- a/targets/PandABox/hdl/biss_master.vhd
+++ b/targets/PandABox/hdl/biss_master.vhd
@@ -10,6 +10,7 @@ entity biss_master is
 port(
     clk_i        : in  std_logic;
     reset_i      : in  std_logic;
+    ENCODING     : in  std_logic_vector(0 downto 0);
     BITS         : in  std_logic_vector(7 downto 0);
     link_up_o    : out std_logic;
     health_o     : out  std_logic_vector(31 downto 0);
@@ -385,6 +386,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
+    ENCODING        => ENCODING,
     enable_i        => data_enable_i,
     clock_i         => biss_sck_rising_edge,
     data_i          => biss_dat_i,
@@ -401,6 +403,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
+    ENCODING        => "0",
     enable_i        => nEnW_enable_i,
     clock_i         => biss_sck_rising_edge,
     data_i          => biss_dat_i,
@@ -417,6 +420,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
+    ENCODING        => "0",
     enable_i        => crc_enable_i,
     clock_i         => biss_sck_rising_edge,
     data_i          => biss_dat_i,

--- a/targets/PandABox/hdl/biss_master.vhd
+++ b/targets/PandABox/hdl/biss_master.vhd
@@ -10,7 +10,7 @@ entity biss_master is
 port(
     clk_i        : in  std_logic;
     reset_i      : in  std_logic;
-    ENCODING     : in  std_logic_vector(0 downto 0);
+    ENCODING     : in  std_logic_vector(1 downto 0);
     BITS         : in  std_logic_vector(7 downto 0);
     link_up_o    : out std_logic;
     health_o     : out  std_logic_vector(31 downto 0);
@@ -403,7 +403,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
-    ENCODING        => "0",
+    ENCODING        => "00",
     enable_i        => nEnW_enable_i,
     clock_i         => biss_sck_rising_edge,
     data_i          => biss_dat_i,
@@ -420,7 +420,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
-    ENCODING        => "0",
+    ENCODING        => "00",
     enable_i        => crc_enable_i,
     clock_i         => biss_sck_rising_edge,
     data_i          => biss_dat_i,

--- a/targets/PandABox/hdl/biss_slave.vhd
+++ b/targets/PandABox/hdl/biss_slave.vhd
@@ -11,7 +11,7 @@ port (
     clk_i               : in  std_logic;
     reset_i             : in  std_logic;
     -- Configuration interface.
-    ENCODING            : in  std_logic_vector(0 downto 0);
+    ENCODING            : in  std_logic_vector(1 downto 0);
     BITS                : in  std_logic_vector(7 downto 0);
     enable_i            : in  std_logic;
     GENERATOR_ERROR     : in  std_logic;
@@ -224,7 +224,7 @@ begin
                    -- Transmit data
                    if (biss_sck_rising_edge = '1') then
                        data_cnt <= data_cnt -1;
-					   if (ENCODING=c_BINARY_ENCODING) then
+					   if ((ENCODING=c_UNSIGNED_BINARY_ENCODING) or (ENCODING=c_SIGNED_BINARY_ENCODING)) then
 					       biss_dat <= posn_latched(to_integer(data_cnt-9));
 					   else
 					       -- gray encoding

--- a/targets/PandABox/hdl/biss_slave.vhd
+++ b/targets/PandABox/hdl/biss_slave.vhd
@@ -11,6 +11,7 @@ port (
     clk_i               : in  std_logic;
     reset_i             : in  std_logic;
     -- Configuration interface.
+    ENCODING            : in  std_logic_vector(0 downto 0);
     BITS                : in  std_logic_vector(7 downto 0);
     enable_i            : in  std_logic;
     GENERATOR_ERROR     : in  std_logic;
@@ -223,7 +224,16 @@ begin
                    -- Transmit data
                    if (biss_sck_rising_edge = '1') then
                        data_cnt <= data_cnt -1;
-                       biss_dat <= posn_latched(to_integer(data_cnt-9));
+					   if (ENCODING=c_BINARY_ENCODING) then
+					       biss_dat <= posn_latched(to_integer(data_cnt-9));
+					   else
+					       -- gray encoding
+					       if(data_cnt = (unsigned(BITS) + c_nEnW_size + c_CRC_size)) then
+					           biss_dat <= posn_latched(to_integer(data_cnt-9));
+					       else
+					           biss_dat <= posn_latched(to_integer(data_cnt-9)) xor posn_latched(to_integer(data_cnt-8));
+					       end if;
+					   end if;
                        if (data_cnt = 9) then
                            data_enable <= '0';
                            nEnW_enable <= '1';

--- a/targets/PandABox/hdl/biss_slave.vhd
+++ b/targets/PandABox/hdl/biss_slave.vhd
@@ -116,7 +116,7 @@ begin
             health_biss_slave<=TO_SVECTOR(1,32);--default error 
         else
            case SM_DATA is
-		   
+           
                -- SYNCH STATE
                when STATE_SYNCH =>
                    if (enable_i = '1') then
@@ -153,7 +153,7 @@ begin
                       SM_DATA <= STATE_SYNCH;
                       sck_timeout_cnt<=c_MAX_TIMEOUT;
                    end if;
-		   
+           
                -- ACK STATE
                when STATE_ACK =>
                    -- ACK = 0
@@ -195,7 +195,7 @@ begin
                    else
                        sck_timeout_cnt<=sck_timeout_cnt-1;
                    end if;
-		   
+           
                -- ZERO STATE
                when STATE_ZERO =>
                    -- ZERO = 0
@@ -218,22 +218,22 @@ begin
                    else
                        sck_timeout_cnt<=sck_timeout_cnt-1;
                    end if;
-		   
+           
                -- DATA STATE
                when STATE_DATA =>
                    -- Transmit data
                    if (biss_sck_rising_edge = '1') then
                        data_cnt <= data_cnt -1;
-					   if ((ENCODING=c_UNSIGNED_BINARY_ENCODING) or (ENCODING=c_SIGNED_BINARY_ENCODING)) then
-					       biss_dat <= posn_latched(to_integer(data_cnt-9));
-					   else
-					       -- gray encoding
-					       if(data_cnt = (unsigned(BITS) + c_nEnW_size + c_CRC_size)) then
-					           biss_dat <= posn_latched(to_integer(data_cnt-9));
-					       else
-					           biss_dat <= posn_latched(to_integer(data_cnt-9)) xor posn_latched(to_integer(data_cnt-8));
-					       end if;
-					   end if;
+                       if ((ENCODING=c_UNSIGNED_BINARY_ENCODING) or (ENCODING=c_SIGNED_BINARY_ENCODING)) then
+                           biss_dat <= posn_latched(to_integer(data_cnt-9));
+                       else
+                           -- gray encoding
+                           if(data_cnt = (unsigned(BITS) + c_nEnW_size + c_CRC_size)) then
+                               biss_dat <= posn_latched(to_integer(data_cnt-9));
+                           else
+                               biss_dat <= posn_latched(to_integer(data_cnt-9)) xor posn_latched(to_integer(data_cnt-8));
+                           end if;
+                       end if;
                        if (data_cnt = 9) then
                            data_enable <= '0';
                            nEnW_enable <= '1';
@@ -253,7 +253,7 @@ begin
                    else
                        sck_timeout_cnt<=sck_timeout_cnt-1;
                    end if;
-		   
+           
                -- nE(error flag) nW(warning flag) STATE
                when STATE_nEnW =>
                    -- Transmit the error and warning bits
@@ -278,7 +278,7 @@ begin
                    else
                        sck_timeout_cnt<=sck_timeout_cnt-1;
                    end if;
-		   
+           
                -- CRC STATE
                when STATE_CRC =>
                    -- Transmit the calculated CRC value
@@ -302,7 +302,7 @@ begin
                    else
                        sck_timeout_cnt<=sck_timeout_cnt-1;
                    end if;
-		   
+           
                -- STOP STATE
                when STATE_STOP =>
                    -- STOP = 0 during timeout
@@ -323,7 +323,7 @@ begin
                    else
                        sck_timeout_cnt<=sck_timeout_cnt-1;
                    end if;
-		   
+           
                -- TIMEOUT STATE
                when STATE_TIMEOUT =>
                    -- STOP = 0 during timeout

--- a/targets/PandABox/hdl/biss_sniffer.vhd
+++ b/targets/PandABox/hdl/biss_sniffer.vhd
@@ -22,6 +22,7 @@ port (
     clk_i           : in  std_logic;
     reset_i         : in  std_logic;
     -- Configuration interface
+    ENCODING        : in  std_logic_vector(0 downto 0);
     BITS            : in  std_logic_vector(7 downto 0);
     link_up_o       : out std_logic;
     health_o        : out  std_logic_vector(31 downto 0);
@@ -227,6 +228,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset,
+    ENCODING        => ENCODING,
     enable_i        => data_valid,
     clock_i         => serial_clock_rise,
     data_i          => serial_data,
@@ -242,6 +244,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset,
+    ENCODING        => "0",
     enable_i        => nError_valid,
     clock_i         => serial_clock_rise,
     data_i          => serial_data,
@@ -257,6 +260,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset,
+    ENCODING        => "0",
     enable_i        => crc_valid,
     clock_i         => serial_clock_rise,
     data_i          => serial_data,

--- a/targets/PandABox/hdl/biss_sniffer.vhd
+++ b/targets/PandABox/hdl/biss_sniffer.vhd
@@ -22,7 +22,7 @@ port (
     clk_i           : in  std_logic;
     reset_i         : in  std_logic;
     -- Configuration interface
-    ENCODING        : in  std_logic_vector(0 downto 0);
+    ENCODING        : in  std_logic_vector(1 downto 0);
     BITS            : in  std_logic_vector(7 downto 0);
     link_up_o       : out std_logic;
     health_o        : out  std_logic_vector(31 downto 0);
@@ -244,7 +244,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset,
-    ENCODING        => "0",
+    ENCODING        => "00",
     enable_i        => nError_valid,
     clock_i         => serial_clock_rise,
     data_i          => serial_data,
@@ -260,7 +260,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset,
-    ENCODING        => "0",
+    ENCODING        => "00",
     enable_i        => crc_valid,
     clock_i         => serial_clock_rise,
     data_i          => serial_data,

--- a/targets/PandABox/hdl/dcard_interface.vhd
+++ b/targets/PandABox/hdl/dcard_interface.vhd
@@ -185,7 +185,7 @@ begin
                     outenc_ctrl(I) <= outenc_dir(I) & "10";
 --                when "100"  =>                        -- Pass-Through
 --                    outenc_ctrl(I) <= "000";
-				when "101" =>
+                when "101" =>
                     outenc_ctrl(I) <= "011";          -- DATA PassThrough
                 when others =>
                     outenc_ctrl(I) <= "000";

--- a/targets/PandABox/hdl/encoders.vhd
+++ b/targets/PandABox/hdl/encoders.vhd
@@ -41,6 +41,7 @@ port (
     -- Block parameters
     GENERATOR_ERROR_i   : in  std_logic;
     OUTENC_PROTOCOL_i   : in  std_logic_vector(2 downto 0);
+    OUTENC_ENCODING_i   : in  std_logic_vector(0 downto 0);
     OUTENC_BITS_i       : in  std_logic_vector(7 downto 0);
     QPERIOD_i           : in  std_logic_vector(31 downto 0);
     QPERIOD_WSTB_i      : in  std_logic;
@@ -49,6 +50,7 @@ port (
 
     DCARD_MODE_i        : in  std_logic_vector(31 downto 0);
     INENC_PROTOCOL_i    : in  std_logic_vector(2 downto 0);
+    INENC_ENCODING_i    : in  std_logic_vector(0 downto 0);
     CLK_SRC_i           : in  std_logic;
     CLK_PERIOD_i        : in  std_logic_vector(31 downto 0);
     FRAME_PERIOD_i      : in  std_logic_vector(31 downto 0);
@@ -172,6 +174,7 @@ ssi_slave_inst : entity work.ssi_slave
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
+    ENCODING        => OUTENC_ENCODING_i,
     BITS            => OUTENC_BITS_i,
     posn_i          => posn_i,
     ssi_sck_i       => CLK_IN,
@@ -185,6 +188,7 @@ biss_slave_inst : entity work.biss_slave
 port map (
     clk_i             => clk_i,
     reset_i           => reset_i,
+    ENCODING          => OUTENC_ENCODING_i,
     BITS              => OUTENC_BITS_i,
     enable_i          => enable_i,
     GENERATOR_ERROR   => GENERATOR_ERROR_i,
@@ -281,6 +285,7 @@ ssi_master_inst : entity work.ssi_master
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
+    ENCODING        => INENC_ENCODING_i,
     BITS            => INENC_BITS_i,
     CLK_PERIOD      => CLK_PERIOD_i,
     FRAME_PERIOD    => FRAME_PERIOD_i,
@@ -295,6 +300,7 @@ ssi_sniffer_inst : entity work.ssi_sniffer
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
+    ENCODING        => INENC_ENCODING_i,
     BITS            => INENC_BITS_i,
     link_up_o       => linkup_ssi,
     error_o         => open,
@@ -311,6 +317,7 @@ biss_master_inst : entity work.biss_master
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
+    ENCODING        => INENC_ENCODING_i,
     BITS            => INENC_BITS_i,
     link_up_o       => linkup_biss_master,
     health_o        => health_biss_master,
@@ -327,6 +334,7 @@ biss_sniffer_inst : entity work.biss_sniffer
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
+    ENCODING        => INENC_ENCODING_i,
     BITS            => INENC_BITS_i,
     link_up_o       => linkup_biss_sniffer,
     health_o        => health_biss_sniffer,

--- a/targets/PandABox/hdl/encoders_block.vhd
+++ b/targets/PandABox/hdl/encoders_block.vhd
@@ -116,7 +116,7 @@ INENC_CONN_OUT_o <= STATUS(0);
 
 -- Certain parameter changes must initiate a block reset.
 reset <= reset_i or OUTENC_PROTOCOL_WSTB or OUTENC_BITS_WSTB or INENC_PROTOCOL_WSTB
-		 or OUTENC_ENCODING_WSTB or INENC_ENCODING_WSTB
+         or OUTENC_ENCODING_WSTB or INENC_ENCODING_WSTB
          or CLK_PERIOD_WSTB or FRAME_PERIOD_WSTB or INENC_BITS_WSTB;
 
 DCARD_TYPE <= x"0000000" & '0' & DCARD_MODE_i(3 downto 1);

--- a/targets/PandABox/hdl/encoders_block.vhd
+++ b/targets/PandABox/hdl/encoders_block.vhd
@@ -241,7 +241,7 @@ port map(
     -- Block parameters
     GENERATOR_ERROR_i   => GENERATOR_ERROR(0),
     OUTENC_PROTOCOL_i   => OUTENC_PROTOCOL(2 downto 0),
-    OUTENC_ENCODING_i   => OUTENC_ENCODING(0 downto 0),
+    OUTENC_ENCODING_i   => OUTENC_ENCODING(1 downto 0),
     OUTENC_BITS_i       => OUTENC_BITS(7 downto 0),
     QPERIOD_i           => QPERIOD,
     QPERIOD_WSTB_i      => QPERIOD_WSTB,
@@ -250,7 +250,7 @@ port map(
 
     DCARD_MODE_i        => DCARD_MODE_i,
     INENC_PROTOCOL_i    => INENC_PROTOCOL(2 downto 0),
-    INENC_ENCODING_i    => INENC_ENCODING(0 downto 0),
+    INENC_ENCODING_i    => INENC_ENCODING(1 downto 0),
     CLK_SRC_i           => CLK_SRC(0),
     CLK_PERIOD_i        => CLK_PERIOD,
     FRAME_PERIOD_i      => FRAME_PERIOD,

--- a/targets/PandABox/hdl/encoders_block.vhd
+++ b/targets/PandABox/hdl/encoders_block.vhd
@@ -66,6 +66,8 @@ signal reset            : std_logic;
 signal GENERATOR_ERROR          : std_logic_vector(31 downto 0);
 signal OUTENC_PROTOCOL          : std_logic_vector(31 downto 0);
 signal OUTENC_PROTOCOL_WSTB     : std_logic;
+signal OUTENC_ENCODING          : std_logic_vector(31 downto 0);
+signal OUTENC_ENCODING_WSTB     : std_logic;
 signal OUTENC_BITS              : std_logic_vector(31 downto 0);
 signal OUTENC_BITS_WSTB         : std_logic;
 signal QPERIOD                  : std_logic_vector(31 downto 0);
@@ -81,6 +83,8 @@ signal clk_ext                  : std_logic;
 -- Block Configuration Registers
 signal INENC_PROTOCOL           : std_logic_vector(31 downto 0);
 signal INENC_PROTOCOL_WSTB      : std_logic;
+signal INENC_ENCODING           : std_logic_vector(31 downto 0);
+signal INENC_ENCODING_WSTB      : std_logic;
 signal CLK_SRC                  : std_logic_vector(31 downto 0);
 signal CLK_PERIOD               : std_logic_vector(31 downto 0);
 signal CLK_PERIOD_WSTB          : std_logic;
@@ -112,6 +116,7 @@ INENC_CONN_OUT_o <= STATUS(0);
 
 -- Certain parameter changes must initiate a block reset.
 reset <= reset_i or OUTENC_PROTOCOL_WSTB or OUTENC_BITS_WSTB or INENC_PROTOCOL_WSTB
+		 or OUTENC_ENCODING_WSTB or INENC_ENCODING_WSTB
          or CLK_PERIOD_WSTB or FRAME_PERIOD_WSTB or INENC_BITS_WSTB;
 
 DCARD_TYPE <= x"0000000" & '0' & DCARD_MODE_i(3 downto 1);
@@ -146,6 +151,8 @@ port map (
     GENERATOR_ERROR     => GENERATOR_ERROR,
     PROTOCOL            => OUTENC_PROTOCOL,
     PROTOCOL_WSTB       => OUTENC_PROTOCOL_WSTB,
+    ENCODING            => OUTENC_ENCODING,
+    ENCODING_WSTB       => OUTENC_ENCODING_WSTB,
     DCARD_TYPE          => DCARD_TYPE,
     BITS                => OUTENC_BITS,
     BITS_WSTB           => OUTENC_BITS_WSTB,
@@ -175,6 +182,8 @@ port map (
 
     PROTOCOL            => INENC_PROTOCOL,
     PROTOCOL_WSTB       => INENC_PROTOCOL_WSTB,
+    ENCODING            => INENC_ENCODING,
+    ENCODING_WSTB       => INENC_ENCODING_WSTB,
     CLK_SRC             => CLK_SRC,
     CLK_SRC_WSTB        => open,
     CLK_PERIOD          => CLK_PERIOD,
@@ -232,6 +241,7 @@ port map(
     -- Block parameters
     GENERATOR_ERROR_i   => GENERATOR_ERROR(0),
     OUTENC_PROTOCOL_i   => OUTENC_PROTOCOL(2 downto 0),
+    OUTENC_ENCODING_i   => OUTENC_ENCODING(0 downto 0),
     OUTENC_BITS_i       => OUTENC_BITS(7 downto 0),
     QPERIOD_i           => QPERIOD,
     QPERIOD_WSTB_i      => QPERIOD_WSTB,
@@ -240,6 +250,7 @@ port map(
 
     DCARD_MODE_i        => DCARD_MODE_i,
     INENC_PROTOCOL_i    => INENC_PROTOCOL(2 downto 0),
+    INENC_ENCODING_i    => INENC_ENCODING(0 downto 0),
     CLK_SRC_i           => CLK_SRC(0),
     CLK_PERIOD_i        => CLK_PERIOD,
     FRAME_PERIOD_i      => FRAME_PERIOD,

--- a/targets/PandABox/hdl/ssi_master.vhd
+++ b/targets/PandABox/hdl/ssi_master.vhd
@@ -19,9 +19,6 @@
 -----------------------------------------------------------------------------
 --  TO DO List:
 -----------------------------------------------------------------------------
---  modified on aug 29, 2020 by Valerio Bassetti, MaxIV Lab, Unversity of Lund 
---  (valerio.bassetti@maxiv.lu.se)
------------------------------------------------------------------------------
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -36,7 +33,7 @@ port (
     clk_i           : in  std_logic;
     reset_i         : in  std_logic;
     -- Block Parameters
-    ENCODING        : in  std_logic_vector(0 downto 0);
+    ENCODING        : in  std_logic_vector(1 downto 0);
     BITS            : in  std_logic_vector(7 downto 0);
     CLK_PERIOD      : in  std_logic_vector(31 downto 0);
     FRAME_PERIOD    : in  std_logic_vector(31 downto 0);

--- a/targets/PandABox/hdl/ssi_master.vhd
+++ b/targets/PandABox/hdl/ssi_master.vhd
@@ -19,6 +19,9 @@
 -----------------------------------------------------------------------------
 --  TO DO List:
 -----------------------------------------------------------------------------
+--  modified on aug 29, 2020 by Valerio Bassetti, MaxIV Lab, Unversity of Lund 
+--  (valerio.bassetti@maxiv.lu.se)
+-----------------------------------------------------------------------------
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -33,6 +36,7 @@ port (
     clk_i           : in  std_logic;
     reset_i         : in  std_logic;
     -- Block Parameters
+    ENCODING        : in  std_logic_vector(0 downto 0);
     BITS            : in  std_logic_vector(7 downto 0);
     CLK_PERIOD      : in  std_logic_vector(31 downto 0);
     FRAME_PERIOD    : in  std_logic_vector(31 downto 0);
@@ -109,6 +113,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
+    ENCODING        => ENCODING,
     enable_i        => shift_enable,
     clock_i         => shift_clock,
     data_i          => shift_data,

--- a/targets/PandABox/hdl/ssi_slave.vhd
+++ b/targets/PandABox/hdl/ssi_slave.vhd
@@ -4,9 +4,6 @@
 --      SOLEIL Synchrotron, GIF-sur-YVETTE, France
 --
 --  Author      : Dr. Isa Uzun (isa.uzun@diamond.ac.uk)
---
---  modified on aug 29, 2020 by Valerio Bassetti, MaxIV Lab, Unversity of Lund 
---  (valerio.bassetti@maxiv.lu.se)
 --------------------------------------------------------------------------------
 --
 --  Description : SSI Slave Interface Block.
@@ -27,7 +24,7 @@ port (
     clk_i               : in  std_logic;
     reset_i             : in  std_logic;
     -- Configuration interface.
-    ENCODING            : in  std_logic_vector(0 downto 0);
+    ENCODING            : in  std_logic_vector(1 downto 0);
     BITS                : in  std_logic_vector(7 downto 0);
     -- Block Input and Outputs.
     posn_i              : in  std_logic_vector(31 downto 0);
@@ -113,7 +110,7 @@ begin
                     if (shift_clock = '1') then
                         shift_reg <= shift_reg(30 downto 0) & shift_reg(31);
                         shift_counter <= shift_counter + 1;
-						if (ENCODING=c_BINARY_ENCODING) then
+						if ((ENCODING=c_UNSIGNED_BINARY_ENCODING) or (ENCODING=c_SIGNED_BINARY_ENCODING)) then
 							ssi_dat_o <= shift_reg(to_integer(unsigned(BITS))-1);
 						else
 							ssi_dat_o <= data_prev xor shift_reg(to_integer(unsigned(BITS))-1);

--- a/targets/PandABox/hdl/ssi_slave.vhd
+++ b/targets/PandABox/hdl/ssi_slave.vhd
@@ -110,11 +110,11 @@ begin
                     if (shift_clock = '1') then
                         shift_reg <= shift_reg(30 downto 0) & shift_reg(31);
                         shift_counter <= shift_counter + 1;
-						if ((ENCODING=c_UNSIGNED_BINARY_ENCODING) or (ENCODING=c_SIGNED_BINARY_ENCODING)) then
-							ssi_dat_o <= shift_reg(to_integer(unsigned(BITS))-1);
-						else
-							ssi_dat_o <= data_prev xor shift_reg(to_integer(unsigned(BITS))-1);
-						end if;
+                        if ((ENCODING=c_UNSIGNED_BINARY_ENCODING) or (ENCODING=c_SIGNED_BINARY_ENCODING)) then
+                            ssi_dat_o <= shift_reg(to_integer(unsigned(BITS))-1);
+                        else
+                            ssi_dat_o <= data_prev xor shift_reg(to_integer(unsigned(BITS))-1);
+                        end if;
                                      
                         data_prev <= shift_reg(to_integer(unsigned(BITS))-1);
                     end if;

--- a/targets/PandABox/hdl/ssi_sniffer.vhd
+++ b/targets/PandABox/hdl/ssi_sniffer.vhd
@@ -171,7 +171,7 @@ begin
                 if (I < intBITS) then
                     posn_o(I) <= data(I);
                 else
-					posn_o(I) <= data(intBITS-1);
+                    posn_o(I) <= data(intBITS-1);
                 end if;
             END LOOP;
         end if;

--- a/targets/PandABox/hdl/ssi_sniffer.vhd
+++ b/targets/PandABox/hdl/ssi_sniffer.vhd
@@ -4,6 +4,9 @@
 --      SOLEIL Synchrotron, GIF-sur-YVETTE, France
 --
 --  Author      : Dr. Isa Uzun (isa.uzun@diamond.ac.uk)
+--
+--  modified on aug 29, 2020 by Valerio Bassetti, MaxIV Lab, Unversity of Lund 
+--  (valerio.bassetti@maxiv.lu.se)
 --------------------------------------------------------------------------------
 --
 --  Description : Serial Interface Synchronous Recevier core.
@@ -22,6 +25,7 @@ port (
     clk_i           : in  std_logic;
     reset_i         : in  std_logic;
     -- Configuration interface
+    ENCODING        : in  std_logic_vector(0 downto 0);
     BITS            : in  std_logic_vector(7 downto 0);
     link_up_o       : out std_logic;
     error_o         : out std_logic;
@@ -148,6 +152,7 @@ generic map (
 port map (
     clk_i           => clk_i,
     reset_i         => reset,
+    ENCODING        => ENCODING,
     enable_i        => shift_enabled,
     clock_i         => serial_clock_fall,
     data_i          => serial_data,
@@ -169,7 +174,7 @@ begin
                 if (I < intBITS) then
                     posn_o(I) <= data(I);
                 else
-                    posn_o(I) <= data(intBITS-1);
+					posn_o(I) <= data(intBITS-1);
                 end if;
             END LOOP;
         end if;

--- a/targets/PandABox/hdl/ssi_sniffer.vhd
+++ b/targets/PandABox/hdl/ssi_sniffer.vhd
@@ -4,9 +4,6 @@
 --      SOLEIL Synchrotron, GIF-sur-YVETTE, France
 --
 --  Author      : Dr. Isa Uzun (isa.uzun@diamond.ac.uk)
---
---  modified on aug 29, 2020 by Valerio Bassetti, MaxIV Lab, Unversity of Lund 
---  (valerio.bassetti@maxiv.lu.se)
 --------------------------------------------------------------------------------
 --
 --  Description : Serial Interface Synchronous Recevier core.
@@ -25,7 +22,7 @@ port (
     clk_i           : in  std_logic;
     reset_i         : in  std_logic;
     -- Configuration interface
-    ENCODING        : in  std_logic_vector(0 downto 0);
+    ENCODING        : in  std_logic_vector(1 downto 0);
     BITS            : in  std_logic_vector(7 downto 0);
     link_up_o       : out std_logic;
     error_o         : out std_logic;

--- a/targets/PandABox/hdl/ttlin_top.vhd
+++ b/targets/PandABox/hdl/ttlin_top.vhd
@@ -28,9 +28,9 @@ port (
     --Memory Bus Interface
     write_strobe_i      : in  std_logic;
     write_address_i     : in  std_logic_vector(PAGE_AW-1 downto 0);
-	write_data_i        : in  std_logic_vector(31 downto 0);
-	--Memory interface
-	slow_tlp_o          : out slow_packet;
+    write_data_i        : in  std_logic_vector(31 downto 0);
+    --Memory interface
+    slow_tlp_o          : out slow_packet;
     -- TTL I/O
     pad_i               : in  std_logic_vector(TTLIN_NUM-1 downto 0);
     val_o               : out std_logic_vector(TTLIN_NUM-1 downto 0)

--- a/tests/hdl/top_defines.vhd
+++ b/tests/hdl/top_defines.vhd
@@ -114,7 +114,7 @@ type SFP_output_interface is
   record
     TXN_OUT     : std_logic;
     TXP_OUT     : std_logic;
-	EVR_REC_CLK : std_logic;
+    EVR_REC_CLK : std_logic;
     LINK_UP     : std_logic;
   end record SFP_output_interface;
 


### PR DESCRIPTION
Possibility to choose between gray and binary encoding and signed/unsigned value for absolute encoders; default is unsigned binary. Description has been updated as per GTHIBAUX comment on PR #30, to show that this affects absolute and not incremental encoders. This pull request also solves issue #34 (position_sign_extension is not optional).
