### PR TITLE
Finedelay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ PS_PROJ = $(TGT_BUILD_DIR)/panda_ps/panda_ps.xpr
 IP_PROJ = $(TGT_BUILD_DIR)/ip_repo/managed_ip_project/managed_ip_project.xpr
 TOP_PROJ = $(FPGA_BUILD_DIR)/panda_top/carrier_fpga_top.xpr
 TOP_MODE ?= batch
+TEST_MODE ?= gui
 DEP_MODE ?= batch
 
 # Store the git hash in top-level build directory 
@@ -166,6 +167,14 @@ python_tests:
 python_timing:
 	$(PYTHON) -m unittest -v tests.test_python_sim_timing
 .PHONY: python_timing
+
+# Run a specific testbench using run_sim_<testbench-folder's-name>
+run_sim_%: $(TOP)/common/fpga.make
+	mkdir -p $(FPGA_BUILD_DIR)
+	$(MAKE) -C $(FPGA_BUILD_DIR) -f $< VIVADO_VER=$(VIVADO_VER) \
+        TOP=$(TOP) TARGET_DIR=$(TARGET_DIR) APP_BUILD_DIR=$(APP_BUILD_DIR) \
+        TGT_BUILD_DIR=$(TGT_BUILD_DIR) TEST_MODE=$(TEST_MODE) \
+        DEP_MODE=$(DEP_MODE) VER=$(VER) $@
 
 
 # ------------------------------------------------------------------------------

--- a/common/fpga.make
+++ b/common/fpga.make
@@ -168,6 +168,13 @@ $(CARRIER_FPGA_BIT) : $(CARRIER_FPGA_DEPS)
 	  -tclargs $(TOP_MODE) \
 	  -tclargs $(PLATFORM)
 
+run_sim_%: $(TOP)/tests/sim/%
+	$(RUNVIVADO) -mode $(TEST_MODE) -source $</bench/$*_tb_compile.tcl \
+	  -log $(BUILD_DIR)/test_build_top.log -nojournal \
+	  -tclargs $(TOP) \
+	  -tclargs $(BUILD_DIR) \
+	  -tclargs $(TEST_MODE)
+
 $(FPGA_BIN_FILE): $(CARRIER_FPGA_BIT)
 	echo -e "all:\n{\n    $(CARRIER_FPGA_BIT)\n}\n" > bs.bif
 	. $(VIVADO) && bootgen -image bs.bif -arch $(PLATFORM) -process_bitstream bin

--- a/common/hdl/clock2_phase.vhd
+++ b/common/hdl/clock2_phase.vhd
@@ -1,0 +1,63 @@
+-- Compute clock2x phase from main clock and main 2x clock.  Essentially
+-- this mirrors the main clock as a signal.  We can't take the main clock as a
+-- signal because that causes awful timing problems.
+--
+--             _     ___     ___     ___     ___     ___     ___     ___
+--  clk_2x_     \___/   \___/   \___/   \___/   \___/   \___/   \___/
+--                   _______         _______         _______         ___
+--  clk_i      _____/       \_______/       \_______/       \_______/
+--                   _______________                 _______________
+--  phase_0    _____/               \_______________/               \___
+--                           _______________                 ___________
+--  phase_90   _____________/               \_______________/
+--                           _______________                 ___________
+--  phase_0_2x   ___________/               \_______________/
+--               ___                 _______________                 ___
+--  phase_90_2x     \_______________/               \_______________/
+--                   _______         _______         _______         ___
+--  phase_o     ____/       \_______/       \_______/       \_______/
+--
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity clock2_phase is
+    port (
+        clk_i : in std_ulogic;
+        clk_2x_i : in std_ulogic;
+        phase_o : out std_ulogic := '0'
+    );
+end;
+
+architecture arch of clock2_phase is
+    signal phase_0 : std_ulogic := '0';
+    signal phase_90 : std_ulogic := '0';
+    -- We need to bring the main clock phase signals over to the main 2x
+    -- clock domain before attempting any logic, as otherwise the timing
+    -- becomes potentially *very* challenging.
+    signal phase_0_2x : std_ulogic := '0';
+    signal phase_90_2x : std_ulogic := '0';
+
+begin
+    process (clk_i) begin
+        if rising_edge(clk_i) then
+            phase_0 <= not phase_0;
+        end if;
+    end process;
+
+    process (clk_i) begin
+        if falling_edge(clk_i) then
+            phase_90 <= phase_0;
+        end if;
+    end process;
+
+    process (clk_2x_i) begin
+        if rising_edge(clk_2x_i) then
+            phase_0_2x <= phase_0;
+            phase_90_2x <= phase_90;
+            phase_o <= phase_0_2x xor phase_90_2x;
+        end if;
+    end process;
+end;
+

--- a/common/hdl/finedelay.vhd
+++ b/common/hdl/finedelay.vhd
@@ -1,0 +1,111 @@
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library unisim;
+use unisim.vcomponents.all;
+
+entity finedelay is
+port (
+    -- Main clock
+    clk_i : in std_logic;
+    -- double rate clock for ODDR
+    clk_2x_i : in std_logic;
+    q_delay_i : in std_logic_vector(1 downto 0);
+    o_delay_i : in std_logic_vector(4 downto 0);
+    o_delay_strobe_i : in std_logic;
+    signal_i : in std_logic;
+    signal_o : out std_logic
+);
+end finedelay;
+
+architecture rtl of finedelay is
+    signal in_signal_delay : std_logic := '0';
+    signal in_signal_delay_on2x : std_logic := '0';
+    signal in_signal_on2x : std_logic := '0';
+    signal q_delay_on2x : std_logic_vector(1 downto 0) := "00";
+    signal ddr_a : std_logic;
+    signal ddr_b : std_logic;
+    signal oddr_out : std_logic;
+    signal phase_on2x : std_logic;
+begin
+
+    process (clk_i) begin
+        if rising_edge(clk_i) then
+            in_signal_delay <= signal_i;
+        end if;
+    end process;
+
+    process (clk_2x_i) begin
+        if rising_edge(clk_2x_i) then
+            in_signal_on2x <= signal_i;
+            in_signal_delay_on2x <= in_signal_delay;
+            q_delay_on2x <= q_delay_i;
+        end if;
+    end process;
+
+    process (in_signal_on2x, in_signal_delay_on2x, phase_on2x, q_delay_on2x)
+    begin
+        case phase_on2x & q_delay_on2x is
+            when "000" =>
+                ddr_a <= in_signal_on2x;
+                ddr_b <= in_signal_on2x;
+            when "100" =>
+                ddr_a <= in_signal_on2x;
+                ddr_b <= in_signal_on2x;
+            when "001" =>
+                ddr_a <= in_signal_delay_on2x;
+                ddr_b <= in_signal_on2x;
+            when "101" =>
+                ddr_a <= in_signal_on2x;
+                ddr_b <= in_signal_on2x;
+            when "010" =>
+                ddr_a <= in_signal_delay_on2x;
+                ddr_b <= in_signal_delay_on2x;
+            when "110" =>
+                ddr_a <= in_signal_on2x;
+                ddr_b <= in_signal_on2x;
+            when "011" =>
+                ddr_a <= in_signal_delay_on2x;
+                ddr_b <= in_signal_delay_on2x;
+            when "111" =>
+                ddr_a <= in_signal_delay_on2x;
+                ddr_b <= in_signal_on2x;
+           when others =>
+        end case;
+
+    end process;
+
+    oddr_inst : ODDR port map (
+        Q => oddr_out,
+        C => clk_2x_i,
+        CE => '1',
+        D1 => ddr_b,
+        D2 => ddr_a
+    );
+
+    clock2_phase_inst : entity work.clock2_phase port map (
+        clk_i => clk_i,
+        clk_2x_i => clk_2x_i,
+        phase_o => phase_on2x
+    );
+
+    odelay_inst : ODELAYE2 generic map (
+        ODELAY_TYPE => "VAR_LOAD",
+        HIGH_PERFORMANCE_MODE => "TRUE"
+    ) port map (
+        C => clk_i,
+        ODATAIN => oddr_out,
+        DATAOUT => signal_o,
+        CLKIN => '0',
+        CNTVALUEIN => o_delay_i,
+        LD => o_delay_strobe_i,
+        LDPIPEEN => '0',
+        REGRST => '0',
+        INC => '0',
+        CINVCTRL => '0',
+        CE => '0'
+    );
+
+end rtl;

--- a/common/hdl/mmcm_clkmux.vhd
+++ b/common/hdl/mmcm_clkmux.vhd
@@ -12,8 +12,10 @@ port (fclk_clk0_ps_i      : in  std_logic;
       clk_sel_i           : in  std_logic_vector(1 downto 0);
       linkup_i            : in  std_logic;
       sma_pll_locked_o    : out std_logic;
+      fclk_locked_o       : out std_logic;
       clk_sel_stat_o      : out std_logic_vector(1 downto 0);
-      fclk_clk0_o         : out std_logic
+      fclk_clk0_o         : out std_logic;
+      fclk_clk0_2x_o      : out std_logic
       );
 
 end mmcm_clkmux;
@@ -22,17 +24,21 @@ end mmcm_clkmux;
 
 architecture rtl of mmcm_clkmux is
 
-constant c_wait_reset       : natural := 1000;
-
-signal sma_pll_reset_cnt    : unsigned(9 downto 0) := (others => '0');
 signal sma_pll_reset        : std_logic;
+signal pll2_reset           : std_logic;
 signal sma_pll_locked       : std_logic;
 signal sma_clkfbout         : std_logic;
 signal sma_clkfbout_buf     : std_logic;
+signal pll2_locked          : std_logic;
+signal pll2_clkfbout        : std_logic;
+signal pll2_clkfbout_buf    : std_logic;
 signal sma_clk_out1         : std_logic;
 signal enable_sma_clk     : std_logic;
 signal enable_mgt_clk     : std_logic;
 signal fclk_clk             : std_logic;
+signal fclk_clk_2x          : std_logic;
+signal fclk_clk_buf         : std_logic;
+signal fclk_clk_2x_buf      : std_logic;
 signal secondary_mux_out    : std_logic;
 signal primary_mux_sel      : std_logic;
 signal ps_fclk_bufh            : std_logic;
@@ -43,27 +49,20 @@ begin
 -- SMA (external clock) PLL reset
 ---------------------------------------------------------------------------
 
-ps_sma_reset_pll: process(fclk_clk)
-begin
-    if rising_edge(fclk_clk) then
-        -- Enable the MMCM reset
-        if sma_pll_reset_cnt /= c_wait_reset and sma_pll_locked = '0' then
-            sma_pll_reset_cnt <= sma_pll_reset_cnt +1;
-        -- Reset the MMCM reset when it goes out of lock
-        elsif sma_pll_locked = '1' then
-            sma_pll_reset_cnt <= (others => '0');
-        end if;
-        -- Enable the reset for 32, 125MHz clocks
-        if sma_pll_locked = '0' then
-            if sma_pll_reset_cnt = c_wait_reset then
-                sma_pll_reset <= '0';
-            else
-                sma_pll_reset <= '1';
-            end if;
-        end if;
-    end if;
-end process ps_sma_reset_pll;
+pll_autoreset_inst1 : entity work.pll_autoreset port map (
+    clk_i => ps_fclk_bufh,
+    pll_locked_i => sma_pll_locked,
+    pll_reset_o => sma_pll_reset
+);
 
+---------------------------------------------------------------------------
+-- fclk 2X PLL reset
+---------------------------------------------------------------------------
+pll_autoreset_inst2 : entity work.pll_autoreset port map (
+    clk_i => ps_fclk_bufh,
+    pll_locked_i => pll2_locked,
+    pll_reset_o => pll2_reset
+);
 
 -- PLL Clocking PRIMITIVE
 --------------------------------------
@@ -109,15 +108,68 @@ plle2_adv_inst : PLLE2_ADV
         RST                 => sma_pll_reset
 );
 
+plle2_adv_inst2 : PLLE2_ADV
+    generic map (
+        DIVCLK_DIVIDE        => 1,
+        CLKFBOUT_MULT        => 8,
+        CLKOUT0_DIVIDE       => 8,
+        CLKOUT1_DIVIDE       => 4,
+        CLKIN1_PERIOD        => 8.000,
+        CLKIN2_PERIOD        => 8.000)
+    port map (
+        -- Output clocks
+        CLKFBOUT            => pll2_clkfbout,
+        CLKOUT0             => fclk_clk,
+        CLKOUT1             => fclk_clk_2x,
+        CLKOUT2             => open,
+        CLKOUT3             => open,
+        CLKOUT4             => open,
+        CLKOUT5             => open,
+        -- Input clock control
+        CLKFBIN             => pll2_clkfbout_buf,
+        CLKIN1              => secondary_mux_out,
+        CLKIN2              => ps_fclk_bufh,
+        CLKINSEL            => primary_mux_sel,
+        -- Ports for dynamic reconfiguration
+        DADDR               => (others => '0'),
+        DCLK                => '0',
+        DEN                 => '0',
+        DI                  => (others => '0'),
+        DO                  => open,
+        DRDY                => open,
+        DWE                 => '0',
+        -- Other control and status signals
+        LOCKED              => pll2_locked,
+        PWRDWN              => '0',
+        RST                 => pll2_reset
+);
 
 ---------------------------------------------------------------------------
   -- Output buffering
 ---------------------------------------------------------------------------
 
-clkf_buf : BUFG
+sma_clkf_buf : BUFG
     port map
         (O => sma_clkfbout_buf,
          I => sma_clkfbout
+);
+
+clkf_buf : BUFG
+    port map
+        (O => pll2_clkfbout_buf,
+         I => pll2_clkfbout
+);
+
+fclk_buf1 : BUFG
+    port map
+        (O => fclk_clk_buf,
+         I => fclk_clk
+);
+
+flck_buf2 : BUFG
+    port map
+        (O => fclk_clk_2x_buf,
+         I => fclk_clk_2x
 );
 
 ---------------------------------------------------------------------------
@@ -139,14 +191,6 @@ clk_mux_bufh: BUFH
         I => fclk_clk0_ps_i
 );
 
-primary_clkmux: BUFGMUX
-    port map (
-        O => fclk_clk,
-        I0 => ps_fclk_bufh,
-        I1 => secondary_mux_out,
-        S => primary_mux_sel
-);
-
 -- Secondary mux switches between external sma clock and mgt recovered clock.
 -- Secondary MUX select checks for MGT link-up.
 
@@ -161,7 +205,9 @@ secondary_clkmux : BUFGMUX
 -- Assign outputs
 
 clk_sel_stat_o <= enable_mgt_clk & enable_sma_clk;
-fclk_clk0_o <= fclk_clk;
+fclk_clk0_o <= fclk_clk_buf;
+fclk_clk0_2x_o <= fclk_clk_2x_buf;
 sma_pll_locked_o <= sma_pll_locked;
+fclk_locked_o <= pll2_locked;
 
 end architecture rtl;

--- a/common/hdl/pll_autoreset.vhd
+++ b/common/hdl/pll_autoreset.vhd
@@ -1,0 +1,40 @@
+library ieee;
+use ieee.numeric_std.all;
+use ieee.std_logic_1164.all;
+
+entity pll_autoreset is
+port (
+    clk_i        : in std_logic;
+    pll_locked_i : in std_logic;
+    pll_reset_o  : out std_logic
+);
+end pll_autoreset;
+
+
+architecture rtl of pll_autoreset is
+constant c_wait_reset : natural := 1000;
+
+signal pll_reset_cnt  : unsigned(9 downto 0) := (others => '0');
+begin
+
+process(clk_i)
+begin
+    if rising_edge(clk_i) then
+        -- Enable the PLL reset
+        if pll_reset_cnt /= c_wait_reset and pll_locked_i = '0' then
+            pll_reset_cnt <= pll_reset_cnt + 1;
+        -- Reset the PLL reset when it goes out of lock
+        elsif pll_locked_i = '1' then
+            pll_reset_cnt <= (others => '0');
+        end if;
+        if pll_locked_i = '0' then
+            if pll_reset_cnt = c_wait_reset then
+                pll_reset_o <= '0';
+            else
+                pll_reset_o <= '1';
+            end if;
+        end if;
+    end if;
+end process;
+
+end architecture rtl;

--- a/modules/lvdsout/hdl/lvdsout_block.vhd
+++ b/modules/lvdsout/hdl/lvdsout_block.vhd
@@ -22,6 +22,7 @@ entity lvdsout_block is
 port (
     -- Clock and Reset
     clk_i               : in  std_logic;
+    clk_2x_i            : in  std_logic;
     reset_i             : in  std_logic;
     -- Memory Bus Interface
     read_strobe_i       : in  std_logic;
@@ -44,6 +45,9 @@ architecture rtl of lvdsout_block is
 
 signal val              : std_logic;
 signal pad_iob          : std_logic;
+signal q_delay          : std_logic_vector(31 downto 0);
+signal o_delay          : std_logic_vector(31 downto 0);
+signal o_delay_wstb     : std_logic;
 
 begin
 
@@ -57,6 +61,9 @@ port map (
     bit_bus_i           => bit_bus_i,
     pos_bus_i           => (others => (others => '0')),
     val_from_bus        => val,
+    QUARTER_DELAY       => q_delay,
+    FINE_DELAY          => o_delay,
+    FINE_DELAY_WSTB     => o_delay_wstb,
 
     read_strobe_i       => read_strobe_i,
     read_address_i      => read_address_i,
@@ -69,14 +76,15 @@ port map (
     write_ack_o         => write_ack_o
 );
 
----------------------------------------------------------------------------
--- Register output and pack into IOB
----------------------------------------------------------------------------
-process(clk_i) begin
-    if rising_edge(clk_i) then
-        pad_iob <= val;
-    end if;
-end process;
+fd_inst : entity work.finedelay port map (
+    clk_i => clk_i,
+    clk_2x_i => clk_2x_i,
+    q_delay_i => q_delay(1 downto 0),
+    o_delay_i => o_delay(4 downto 0),
+    o_delay_strobe_i => o_delay_wstb,
+    signal_i => val,
+    signal_o => pad_iob
+);
 
 pad_o <= pad_iob;
 

--- a/modules/lvdsout/hdl/lvdsout_top.vhd
+++ b/modules/lvdsout/hdl/lvdsout_top.vhd
@@ -25,6 +25,7 @@ entity lvdsout_top is
 port (
     -- Clocks and Resets
     clk_i               : in  std_logic;
+    clk_2x_i            : in std_logic;
     reset_i             : in  std_logic;
     -- Memory Bus Interface
     read_strobe_i       : in  std_logic;
@@ -68,6 +69,7 @@ lvdsout_block : entity work.lvdsout_block
 port map (
     -- Clock and Reset
     clk_i               => clk_i,
+    clk_2x_i            => clk_2x_i,
     reset_i             => reset_i,
     -- Memory Bus Interface
     read_strobe_i       => read_strobe(I),

--- a/modules/lvdsout/lvdsout.block.ini
+++ b/modules/lvdsout/lvdsout.block.ini
@@ -2,6 +2,14 @@
 description: LVDS output
 entity: lvdsout
 
+[QUARTER_DELAY]
+type: param uint 3
+description: Number of 1/4 ticks to delay (range 0-3)
+
+[FINE_DELAY]
+type: param uint 31
+description: Fine delay (range 0-31)
+
 [VAL]
 type: bit_mux
 description: LVDS output value

--- a/modules/ttlout/hdl/ttlout_block.vhd
+++ b/modules/ttlout/hdl/ttlout_block.vhd
@@ -22,6 +22,7 @@ entity ttlout_block is
 port (
     -- Clock and Reset
     clk_i               : in  std_logic;
+    clk_2x_i            : in  std_logic;
     reset_i             : in  std_logic;
     -- Memory Bus Interface
     read_strobe_i       : in  std_logic;
@@ -45,6 +46,9 @@ architecture rtl of ttlout_block is
 
 signal val              : std_logic;
 signal pad_iob          : std_logic;
+signal q_delay          : std_logic_vector(31 downto 0);
+signal o_delay          : std_logic_vector(31 downto 0);
+signal o_delay_wstb     : std_logic;
 
 begin
 
@@ -58,6 +62,9 @@ port map (
     bit_bus_i           => bit_bus_i,
     pos_bus_i           => (others => (others => '0')),
     VAL_from_bus        => val,
+    QUARTER_DELAY       => q_delay,
+    FINE_DELAY          => o_delay,
+    FINE_DELAY_WSTB     => o_delay_wstb,
 
     read_strobe_i       => read_strobe_i,
     read_address_i      => read_address_i,
@@ -70,14 +77,15 @@ port map (
     write_ack_o         => write_ack_o
 );
 
----------------------------------------------------------------------------
--- Register output and pack into IOB
----------------------------------------------------------------------------
-process(clk_i) begin
-    if rising_edge(clk_i) then
-        pad_iob <= val;
-    end if;
-end process;
+fd_inst : entity work.finedelay port map (
+    clk_i => clk_i,
+    clk_2x_i => clk_2x_i,
+    q_delay_i => q_delay(1 downto 0),
+    o_delay_i => o_delay(4 downto 0),
+    o_delay_strobe_i => o_delay_wstb,
+    signal_i => val,
+    signal_o => pad_iob
+);
 
 pad_o <= pad_iob;
 val_o <= val;

--- a/modules/ttlout/hdl/ttlout_top.vhd
+++ b/modules/ttlout/hdl/ttlout_top.vhd
@@ -25,6 +25,7 @@ entity ttlout_top is
 port (
     -- Clocks and Resets
     clk_i               : in  std_logic;
+    clk_2x_i            : in  std_logic;
     reset_i             : in  std_logic;
     -- Memory Bus Interface
     read_strobe_i       : in  std_logic;
@@ -71,6 +72,7 @@ ttlout_block : entity work.ttlout_block
 port map (
     -- Clock and Reset
     clk_i               => clk_i,
+    clk_2x_i            => clk_2x_i,
     reset_i             => reset_i,
     -- Memory Bus Interface
     read_strobe_i       => read_strobe(I),

--- a/modules/ttlout/ttlout.block.ini
+++ b/modules/ttlout/ttlout.block.ini
@@ -2,6 +2,14 @@
 description: TTL output
 entity: ttlout
 
+[QUARTER_DELAY]
+type: param uint 3
+description: Number of 1/4 ticks to delay (range 0-3)
+
+[FINE_DELAY]
+type: param uint 31
+description: Fine delay (range 0-31)
+
 [VAL]
 type: bit_mux
 description: TTL output value

--- a/targets/PandABox/bd/panda_ps.tcl
+++ b/targets/PandABox/bd/panda_ps.tcl
@@ -273,6 +273,10 @@ proc create_root_design { parentCell } {
 
   # Create ports
   set FCLK_CLK0 [ create_bd_port -dir O -type clk FCLK_CLK0 ]
+  set FCLK_CLK1 [ create_bd_port -dir O -type clk FCLK_CLK1 ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {200000000} \
+ ] $FCLK_CLK1
   set FCLK_RESET0_N [ create_bd_port -dir O -from 0 -to 0 -type rst FCLK_RESET0_N ]
   set IRQ_F2P [ create_bd_port -dir I -from 0 -to 0 -type intr IRQ_F2P ]
   set_property -dict [ list \
@@ -297,7 +301,7 @@ proc create_root_design { parentCell } {
    CONFIG.PCW_ACT_ENET0_PERIPHERAL_FREQMHZ {125.000000} \
    CONFIG.PCW_ACT_ENET1_PERIPHERAL_FREQMHZ {10.000000} \
    CONFIG.PCW_ACT_FPGA0_PERIPHERAL_FREQMHZ {125.000000} \
-   CONFIG.PCW_ACT_FPGA1_PERIPHERAL_FREQMHZ {10.000000} \
+   CONFIG.PCW_ACT_FPGA1_PERIPHERAL_FREQMHZ {200.000000} \
    CONFIG.PCW_ACT_FPGA2_PERIPHERAL_FREQMHZ {10.000000} \
    CONFIG.PCW_ACT_FPGA3_PERIPHERAL_FREQMHZ {10.000000} \
    CONFIG.PCW_ACT_I2C_PERIPHERAL_FREQMHZ {50} \
@@ -332,7 +336,7 @@ proc create_root_design { parentCell } {
    CONFIG.PCW_CAN_PERIPHERAL_DIVISOR1 {1} \
    CONFIG.PCW_CAN_PERIPHERAL_VALID {0} \
    CONFIG.PCW_CLK0_FREQ {125000000} \
-   CONFIG.PCW_CLK1_FREQ {10000000} \
+   CONFIG.PCW_CLK1_FREQ {200000000} \
    CONFIG.PCW_CLK2_FREQ {10000000} \
    CONFIG.PCW_CLK3_FREQ {10000000} \
    CONFIG.PCW_CORE0_FIQ_INTR {0} \
@@ -391,7 +395,7 @@ proc create_root_design { parentCell } {
    CONFIG.PCW_EN_CAN0 {0} \
    CONFIG.PCW_EN_CAN1 {0} \
    CONFIG.PCW_EN_CLK0_PORT {1} \
-   CONFIG.PCW_EN_CLK1_PORT {0} \
+   CONFIG.PCW_EN_CLK1_PORT {1} \
    CONFIG.PCW_EN_CLK2_PORT {0} \
    CONFIG.PCW_EN_CLK3_PORT {0} \
    CONFIG.PCW_EN_CLKTRIG0_PORT {0} \
@@ -455,7 +459,7 @@ proc create_root_design { parentCell } {
    CONFIG.PCW_FCLK0_PERIPHERAL_DIVISOR0 {4} \
    CONFIG.PCW_FCLK0_PERIPHERAL_DIVISOR1 {2} \
    CONFIG.PCW_FCLK1_PERIPHERAL_CLKSRC {IO PLL} \
-   CONFIG.PCW_FCLK1_PERIPHERAL_DIVISOR0 {1} \
+   CONFIG.PCW_FCLK1_PERIPHERAL_DIVISOR0 {5} \
    CONFIG.PCW_FCLK1_PERIPHERAL_DIVISOR1 {1} \
    CONFIG.PCW_FCLK2_PERIPHERAL_CLKSRC {IO PLL} \
    CONFIG.PCW_FCLK2_PERIPHERAL_DIVISOR0 {1} \
@@ -464,15 +468,15 @@ proc create_root_design { parentCell } {
    CONFIG.PCW_FCLK3_PERIPHERAL_DIVISOR0 {1} \
    CONFIG.PCW_FCLK3_PERIPHERAL_DIVISOR1 {1} \
    CONFIG.PCW_FCLK_CLK0_BUF {TRUE} \
-   CONFIG.PCW_FCLK_CLK1_BUF {FALSE} \
+   CONFIG.PCW_FCLK_CLK1_BUF {TRUE} \
    CONFIG.PCW_FCLK_CLK2_BUF {FALSE} \
    CONFIG.PCW_FCLK_CLK3_BUF {FALSE} \
    CONFIG.PCW_FPGA0_PERIPHERAL_FREQMHZ {125} \
-   CONFIG.PCW_FPGA1_PERIPHERAL_FREQMHZ {100} \
+   CONFIG.PCW_FPGA1_PERIPHERAL_FREQMHZ {200} \
    CONFIG.PCW_FPGA2_PERIPHERAL_FREQMHZ {33.333333} \
    CONFIG.PCW_FPGA3_PERIPHERAL_FREQMHZ {50} \
    CONFIG.PCW_FPGA_FCLK0_ENABLE {1} \
-   CONFIG.PCW_FPGA_FCLK1_ENABLE {0} \
+   CONFIG.PCW_FPGA_FCLK1_ENABLE {1} \
    CONFIG.PCW_FPGA_FCLK2_ENABLE {0} \
    CONFIG.PCW_FPGA_FCLK3_ENABLE {0} \
    CONFIG.PCW_GP0_EN_MODIFIABLE_TXN {0} \
@@ -821,7 +825,7 @@ proc create_root_design { parentCell } {
    CONFIG.PCW_PCAP_PERIPHERAL_CLKSRC {IO PLL} \
    CONFIG.PCW_PCAP_PERIPHERAL_DIVISOR0 {5} \
    CONFIG.PCW_PCAP_PERIPHERAL_FREQMHZ {200} \
-   CONFIG.PCW_PERIPHERAL_BOARD_PRESET {None} \
+   CONFIG.PCW_PERIPHERAL_BOARD_PRESET {part0} \
    CONFIG.PCW_PJTAG_PERIPHERAL_ENABLE {0} \
    CONFIG.PCW_PRESET_BANK0_VOLTAGE {LVCMOS 3.3V} \
    CONFIG.PCW_PRESET_BANK1_VOLTAGE {LVCMOS 1.8V} \
@@ -1092,6 +1096,7 @@ proc create_root_design { parentCell } {
   connect_bd_net -net proc_sys_reset_0_interconnect_aresetn [get_bd_pins proc_sys_reset_0/interconnect_aresetn] [get_bd_pins read_dma_interface/ARESETN] [get_bd_pins register_interface/ARESETN] [get_bd_pins write_dma_converter/s_axi_aresetn]
   connect_bd_net -net proc_sys_reset_0_peripheral_aresetn [get_bd_ports FCLK_RESET0_N] [get_bd_pins proc_sys_reset_0/peripheral_aresetn] [get_bd_pins read_dma_interface/M00_ARESETN] [get_bd_pins read_dma_interface/S00_ARESETN] [get_bd_pins register_interface/M00_ARESETN] [get_bd_pins register_interface/S00_ARESETN]
   connect_bd_net -net processing_system7_0_FCLK_CLK0 [get_bd_ports FCLK_CLK0] [get_bd_pins processing_system7_0/FCLK_CLK0]
+  connect_bd_net -net processing_system7_0_FCLK_CLK1 [get_bd_ports FCLK_CLK1] [get_bd_pins processing_system7_0/FCLK_CLK1]
   connect_bd_net -net processing_system7_0_FCLK_RESET0_N [get_bd_pins proc_sys_reset_0/ext_reset_in] [get_bd_pins processing_system7_0/FCLK_RESET0_N]
 
   # Create address segments

--- a/targets/PandABox/const/PandABox-clks_impl.xdc
+++ b/targets/PandABox/const/PandABox-clks_impl.xdc
@@ -3,10 +3,24 @@
 # -------------------------------------------------------------------
 
 set_clock_groups -asynchronous -group clk_fpga_0
+set_clock_groups -asynchronous -group clk_fpga_1
 set_clock_groups -asynchronous -group EXTCLK_P
 set_clock_groups -asynchronous -group GTXCLK0_P
 set_clock_groups -asynchronous -group GTXCLK1_P
 
-# Pack IOB registers
-set_property iob true [get_cells -hierarchical -regexp -filter {NAME =~ .*iob_reg.*}]
+create_generated_clock -name pll2_clkin1_out0 -master_clock sma_clk_out1 \
+    [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT0]
+create_generated_clock -name pll2_clkin2_out0 -master_clock clk_fpga_0 \
+    [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT0]
+
+create_generated_clock -name pll2_clkin1_out1 -master_clock sma_clk_out1 \
+    [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT1]
+create_generated_clock -name pll2_clkin2_out1 -master_clock clk_fpga_0 \
+    [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT1]
+
+set_clock_groups -physically_exclusive -group pll2_clkin1_out0 -group pll2_clkin2_out0
+set_clock_groups -physically_exclusive -group pll2_clkin1_out1 -group pll2_clkin2_out1
+
+set_clock_groups -physically_exclusive -group pll2_clkin1_out0 -group pll2_clkin2_out1
+set_clock_groups -physically_exclusive -group pll2_clkin2_out0 -group pll2_clkin1_out1
 

--- a/targets/PandABox/hdl/PandABox_top.vhd
+++ b/targets/PandABox/hdl/PandABox_top.vhd
@@ -111,6 +111,7 @@ architecture rtl of PandABox_top is
 -- Zynq PS Block
 signal FCLK_CLK0            : std_logic;
 signal FCLK_CLK0_PS         : std_logic;
+signal FCLK_CLK1_PS         : std_logic;
 signal FCLK_RESET0_N        : std_logic_vector(0 downto 0);
 signal FCLK_RESET0          : std_logic;
 
@@ -312,6 +313,12 @@ port map (
         IB              =>      GTXCLK1_N
     );
 
+idelayctrl_inst : IDELAYCTRL port map (
+    REFCLK => FCLK_CLK1_PS,
+    RST => '0',
+    RDY => open
+);
+
 mmcm_clkmux_inst: entity work.mmcm_clkmux
 port map(
     fclk_clk0_ps_i      => FCLK_CLK0_PS,
@@ -331,6 +338,8 @@ port map(
 ps : entity work.panda_ps
 port map (
     FCLK_CLK0                   => FCLK_CLK0_PS,
+    -- 200 MHZ reference clock
+    FCLK_CLK1                   => FCLK_CLK1_PS,
     PL_CLK                      => FCLK_CLK0,
     FCLK_RESET0_N               => FCLK_RESET0_N,
 

--- a/targets/PandABox/hdl/PandABox_top.vhd
+++ b/targets/PandABox/hdl/PandABox_top.vhd
@@ -259,8 +259,6 @@ signal sma_pll_locked       : std_logic;
 signal clk_src_sel          : std_logic_vector(1 downto 0);
 signal clk_sel_stat         : std_logic_vector(1 downto 0);
 
-signal slow_tlp   : slow_packet;
-
 attribute IO_BUFFER_TYPE : string;
 attribute IO_BUFFER_TYPE of SFP_TX_P : signal is "none";
 attribute IO_BUFFER_TYPE of SFP_TX_N : signal is "none";

--- a/targets/PandABox/hdl/PandABox_top.vhd
+++ b/targets/PandABox/hdl/PandABox_top.vhd
@@ -110,6 +110,7 @@ architecture rtl of PandABox_top is
 
 -- Zynq PS Block
 signal FCLK_CLK0            : std_logic;
+signal FCLK_CLK0_2X         : std_logic;
 signal FCLK_CLK0_PS         : std_logic;
 signal FCLK_CLK1_PS         : std_logic;
 signal FCLK_RESET0_N        : std_logic_vector(0 downto 0);
@@ -254,7 +255,6 @@ attribute syn_noclockbuf of q0_clk0_gtrefclk : signal is true;
 attribute syn_noclockbuf of q0_clk1_gtrefclk : signal is true;
 signal EXTCLK : std_logic;
 
-
 signal sma_pll_locked       : std_logic;
 signal clk_src_sel          : std_logic_vector(1 downto 0);
 signal clk_sel_stat         : std_logic_vector(1 downto 0);
@@ -326,7 +326,8 @@ port map(
     linkup_i             => SFP1_o.LINK_UP,
     sma_pll_locked_o    => sma_pll_locked,
     clk_sel_stat_o        => clk_sel_stat,
-    fclk_clk0_o         => FCLK_CLK0
+    fclk_clk0_o         => FCLK_CLK0,
+    fclk_clk0_2x_o => FCLK_CLK0_2X
 );
 
 
@@ -500,6 +501,7 @@ port map (
 ttlout_inst : entity work.ttlout_top
 port map (
     clk_i               => FCLK_CLK0,
+    clk_2x_i            => FCLK_CLK0_2X,
     reset_i             => FCLK_RESET0,
 
     read_strobe_i       => read_strobe(TTLOUT_CS),
@@ -530,6 +532,7 @@ port map (
 lvdsout_inst : entity work.lvdsout_top
 port map (
     clk_i               => FCLK_CLK0,
+    clk_2x_i            => FCLK_CLK0_2X,
     reset_i             => FCLK_RESET0,
 
     read_strobe_i       => read_strobe(LVDSOUT_CS),

--- a/targets/PandABox/hdl/PandABox_top.vhd
+++ b/targets/PandABox/hdl/PandABox_top.vhd
@@ -313,7 +313,7 @@ port map (
 
 idelayctrl_inst : IDELAYCTRL port map (
     REFCLK => FCLK_CLK1_PS,
-    RST => '0',
+    RST => FCLK_RESET0,
     RDY => open
 );
 

--- a/targets/xu5_st1/hdl/xu5_st1_top.vhd
+++ b/targets/xu5_st1/hdl/xu5_st1_top.vhd
@@ -142,7 +142,6 @@ signal pcap_active          : std_logic_vector(0 downto 0);
 signal ttlin_val            : std_logic_vector(TTLIN_NUM-1 downto 0);
 signal TTLIN_TERM           : std32_array(TTLIN_NUM-1 downto 0);
 signal TTLIN_TERM_WSTB      : std_logic_vector(TTLIN_NUM-1 downto 0);
-signal ttlout_val           : std_logic_vector(TTLOUT_NUM-1 downto 0);
 
 signal rdma_req             : std_logic_vector(5 downto 0);
 signal rdma_ack             : std_logic_vector(5 downto 0);
@@ -312,26 +311,6 @@ port map (
     pos_bus_i           => pos_bus,
     TTLIN_TERM_o        => TTLIN_TERM,
     TTLIN_TERM_WSTB_o   => TTLIN_TERM_WSTB
-);
-
-ttlout_inst : entity work.ttlout_top
-port map (
-    clk_i               => FCLK_CLK0,
-    reset_i             => FCLK_RESET0,
-
-    read_strobe_i       => read_strobe(TTLOUT_CS),
-    read_address_i      => read_address,
-    read_data_o         => read_data(TTLOUT_CS),
-    read_ack_o          => read_ack(TTLOUT_CS),
-
-    write_strobe_i      => write_strobe(TTLOUT_CS),
-    write_address_i     => write_address,
-    write_data_i        => write_data,
-    write_ack_o         => write_ack(TTLOUT_CS),
-
-    bit_bus_i           => bit_bus,
-    val_o               => ttlout_val,
-    pad_o               => TTLOUT_PAD_O
 );
 
 ---------------------------------------------------------------------------

--- a/targets/xu5_st1/xu5_st1.target.ini
+++ b/targets/xu5_st1/xu5_st1.target.ini
@@ -7,9 +7,6 @@ io: fmc: 1, i, o, io
 [TTLIN]
 number: 1
 
-[TTLOUT]
-number: 1
-
 [PCAP]
 number: 1
 

--- a/tests/sim/finedelay/bench/finedelay_tb.vhd
+++ b/tests/sim/finedelay/bench/finedelay_tb.vhd
@@ -1,0 +1,67 @@
+library ieee;
+use ieee.numeric_std.all;
+use ieee.std_logic_1164.all;
+use ieee.math_real.all;
+use std.env.finish;
+
+library work;
+
+
+entity finedelay_tb is
+end finedelay_tb;
+
+
+architecture rtl of finedelay_tb is
+    signal fclk_clk0_ps : std_logic := '1';
+    signal fclk_clk0_ps_2x : std_logic := '1';
+    signal q_delay : std_logic_vector(1 downto 0) := (others => '0');
+    signal o_delay : std_logic_vector(4 downto 0) := (others => '0');
+    signal o_delay_strobe : std_logic := '0';
+    signal input_signal : std_logic := '0';
+    signal output_signal : std_logic;
+    procedure clk_wait(count : in natural :=1) is
+    begin
+        for i in 0 to count-1 loop
+            wait until rising_edge(fclk_clk0_ps);
+        end loop;
+    end procedure;
+begin
+
+-- 125MHz clock from PS interface
+fclk_clk0_ps <= not fclk_clk0_ps after 4ns;
+fclk_clk0_ps_2x <= not fclk_clk0_ps_2x after 2ns;
+
+finedelay_inst: entity work.finedelay port map (
+    clk_i => fclk_clk0_ps,
+    clk_2x_i => fclk_clk0_ps_2x,
+    q_delay_i => q_delay,
+    o_delay_i => o_delay,
+    o_delay_strobe_i => o_delay_strobe,
+    signal_i => input_signal,
+    signal_o => output_signal
+);
+
+process
+begin
+    input_signal <= not input_signal;
+    clk_wait(4);
+end process;
+
+process
+    variable o_delay_val : integer := 0;
+    variable q_delay_val : integer := 0;
+begin
+    for o_delay_val in 0 to 31 loop
+        o_delay <= std_logic_vector(to_unsigned(o_delay_val, 5));
+        o_delay_strobe <= '1';
+        clk_wait(1);
+        o_delay_strobe <= '0';
+        for q_delay_val in 0 to 3 loop
+            q_delay <= std_logic_vector(to_unsigned(q_delay_val, 2));
+            clk_wait(32);
+        end loop;
+    end loop;
+    finish;
+end process;
+
+end rtl;

--- a/tests/sim/finedelay/bench/finedelay_tb_compile.tcl
+++ b/tests/sim/finedelay/bench/finedelay_tb_compile.tcl
@@ -1,0 +1,14 @@
+set TOP [lindex $argv 0]
+set BUILD_DIR [lindex $argv 1]
+set MODE [lindex $argv 2]
+
+create_project finedelay_tb $BUILD_DIR/build/tests/finedelay_tb -force -part xc7z030sbg485-1
+
+set_property top finedelay_tb [current_fileset -simset]
+add_files [glob $TOP/common/hdl/*.vhd]
+add_files $TOP/tests/sim/finedelay/bench
+set_property FILE_TYPE "VHDL 2008" [get_files $TOP/tests/sim/finedelay/bench/*.vhd]
+
+launch_simulation
+restart
+run -all


### PR DESCRIPTION
This change provides fine delay control in TTLOUT and LVDSOUT modules. It requires 2 parameters:
QUARTER_DELAY: number of 1/4 tick (range 0-3)
FINE_DELAY: counter used in ODELAY (range 0-31)

The ODELAY counter is supposed to provide 78 ps resolution ~~, however, some tests using a scope shows around twice that value~~.
Another thing to consider is that the ODELAY is not available in all I/O banks, so, there is a possibility that other targets will not benefit from it.