### PR TITLE
pcap: fix driver overrun issue caused by the last 2 IRQs too close

### DIFF
--- a/modules/pcap/hdl/pcap_dma.vhd
+++ b/modules/pcap/hdl/pcap_dma.vhd
@@ -320,7 +320,8 @@ if rising_edge(clk_i) then
                 -- Position compare completed
                 elsif (pcap_completed = '1' and writing_sample = '0') then
                     last_tlp <= '1';
-                    if (fifo_count = 0) then
+                    -- if last_tlp, wait for next buffer address assigned by PS
+                    if (fifo_count = 0 and next_dmaaddr_valid = '1') then
                         pcap_fsm <= IRQ;
                     else
                         dma_start <= '1';


### PR DESCRIPTION
to fix issue #56: "Driver data overrun" error occured when the last DMA IRQ is too close to the completion IRQ. 