### PR TITLE
pcap: avoid pcap_fsm jumping in ACTV/DMA states before last IRQ

### DIFF
--- a/modules/pcap/hdl/pcap_dma.vhd
+++ b/modules/pcap/hdl/pcap_dma.vhd
@@ -320,9 +320,11 @@ if rising_edge(clk_i) then
                 -- Position compare completed
                 elsif (pcap_completed = '1' and writing_sample = '0') then
                     last_tlp <= '1';
-                    -- if last_tlp, wait for next buffer address assigned by PS
-                    if (fifo_count = 0 and next_dmaaddr_valid = '1') then
-                        pcap_fsm <= IRQ;
+                    if (fifo_count = 0) then 
+                        -- if last_tlp, wait for next buffer address assigned by PS
+                        if (next_dmaaddr_valid = '1') then
+                            pcap_fsm <= IRQ;
+                        end if;
                     else
                         dma_start <= '1';
                         sample_count <= sample_count + transfer_size;


### PR DESCRIPTION
Sorry to add a patch to the last PR #57, I found with ILA that the last change will make pcap_fsm jumping in ACTV-DMA-IS_FINISHED states before achieving the last IRQ state, as shown in this image: 
<img width="907" alt="ILA_Overrun_200-00024ms_3pts_2 1-14-gbe2a2ea" src="https://user-images.githubusercontent.com/10975033/134166123-dbf9c267-5b47-44f4-bce4-f1cf25bb1cba.PNG">

So I fixed it by this new PR.