### PR TITLE
Adapt FPGA loading to use the FPGA manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,7 @@ hdl_timing: $(TIMING_BUILD_DIRS)
 # FPGA build
 
 FPGA_FILE = $(FPGA_BUILD_DIR)/panda_top.bit
+FPGA_BIN_FILE = $(FPGA_BUILD_DIR)/panda_top.bin
 SLOW_FPGA_FILE = $(SLOW_FPGA_BUILD_DIR)/slow_top.bin
 
 FPGA_DEPENDS =
@@ -212,6 +213,13 @@ else
             TOP=$(TOP) TARGET_DIR=$(TARGET_DIR) BUILD_DIR=$(dir $@) \
             IP_DIR=$(IP_DIR)
 endif
+
+$(FPGA_BIN_FILE): $(FPGA_FILE)
+	cd $(FPGA_BUILD_DIR) && \
+        echo -e "all:\n{\n    $(FPGA_FILE)\n}\n" > bs.bif && \
+        source $(VIVADO) && \
+        bootgen -image bs.bif -arch zynq -process_bitstream bin && \
+        mv $(FPGA_FILE).bin $@
 
 $(SLOW_FPGA_FILE): $(AUTOGEN_BUILD_DIR) $(SLOW_FPGA_DEPENDS)
 	mkdir -p $(dir $@)
@@ -240,7 +248,7 @@ ZPKG_LIST = etc/panda-fpga.list
 ZPKG_VERSION = $(APP_NAME)-$(GIT_VERSION)
 ZPKG_FILE = $(BUILD_DIR)/panda-fpga@$(ZPKG_VERSION).zpg
 
-ZPKG_DEPENDS += $(FPGA_FILE)
+ZPKG_DEPENDS += $(FPGA_BIN_FILE)
 ZPKG_DEPENDS += $(SLOW_FPGA_FILE)
 ZPKG_DEPENDS += $(APP_BUILD_DIR)/ipmi.ini
 ZPKG_DEPENDS += $(APP_BUILD_DIR)/extensions

--- a/etc/load-panda-firmware
+++ b/etc/load-panda-firmware
@@ -6,7 +6,7 @@
 # on panda-server being installed
 
 # File locations
-carrier_firmware=/opt/share/panda-fpga/panda_top.bit
+carrier_firmware=/opt/share/panda-fpga/panda_top.bin
 slow_firmware=/opt/share/panda-fpga/slow_top.bin
 slow_load=/opt/bin/slow_load
 check_ipmi=/opt/bin/check_ipmi
@@ -33,6 +33,15 @@ configure_gpio_m0()
     echo $GPIO_M0 >/sys/class/gpio/unexport
 }
 
+load_fpga()
+{
+    local bitstream="$1"
+    local name="$(basename $bitstream)"
+    # Set flags for loading full bitstream
+    echo 0 > /sys/class/fpga_manager/fpga0/flags
+    ln -sf $bitstream /opt/firmware/$name
+    echo $name > /sys/class/fpga_manager/fpga0/firmware
+}
 
 [ -e $carrier_firmware -a -e $slow_firmware ]  ||
     fail "Firmware not installed"
@@ -44,6 +53,6 @@ configure_gpio_m0  &&
 $check_ipmi  &&
 
 # If FMC passes then load the carrier firmware
-cat $carrier_firmware >/dev/xdevcfg  &&
+load_fpga $carrier_firmware  &&
 # Finally load the slow FPGA
 $slow_load <$slow_firmware

--- a/etc/panda-fpga.list
+++ b/etc/panda-fpga.list
@@ -5,6 +5,7 @@ d share/www
 d lib/python/site-packages/i2c
 d etc/www
 d bin
+d firmware
 
 # Configuration files
 b share/panda-fpga/config_d autogen/config_d/config
@@ -22,7 +23,7 @@ t bin etc/check_ipmi
 t bin etc/show_ipmi
 
 # Firmware
-b share/panda-fpga FPGA/panda_top.bit
+b share/panda-fpga FPGA/panda_top.bin
 b share/panda-fpga SlowFPGA/slow_top.bin
 
 # Docs (built once for all zpkgs)


### PR DESCRIPTION
This is required to use the latest kernel version and should be merged at the same time that this [PR](https://github.com/PandABlocks/PandABlocks-rootfs/pull/18)