### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Upload zpkg
         uses: actions/upload-artifact@v2
         with:
-          name: fgpa-zpkg-${{ matrix.app }}
+          name: zpkgs
           path: build/panda-fpga@*.zpg
 
 
@@ -221,15 +221,15 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: fgpa-zpkg-*
-          path: artifacts
+          name: zpkgs
+          path: zpkgs
 
       - name: Github Release
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
         uses: softprops/action-gh-release@2d72d869af3bf23602f9593a1e3fd739b80ac1eb  # v0.1.12
         with:
-          files: artifacts/*
+          files: zpkgs/*
           body: See [Changelog](CHANGELOG.rst) for more details
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Merges multiple artifacts into a single artifact that the release action can use to make a release. 
- Follows solution from: https://github.com/PandABlocks/PandABlocks-server/commit/6094f414c1bed4f33b97c05bc486a3f98b6f2229 