### PR TITLE
Fixed the PCAP python simulation tests.

### DIFF
--- a/modules/pcap/pcap.timing.ini
+++ b/modules/pcap/pcap.timing.ini
@@ -209,7 +209,8 @@ scope: pcap.block.ini
 # SAMPLES = 3
 56      :                               -> DATA = -370368
 57      :                               -> DATA = -1
-58      :                               -> DATA = 2774478848
+58      :                               -> DATA = -1520488448
+# -1520488448 is Int32 for 2774478848
 59      :                               -> DATA = 10
 60      :                               -> DATA = 0
 61      :                               -> DATA = 3

--- a/modules/pcap/pcap.timing.ini
+++ b/modules/pcap/pcap.timing.ini
@@ -209,8 +209,7 @@ scope: pcap.block.ini
 # SAMPLES = 3
 56      :                               -> DATA = -370368
 57      :                               -> DATA = -1
-58      :                               -> DATA = -1520488448
-# -1520488448 is Int32 for 2774478848
+58      :                               -> DATA = 2774478848
 59      :                               -> DATA = 10
 60      :                               -> DATA = 0
 61      :                               -> DATA = 3

--- a/modules/pcap/pcap_sim.py
+++ b/modules/pcap/pcap_sim.py
@@ -17,6 +17,9 @@ SUM_L = 2
 SUM_H = 3
 MIN = 4
 MAX = 5
+SUM2_L = 6
+SUM2_M = 7
+SUM2_H = 8
 
 # Enums for HEALTH
 OK = 0
@@ -156,6 +159,27 @@ class SumCaptureEntry(CaptureEntry):
             yield data >> 32
         self.data = 0
 
+class Sum2CaptureEntry(SumCaptureEntry):
+    mid = False
+    data=0
+
+    def __init__(self, idx, shift):
+        super(Sum2CaptureEntry, self).__init__(idx, shift)
+
+    def latch_value(self, ts):
+        self.prev_ts = ts
+        self.prev_value = self.value**2
+
+    def yield_data(self):
+        data =int(self.data >> self.shift)
+        # Yield low then mid then high
+        if self.lo:
+            yield data & (2**32 -1)
+        if self.mid:
+            yield data >> 32 & (2 ** 32 - 1)
+        if self.hi:
+            yield data >> 64
+        self.data = 0
 
 class MinCaptureEntry(CaptureEntry):
     INT32_MAX = np.iinfo(np.int32).max
@@ -302,6 +326,8 @@ class PcapSimulation(BlockSimulation):
         self.ARM = 0
         self.DISARM = 0
         self.DATA = 0
+        self.dataDelay1 = 0
+        self.dataDelay2 = 0
         # This lets us find the name of the field from the index
         self.ext_names = {}
         i = 32
@@ -369,9 +395,12 @@ class PcapSimulation(BlockSimulation):
                 self.buf_produced += 1
             else:
                 self.pend_data.append(None)
-            data = self.pend_data.popleft()
-            if data is not None:
-                self.DATA = data
+            # Reading data from the buffer has a 2 TS delay in the vhdl
+            if self.dataDelay2 is not None:
+                self.DATA = self.dataDelay2
+            if self.dataDelay1 is not None:
+                self.dataDelay2 = self.dataDelay1
+            self.dataDelay1 = self.pend_data.popleft()
             ret = ts + 1
         return ret
 
@@ -400,6 +429,18 @@ class PcapSimulation(BlockSimulation):
                 entry = MinCaptureEntry(i)
             elif mode == MAX:
                 entry = MaxCaptureEntry(i)
+            elif mode == SUM2_L:
+                entry = Sum2CaptureEntry.definitely_create(
+                    entries, i, self.SHIFT_SUM)
+                entry.lo = True
+            elif mode == SUM2_M:
+                entry = Sum2CaptureEntry.create_if_not_existing(
+                    entries, i, self.SHIFT_SUM)
+                entry.mid = True
+            elif mode == SUM2_H:
+                 entry = Sum2CaptureEntry.create_if_not_existing(
+                    entries, i, self.SHIFT_SUM)
+                 entry.hi = True
             else:
                 raise ValueError(" Bad mode %d" % mode)
         else:
@@ -485,7 +526,7 @@ class PcapSimulation(BlockSimulation):
         sample"""
         if self.tick_data and self.buf_len > self.buf_produced:
             # Told to push more data when we hadn't finished the last capture
-            self.pend_error = ts + 2
+            self.pend_error = ts + 4
         else:
             new_size = len(new_data)
             self.buf[self.buf_len:self.buf_len + new_size] = new_data

--- a/tests/test_python_sim_timing.py
+++ b/tests/test_python_sim_timing.py
@@ -10,6 +10,7 @@ else:
 import sys
 import os
 import imp
+import numpy
 
 import unittest
 
@@ -117,7 +118,7 @@ def load_tests(loader=None, standard_tests=None, pattern=None):
 
                 # Check all outputs have correct field values
                 for name in outputs:
-                    expected = int(outputs[name], 0)
+                    expected = numpy.int32(int(outputs[name], 0))
                     actual = getattr(block, name)
                     assert actual == expected, \
                         "%d: Attr %s = %d != %d" % (


### PR DESCRIPTION
These changes fix the PCAP python simulation which were not working after #68.

An additional 2 TS delay was required on the DATA output.
Sum^2 capture entry was added.

With these changes all python_timing tests will now complete successfully. 