### PR TITLE
Fix sequencer to work with 1 clock tick PHASE2

### DIFF
--- a/modules/seq/hdl/seq.vhd
+++ b/modules/seq/hdl/seq.vhd
@@ -272,7 +272,7 @@ enable_mem_reset <= '1' when (current_frame.time1 = x"00000000") else '0';
 
 
 -- combinatorial logic so we can load a new row in 1 clock tick
--- commented out load_next in SEQ_FSM shows where this logically sits
+-- comments in SEQ_FSM shows where this logically sits
 load_next <= '1' when (seq_sm = WAIT_ENABLE and enable_rise = '1') or (
     seq_sm = PHASE_2 and presc_ce = '1' and tframe_counter = next_ts -1
     and last_line_repeat = '1') else '0';
@@ -285,7 +285,6 @@ if rising_edge(clk_i) then
     --
     -- Sequencer State Machine
     --
---    load_next <= '0';
 
     if TABLE_START_WSTB = '1' then
         out_val <= (others => '0');
@@ -297,7 +296,6 @@ if rising_edge(clk_i) then
         out_val <= (others => '0');
         active <= '0';
         if seq_sm /= LOAD_TABLE then
---          reset_table <= '1';
             seq_sm <= WAIT_ENABLE;
         end if;
     else
@@ -306,7 +304,6 @@ if rising_edge(clk_i) then
 
             -- State 0
             when WAIT_ENABLE =>
---              reset_table <= '0';
                 if enable_rise = '1' then
                     -- rising ENABLE and trigger not met
                     if next_trig_valid  = '0' then
@@ -330,7 +327,7 @@ if rising_edge(clk_i) then
                     TABLE_LINE_OUT <= to_unsigned(1,16);
                     LINE_REPEAT_OUT <= to_unsigned(1,32);
                     current_frame <= next_frame;
---                    load_next <= '1';
+                    -- load_next fires here
                     active <= '1';
                 end if;
 
@@ -415,7 +412,7 @@ if rising_edge(clk_i) then
                             seq_sm <= PHASE_2;                                  -- PHASE2 4
                         end if;
                         current_frame <= next_frame;
---                        load_next <= '1';
+                        -- load_next fires here
                     else
                         LINE_REPEAT_OUT <= LINE_REPEAT_OUT + 1;
                         -- No trigger active so go and wait

--- a/modules/seq/seq.timing.ini
+++ b/modules/seq/seq.timing.ini
@@ -648,22 +648,22 @@ scope: seq.block.ini
 3   : TABLE_START=1
 4   : TABLE_START=0, PRESCALE=1
 
-# OUT = 0x1 (OUT1=A)
+# OUT = 0x81 (OUT1=A, OUT2=B)
 # TRIGGER = 0x8 (POSA<=POSITION)
 # REPEATS = 0x0001
 5   : TABLE_DATA=0x8180001
 6   : TABLE_DATA=20
 7   : TABLE_DATA=1
 8   : TABLE_DATA=0
-# OUT = 0x1 (OUT1=A)
-# TRIGGER = 0x7 (POSA>=POSITION)
-# REPEATS = 0x0002
+# OUT = 0x41 (OUT1=A, OUT2=A)
+# TRIGGER = 0x8 (POSA<=POSITION)
+# REPEATS = 0x0001
 9   : TABLE_DATA=0x4180001
 10  : TABLE_DATA=20
 11  : TABLE_DATA=0
 12  : TABLE_DATA=0
 # OUT = 0x2 (OUT1=B)
-# TRIGGER = 0x8 (POSA<=POSITION)
+# TRIGGER = 0x7 (POSA>=POSITION)
 # REPEATS = 0x0003
 13   : TABLE_DATA=0x270003
 14   : TABLE_DATA=20
@@ -674,10 +674,6 @@ scope: seq.block.ini
 18  :                   -> STATE=1
 25  : ENABLE=1          -> STATE=3, ACTIVE=1, TABLE_REPEAT=1, LINE_REPEAT=1, TABLE_LINE=1, OUTA=1
 26  :                   -> STATE=4, OUTA=0, OUTB=1
-
-#27  :                   -> TABLE_LINE=2, OUTA=1, OUTB=0, STATE=3
-#28  :                   -> STATE=4
-#29  :                   -> STATE=2, TABLE_LINE=3
 27  :                   -> TABLE_LINE=2, OUTA=1, OUTB=0
 28  :                   -> STATE=2, TABLE_LINE=3
 36  : TABLE_START=1     -> STATE=0, OUTA=0, TABLE_REPEAT=0, LINE_REPEAT=0, TABLE_LINE=0
@@ -819,3 +815,45 @@ scope: seq.block.ini
 37  : TABLE_LENGTH=0
 40  : ENABLE=1
 42  : ENABLE=0
+
+
+[Test case for issue #41]
+4   : REPEATS=1
+5   : TABLE_START=1
+6   : TABLE_START=0
+# OUT = 0x40 (OUT2=A)
+# TRIGGER = 0x0 (Immediate)
+# REPEATS = 0x0001
+7   : TABLE_DATA=0x4000001
+8   : TABLE_DATA=0
+9   : TABLE_DATA=0
+10  : TABLE_DATA=1
+# OUT = 0x80 (OUT2=B)
+# TRIGGER = 0x0 (Immediate)
+# REPEATS = 0x0001
+11  : TABLE_DATA=0x8000001
+12  : TABLE_DATA=0
+13  : TABLE_DATA=0
+14  : TABLE_DATA=2
+# OUT = 0x100 (OUT2=C)
+# TRIGGER = 0x0 (Immediate)
+# REPEATS = 0x0001
+15  : TABLE_DATA=0x10000001
+16  : TABLE_DATA=0
+17  : TABLE_DATA=0
+18  : TABLE_DATA=3
+# OUT = 0x200 (OUT2=D)
+# TRIGGER = 0x0 (Immediate)
+# REPEATS = 0x0001
+19  : TABLE_DATA=0x20000001
+20  : TABLE_DATA=0
+21  : TABLE_DATA=0
+22  : TABLE_DATA=4
+23  : TABLE_LENGTH=16
+24  :                   -> STATE=1
+30  : ENABLE=1          -> ACTIVE=1, LINE_REPEAT=1, OUTA=1, TABLE_LINE=1, TABLE_REPEAT=1, STATE=4
+31  :                   -> OUTA=0, OUTB=1, TABLE_LINE=2
+33  :                   -> OUTB=0, OUTC=1, TABLE_LINE=3
+36  :                   -> OUTC=0, OUTD=1, TABLE_LINE=4
+40  :                   -> OUTD=0, ACTIVE=0, STATE=1
+48  : ENABLE=0


### PR DESCRIPTION
`load_next` was introducing a 1 clock delay on getting the next line, stopping it working for a 1 clock tick PHASE2. The following clause was inserted in the past to activate it in PHASE1, but the logic was wrong, causing #41 
`(current_frame = next_frame and seq_sm = PHASE_1 and unsigned(PRESCALE) < to_unsigned(2,32) and (current_frame.time2 = 0 or current_frame.time2 = to_unsigned(1,32)))`

This PR moves the selection of `seq_raddr` into combinatorial logic backed by a clock process that is always updating `seq_raddr_next`

All tests passing