### PR TITLE
finedelay: register ddr outputs to meet timing constraints

### DIFF
--- a/common/hdl/finedelay.vhd
+++ b/common/hdl/finedelay.vhd
@@ -42,39 +42,35 @@ begin
             in_signal_on2x <= signal_i;
             in_signal_delay_on2x <= in_signal_delay;
             q_delay_on2x <= q_delay_i;
+
+            case phase_on2x & q_delay_on2x is
+                when "000" =>
+                    ddr_a <= in_signal_on2x;
+                    ddr_b <= in_signal_on2x;
+                when "100" =>
+                    ddr_a <= in_signal_on2x;
+                    ddr_b <= in_signal_on2x;
+                when "001" =>
+                    ddr_a <= in_signal_delay_on2x;
+                    ddr_b <= in_signal_on2x;
+                when "101" =>
+                    ddr_a <= in_signal_on2x;
+                    ddr_b <= in_signal_on2x;
+                when "010" =>
+                    ddr_a <= in_signal_delay_on2x;
+                    ddr_b <= in_signal_delay_on2x;
+                when "110" =>
+                    ddr_a <= in_signal_on2x;
+                    ddr_b <= in_signal_on2x;
+                when "011" =>
+                    ddr_a <= in_signal_delay_on2x;
+                    ddr_b <= in_signal_delay_on2x;
+                when "111" =>
+                    ddr_a <= in_signal_delay_on2x;
+                    ddr_b <= in_signal_on2x;
+               when others =>
+            end case;
         end if;
-    end process;
-
-    process (in_signal_on2x, in_signal_delay_on2x, phase_on2x, q_delay_on2x)
-    begin
-        case phase_on2x & q_delay_on2x is
-            when "000" =>
-                ddr_a <= in_signal_on2x;
-                ddr_b <= in_signal_on2x;
-            when "100" =>
-                ddr_a <= in_signal_on2x;
-                ddr_b <= in_signal_on2x;
-            when "001" =>
-                ddr_a <= in_signal_delay_on2x;
-                ddr_b <= in_signal_on2x;
-            when "101" =>
-                ddr_a <= in_signal_on2x;
-                ddr_b <= in_signal_on2x;
-            when "010" =>
-                ddr_a <= in_signal_delay_on2x;
-                ddr_b <= in_signal_delay_on2x;
-            when "110" =>
-                ddr_a <= in_signal_on2x;
-                ddr_b <= in_signal_on2x;
-            when "011" =>
-                ddr_a <= in_signal_delay_on2x;
-                ddr_b <= in_signal_delay_on2x;
-            when "111" =>
-                ddr_a <= in_signal_delay_on2x;
-                ddr_b <= in_signal_on2x;
-           when others =>
-        end case;
-
     end process;
 
     oddr_inst : ODDR port map (

--- a/tests/sim/finedelay/bench/finedelay_tb.vhd
+++ b/tests/sim/finedelay/bench/finedelay_tb.vhd
@@ -28,8 +28,8 @@ architecture rtl of finedelay_tb is
 begin
 
 -- 125MHz clock from PS interface
-fclk_clk0_ps <= not fclk_clk0_ps after 4ns;
-fclk_clk0_ps_2x <= not fclk_clk0_ps_2x after 2ns;
+fclk_clk0_ps <= not fclk_clk0_ps after 4 ns;
+fclk_clk0_ps_2x <= not fclk_clk0_ps_2x after 2 ns;
 
 finedelay_inst: entity work.finedelay port map (
     clk_i => fclk_clk0_ps,
@@ -58,10 +58,38 @@ begin
         o_delay_strobe <= '0';
         for q_delay_val in 0 to 3 loop
             q_delay <= std_logic_vector(to_unsigned(q_delay_val, 2));
-            clk_wait(32);
+            clk_wait(16);
         end loop;
     end loop;
     finish;
+end process;
+
+process
+    variable ts : time;
+    variable qd : std_logic_vector(1 downto 0);
+    variable od : std_logic_vector(4 downto 0);
+begin
+    wait until rising_edge(input_signal);
+    qd := q_delay;
+    od := o_delay;
+    ts := now;
+    wait until rising_edge(output_signal);
+    report "Between rising edges, qdelay " & to_hstring(qd) & " odelay " &
+        to_hstring(od)  & " Delay took " & time'image(now - ts);
+end process;
+
+process
+    variable ts : time;
+    variable qd : std_logic_vector(1 downto 0);
+    variable od : std_logic_vector(4 downto 0);
+begin
+    wait until falling_edge(input_signal);
+    qd := q_delay;
+    od := o_delay;
+    ts := now;
+    wait until falling_edge(output_signal);
+    report "Between falling edges, qdelay " & to_hstring(qd) & " odelay " &
+        to_hstring(od)  & " Delay took " & time'image(now - ts);
 end process;
 
 end rtl;


### PR DESCRIPTION
Additionally, the associated test bench was modified to print timing information. It can be run with `make run_sim_finedelay`

This fixes [issue 86](https://github.com/PandABlocks/PandABlocks-FPGA/issues/86)

The testbench shows the expected behavior, but this hasn't been tested in a Pandabox yet