### PR TITLE
Changed target IO definitions

### DIFF
--- a/common/python/generate_app.py
+++ b/common/python/generate_app.py
@@ -99,10 +99,10 @@ class AppGenerator(object):
                     target + ".target.ini")))
             #self.implement_blocks(target_ini, target_path, "carrier")
             self.implement_blocks(target_ini, "modules", "carrier")
-            target_info = target_ini.items('.')
-            for item in target_info:
-                siteType=item[0]
-                siteInfo=item[1]
+            # Read in what IO site options are available on target
+            target_info = ini_get(target_ini,'.', 'io','').split('\n')
+            for target in target_info:
+                siteType, siteInfo = target.split(':')
                 site=TargetSiteConfig(siteType, siteInfo)
                 self.target_sites.append(site)
         # Implement the blocks for the soft blocks

--- a/targets/PandABox/PandABox.target.ini
+++ b/targets/PandABox/PandABox.target.ini
@@ -2,8 +2,8 @@
 # module. The config files for each carrier block can be found in
 # blocks/blockname
 [.]
-sfp: 3, i, o
-fmc: 1, i, o, io
+io: sfp: 3, i, o
+    fmc: 1, i, o, io
 
 [TTLIN]
 number: 6

--- a/targets/ZedBoard/ZedBoard.target.ini
+++ b/targets/ZedBoard/ZedBoard.target.ini
@@ -2,8 +2,7 @@
 # module. The config files for each carrier block can be found in
 # blocks/blockname
 [.]
-fmc: 1, i, o, io
-
+io: fmc: 1, i, o, io
 
 [PCAP]
 number: 1


### PR DESCRIPTION
Previously everything in [.] was assumed to be an IO interface. These changes now use an "io" key in the [.] section to define the target's IO interface definitions, allowing other keys to be added to the [.] section.