### PR TITLE
Optional finedelay

### DIFF
--- a/common/hdl/defines/top_defines.vhd
+++ b/common/hdl/defines/top_defines.vhd
@@ -41,7 +41,8 @@ alias BBUSBW is top_defines_gen.BBUSBW;
 alias PBUSW is top_defines_gen.PBUSW;
 alias PBUSBW is top_defines_gen.PBUSBW;
 alias EBUSW is top_defines_gen.EBUSW;
-alias PCAP_SUPPORTS_STD_DEV is top_defines_gen.PCAP_SUPPORTS_STD_DEV;
+alias PCAP_STD_DEV_OPTION is top_defines_gen.PCAP_STD_DEV_OPTION;
+alias FINE_DELAY_OPTION is top_defines_gen.FINE_DELAY_OPTION;
 --------------------------------------------------------------------------
 
 constant DCARD_MONITOR          : std_logic_vector(2 downto 0) := "011";

--- a/common/hdl/reg_top.vhd
+++ b/common/hdl/reg_top.vhd
@@ -178,7 +178,7 @@ POS_READ_RSTB <= '1' when (read_ack = '1' and
 
 -- Register of FPGA capabilities 
 -- Bit0: presence of PCAP_STD_DEV functionality
-FPGA_CAPABILITIES <= (0 => PCAP_SUPPORTS_STD_DEV,
+FPGA_CAPABILITIES <= (0 => PCAP_STD_DEV_OPTION,
                       others => '0');
 --------------------------------------------------------------------------
 -- Status Register Read

--- a/common/hdl/reg_top.vhd
+++ b/common/hdl/reg_top.vhd
@@ -179,6 +179,7 @@ POS_READ_RSTB <= '1' when (read_ack = '1' and
 -- Register of FPGA capabilities 
 -- Bit0: presence of PCAP_STD_DEV functionality
 FPGA_CAPABILITIES <= (0 => PCAP_STD_DEV_OPTION,
+                      1 => FINE_DELAY_OPTION,
                       others => '0');
 --------------------------------------------------------------------------
 -- Status Register Read

--- a/common/python/configs.py
+++ b/common/python/configs.py
@@ -125,8 +125,7 @@ class BlockConfig(object):
         if self.extension == '':
             self.extension = self.entity
         #: All the child fields
-        self.fields = FieldConfig.from_ini(
-            ini, number)  # type: List[FieldConfig]
+        self.fields = FieldConfig.from_ini(ini, number)
         #: Are there any suffixes?
         self.block_suffixes = ini_get(ini, '.', 'block_suffixes', '').split()
 
@@ -238,6 +237,8 @@ class FieldConfig(object):
         self.bus_entries = []  # type: List[BusEntryConfig]
         #: If a write strobe is required, set wstb to 1
         self.wstb = extra_config.pop("wstb", False)
+        #: If the field is associated to an option
+        self.option_filter = extra_config.pop("if-option", "")
         #: Store the extension register info
         self.extension = extra_config.pop("extension", None)
         self.extension_reg = extra_config.pop("extension_reg", None)

--- a/common/python/generate_app.py
+++ b/common/python/generate_app.py
@@ -30,10 +30,14 @@ log = logging.getLogger(__name__)
 ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 TEMPLATES = os.path.join(os.path.abspath(ROOT), "common", "templates")
 
-# List of allowing FPGA options enabled in target ini file
-VALID_FPGA_OPTIONS = [
-    "pcap_std_dev",
-]
+
+# All options are disabled by default, this is also use to check allowed
+# FPGA options, which could be enabled in the app ini file or in the target
+# ini file
+FPGA_OPTIONS_DEFAULTS = {
+    'pcap_std_dev': False
+}
+
 
 def jinja_context(**kwargs):
     context = dict(pad=pad)
@@ -68,7 +72,7 @@ class AppGenerator(object):
         self.fpga_blocks = []  # type: List[BlockConfig]
         self.server_blocks = []  # type: List[BlockConfig]
         self.target_sites = [] #type: List[TargetSiteConfig]
-        self.fpga_options = set() #type: Set[str]
+        self.fpga_options = dict(FPGA_OPTIONS_DEFAULTS)  # type: dict[str, bool]
         self.app = app
 
     def generate_all(self):
@@ -124,6 +128,38 @@ class AppGenerator(object):
             ini_get(app_ini, '.', 'options', ''))
         # Implement the blocks for the soft blocks
         self.implement_blocks(app_ini, "modules", "soft")
+        # Filter option sensitive fields
+        for block in self.server_blocks:
+            to_delete = [
+                field for field in block.fields
+                    if not self.match_fpga_options(
+                        self.parse_fpga_options(field.option_filter))
+            ]
+            for field in to_delete:
+                block.fields.remove(field)
+
+    def parse_fpga_options(self, text):
+        # returns a dict with option -> expected_value
+        options = {}
+        for option in filter(None, (item.strip() for item in text.split(','))):
+            expected = True
+            if option.startswith('!'):
+                option = option[1:].strip()
+                expected = False
+
+            assert option in self.fpga_options, \
+                "%r option is not valid" % option
+
+            options[option] = expected
+
+        return options
+
+    def match_fpga_options(self, options):
+        for key, val in options.items():
+            if self.fpga_options[key] != val:
+                return False
+
+        return True
 
     def implement_blocks(self, ini, path, type):
         """Read the ini file and for each section create a new block"""
@@ -189,7 +225,10 @@ class AppGenerator(object):
                     for suffix in block.block_suffixes:
                         self.server_blocks.append(server_blocks[suffix])
                 else:
-                    self.server_blocks.append(block)
+                    # We need to copy because this is going to be filtered
+                    # afterwards and we don't want to affect fpga_blocks
+                    server_block = copy.deepcopy(block)
+                    self.server_blocks.append(server_block)
 
     def expand_template(self, template_name, context, out_dir, out_fname,
                         template_dir=None):
@@ -230,10 +269,6 @@ class AppGenerator(object):
             "descriptions.jinja2", context, config_dir, "description")
         self.expand_template(
             "sim_server.jinja2", context, self.app_build_dir, "sim_server")
-        #context = jinja_context(app=self.app_name)
-        #self.expand_template(
-        #    "slow_top.files.jinja2",
-        #    context, self.app_build_dir, "slow_top.files")
 
     def generate_wrappers(self):
         """Generate wrappers in hdl"""
@@ -287,6 +322,7 @@ class AppGenerator(object):
             if block.entity not in block_names:
                 register_blocks.append(block)
                 block_names.append(block.entity)
+
         context = jinja_context(
             fpga_blocks=self.fpga_blocks,
             target_sites=self.target_sites,
@@ -389,25 +425,7 @@ class AppGenerator(object):
         return any(char.isdigit() for char in inputstring)
 
     def process_fpga_options(self, options_text):
-        for option_text in filter(None, [option_text.strip()
-                for option_text in options_text.split(',')]):
-            self.process_fpga_option(option_text)
-
-    def process_fpga_option(self, option_text):
-        want_delete = option_text.startswith('!')
-        fpga_option = option_text[int(want_delete):].strip()
-
-        assert fpga_option in VALID_FPGA_OPTIONS, \
-            "%r option defined in target ini file is not valid" % fpga_option
-
-        if want_delete:
-            try:
-                self.fpga_options.remove(fpga_option)
-            except KeyError:
-                log.warning('Trying to remove option not added before: %s',
-                            fpga_option)
-        else:
-            self.fpga_options.add(fpga_option)
+        self.fpga_options.update(self.parse_fpga_options(options_text))
 
 
 def main():

--- a/common/python/generate_app.py
+++ b/common/python/generate_app.py
@@ -35,7 +35,8 @@ TEMPLATES = os.path.join(os.path.abspath(ROOT), "common", "templates")
 # FPGA options, which could be enabled in the app ini file or in the target
 # ini file
 FPGA_OPTIONS_DEFAULTS = {
-    'pcap_std_dev': False
+    'pcap_std_dev': False,
+    'fine_delay': False
 }
 
 

--- a/common/templates/top_defines_gen.vhd.jinja2
+++ b/common/templates/top_defines_gen.vhd.jinja2
@@ -19,7 +19,9 @@ constant PBUSBW                 : natural := 5;
 constant EBUSW                  : natural := 12;
 --------------------------------------------------------------------------
 
--- Presence of PCAP_STD_DEV functionality
-constant PCAP_SUPPORTS_STD_DEV  : std_logic := '{{ ("pcap_std_dev" in fpga_options) | int}}';
+-- FPGA options
+{% for option, val in fpga_options.items() %}
+constant {{ option | upper }}_OPTION : std_logic := '{{ val | int }}';
+{% endfor %}
 
 end top_defines_gen;

--- a/modules/lvdsout/hdl/lvdsout_block.vhd
+++ b/modules/lvdsout/hdl/lvdsout_block.vhd
@@ -51,9 +51,7 @@ signal o_delay_wstb     : std_logic;
 
 begin
 
----------------------------------------------------------------------------
 -- Control System Interface
----------------------------------------------------------------------------
 lvdsout_ctrl_inst : entity work.lvdsout_ctrl
 port map (
     clk_i               => clk_i,
@@ -76,15 +74,23 @@ port map (
     write_ack_o         => write_ack_o
 );
 
-fd_inst : entity work.finedelay port map (
-    clk_i => clk_i,
-    clk_2x_i => clk_2x_i,
-    q_delay_i => q_delay(1 downto 0),
-    o_delay_i => o_delay(4 downto 0),
-    o_delay_strobe_i => o_delay_wstb,
-    signal_i => val,
-    signal_o => pad_iob
-);
+FINE_DELAY_GEN1: if FINE_DELAY_OPTION = '1' generate
+begin
+    fd_inst : entity work.finedelay port map (
+        clk_i => clk_i,
+        clk_2x_i => clk_2x_i,
+        q_delay_i => q_delay(1 downto 0),
+        o_delay_i => o_delay(4 downto 0),
+        o_delay_strobe_i => o_delay_wstb,
+        signal_i => val,
+        signal_o => pad_iob
+    );
+end generate;
+
+NO_FINE_DELAY_GEN1: if FINE_DELAY_OPTION = '0' generate
+begin
+    pad_iob <= val;
+end generate;
 
 pad_o <= pad_iob;
 

--- a/modules/lvdsout/lvdsout.block.ini
+++ b/modules/lvdsout/lvdsout.block.ini
@@ -5,10 +5,12 @@ entity: lvdsout
 [QUARTER_DELAY]
 type: param uint 3
 description: Number of 1/4 ticks to delay (range 0-3)
+if-option: fine_delay
 
 [FINE_DELAY]
 type: param uint 31
 description: Fine delay (range 0-31)
+if-option: fine_delay
 
 [VAL]
 type: bit_mux

--- a/modules/pcap/hdl/pcap_frame_mode.vhd
+++ b/modules/pcap/hdl/pcap_frame_mode.vhd
@@ -29,7 +29,7 @@ use ieee.numeric_std.all;
 use ieee.std_logic_1164.all;
 
 library work;
-use work.top_defines.all;  -- need PCAP_SUPPORTS_STD_DEV
+use work.top_defines.all;  -- need PCAP_STD_DEV_OPTION
 
 
 entity pcap_frame_mode is
@@ -189,7 +189,7 @@ end process ps_sum_val;
 -- Modes 6-7-8 : sum of squared input values
 --------------------------------------------------------------------------------
 -- case PCAP supports std_dev fpga_option
-SUM_SQ_GEN_1 : if PCAP_SUPPORTS_STD_DEV = '1' generate
+SUM_SQ_GEN_1 : if PCAP_STD_DEV_OPTION = '1' generate
 begin
 
   -- Mode 6 / 7 / 8 : Sum^2 Low / Middle / High
@@ -223,7 +223,7 @@ begin
 end generate;
 
 -- case PCAP does not supports std_dev fpga_option
-SUM_SQ_GEN_0 : if PCAP_SUPPORTS_STD_DEV = '0' generate
+SUM_SQ_GEN_0 : if PCAP_STD_DEV_OPTION = '0' generate
 begin
     sum_data_sq <= (others=>'0');
     sum_sq_0_o <= (others=>'0');

--- a/modules/ttlout/hdl/ttlout_block.vhd
+++ b/modules/ttlout/hdl/ttlout_block.vhd
@@ -52,9 +52,7 @@ signal o_delay_wstb     : std_logic;
 
 begin
 
----------------------------------------------------------------------------
 -- Control System Interface
----------------------------------------------------------------------------
 ttlout_ctrl_inst : entity work.ttlout_ctrl
 port map (
     clk_i               => clk_i,
@@ -77,15 +75,23 @@ port map (
     write_ack_o         => write_ack_o
 );
 
-fd_inst : entity work.finedelay port map (
-    clk_i => clk_i,
-    clk_2x_i => clk_2x_i,
-    q_delay_i => q_delay(1 downto 0),
-    o_delay_i => o_delay(4 downto 0),
-    o_delay_strobe_i => o_delay_wstb,
-    signal_i => val,
-    signal_o => pad_iob
-);
+FINE_DELAY_GEN1: if FINE_DELAY_OPTION = '1' generate
+begin
+    fd_inst : entity work.finedelay port map (
+        clk_i => clk_i,
+        clk_2x_i => clk_2x_i,
+        q_delay_i => q_delay(1 downto 0),
+        o_delay_i => o_delay(4 downto 0),
+        o_delay_strobe_i => o_delay_wstb,
+        signal_i => val,
+        signal_o => pad_iob
+    );
+end generate;
+
+NO_FINE_DELAY_GEN1: if FINE_DELAY_OPTION = '0' generate
+begin
+    pad_iob <= val;
+end generate;
 
 pad_o <= pad_iob;
 val_o <= val;

--- a/modules/ttlout/ttlout.block.ini
+++ b/modules/ttlout/ttlout.block.ini
@@ -5,10 +5,12 @@ entity: ttlout
 [QUARTER_DELAY]
 type: param uint 3
 description: Number of 1/4 ticks to delay (range 0-3)
+if-option: fine_delay
 
 [FINE_DELAY]
 type: param uint 31
 description: Fine delay (range 0-31)
+if-option: fine_delay
 
 [VAL]
 type: bit_mux

--- a/targets/PandABox/const/PandABox-clks_impl.xdc
+++ b/targets/PandABox/const/PandABox-clks_impl.xdc
@@ -8,19 +8,19 @@ set_clock_groups -asynchronous -group EXTCLK_P
 set_clock_groups -asynchronous -group GTXCLK0_P
 set_clock_groups -asynchronous -group GTXCLK1_P
 
-create_generated_clock -name pll2_clkin1_out0 -master_clock sma_clk_out1 \
+create_generated_clock -quiet -name pll2_clkin1_out0 -master_clock sma_clk_out1 \
     [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT0]
-create_generated_clock -name pll2_clkin2_out0 -master_clock clk_fpga_0 \
+create_generated_clock -quiet -name pll2_clkin2_out0 -master_clock clk_fpga_0 \
     [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT0]
 
-create_generated_clock -name pll2_clkin1_out1 -master_clock sma_clk_out1 \
+create_generated_clock -quiet -name pll2_clkin1_out1 -master_clock sma_clk_out1 \
     [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT1]
-create_generated_clock -name pll2_clkin2_out1 -master_clock clk_fpga_0 \
+create_generated_clock -quiet -name pll2_clkin2_out1 -master_clock clk_fpga_0 \
     [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT1]
 
-set_clock_groups -physically_exclusive -group pll2_clkin1_out0 -group pll2_clkin2_out0
-set_clock_groups -physically_exclusive -group pll2_clkin1_out1 -group pll2_clkin2_out1
+set_clock_groups -quiet -physically_exclusive -group pll2_clkin1_out0 -group pll2_clkin2_out0
+set_clock_groups -quiet -physically_exclusive -group pll2_clkin1_out1 -group pll2_clkin2_out1
 
-set_clock_groups -physically_exclusive -group pll2_clkin1_out0 -group pll2_clkin2_out1
-set_clock_groups -physically_exclusive -group pll2_clkin2_out0 -group pll2_clkin1_out1
+set_clock_groups -quiet -physically_exclusive -group pll2_clkin1_out0 -group pll2_clkin2_out1
+set_clock_groups -quiet -physically_exclusive -group pll2_clkin2_out0 -group pll2_clkin1_out1
 

--- a/tests/python/test_generate_app.py
+++ b/tests/python/test_generate_app.py
@@ -56,14 +56,14 @@ class TestGenerateApp(unittest.TestCase):
         self.assertGeneratedEqual("hdl", "addr_defines.vhd")
 
     def test_fpga_option_is_parsed(self):
-        self.assertIn('pcap_std_dev', self.app_generator.fpga_options)
+        self.assertTrue(self.app_generator.fpga_options['pcap_std_dev'])
 
     def test_fpga_option_can_be_enabled_and_disabled(self):
         app_generator = AppGenerator('dummy_app', 'dummy_build_dir')
         app_generator.process_fpga_options('pcap_std_dev')
-        self.assertIn('pcap_std_dev', app_generator.fpga_options)
+        self.assertTrue(app_generator.fpga_options['pcap_std_dev'])
         app_generator.process_fpga_options('!pcap_std_dev')
-        self.assertNotIn('pcap_std_dev', app_generator.fpga_options)
+        self.assertFalse(app_generator.fpga_options['pcap_std_dev'])
 
     def test_usage(self):
         self.assertGeneratedEqual("usage.txt")


### PR DESCRIPTION
- Autogenerate constants for options
- Add 'if-option' to allow filtering fields in block ini files
- Add fine delay option, a target or application can have it by adding the FPGA option 'fine_delay'