### PR TITLE
Add PCAP interrupt on PCAP.ENABLE high when armed and enabled

### DIFF
--- a/common/fpga.make
+++ b/common/fpga.make
@@ -40,6 +40,7 @@ CARRIER_FPGA_BIT = $(BUILD_DIR)/panda_top.bit
 FPGA_BIN_FILE = $(BUILD_DIR)/panda_top.bin
 
 VERSION_FILE = $(AUTOGEN)/hdl/version.vhd
+CONSTANT_FILE = $(AUTOGEN)/hdl/panda_constants.vhd
 
 # target_incl.make needs to be included after the VERSION_FILE variable is defined otherwise
 # make does not work out the dependencies properly. I don't understand why exactly!
@@ -135,6 +136,11 @@ $(VERSION_FILE) : $(VER)
 	echo ' := X"$(SHA)";' >> $(VERSION_FILE)
 	echo 'end version;' >> $(VERSION_FILE)
 
+
+$(CONSTANT_FILE) : $(TOP)/common/templates/registers_server
+	$(TOP)/common/python/generate_constants.py "$<" > $@
+
+
 ###########################################################
 # Build Zynq Firmware targets
 
@@ -152,6 +158,7 @@ $(PS_CORE) : $(PS_BUILD_SCR) $(PS_CONFIG_SCR) $(TGT_INCL_SCR)
 
 CARRIER_FPGA_DEPS += $(TOP_BUILD_SCR)
 CARRIER_FPGA_DEPS += $(VERSION_FILE)
+CARRIER_FPGA_DEPS += $(CONSTANT_FILE)
 CARRIER_FPGA_DEPS += $(IP_DIR)/IP_BUILD_SUCCESS
 CARRIER_FPGA_DEPS += $(PS_CORE)
 CARRIER_FPGA_DEPS += $(TGT_INCL_SCR)

--- a/common/python/generate_app.py
+++ b/common/python/generate_app.py
@@ -348,6 +348,10 @@ class AppGenerator(object):
         regs = []
         with open(reg_server_dir, 'r') as fp:
             for line in fp:
+                if "=" in line:
+                    # ignore constants
+                    continue
+
                 if "*" in line:
                     # The prefix for the signals are either REG or DRV
                     block = line.split(" ", 1)[0]

--- a/common/python/generate_constants.py
+++ b/common/python/generate_constants.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+import argparse
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('file_path')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    print('library ieee;')
+    print('use ieee.std_logic_1164.all;')
+    print('package panda_constants is')
+
+    for line in open(args.file_path, 'r'):
+        if '=' not in line:
+            continue
+
+        first, second = line.split('=')
+        key, val = first.strip().upper(), int(second)
+        print(f'    constant {key} : std_logic_vector(31 downto 0)', end='')
+        print(f' := X"{val:08x}";')
+
+    print('end panda_constants;')
+
+
+if __name__ == "__main__":
+    main()

--- a/common/templates/registers_server
+++ b/common/templates/registers_server
@@ -1,5 +1,9 @@
 # Register interface definition
 
+# This must be updated when there are changes that require the driver
+# to be updated
+DRIVER_COMPAT_VERSION = 1
+
 # This special register block is not present in the config file and contains
 # fixed register definitions used in the hardware interface.
 *REG        0
@@ -56,3 +60,6 @@
     PCAP_IRQ_STATUS         4
     # DMA block size in bytes
     PCAP_BLOCK_SIZE         6
+    # Kernel driver compatiblity version check register.  The value in this
+    # register must match DRIVER_COMPAT_VERSION.
+    COMPAT_VERSION          7

--- a/modules/pcap/hdl/pcap_core.vhd
+++ b/modules/pcap/hdl/pcap_core.vhd
@@ -47,6 +47,7 @@ port (
     pcap_dat_valid_o    : out std_logic;
     pcap_done_o         : out std_logic;
     pcap_actv_o         : out std_logic;
+    pcap_start_event_o  : out std_logic;
     pcap_status_o       : out std_logic_vector(2 downto 0)
 );
 end pcap_core;
@@ -78,6 +79,7 @@ pcap_dat_valid_o <= pcap_dat_valid;
 pcap_status_o <= pcap_status;
 pcap_actv_o <= pcap_armed;
 
+
 --------------------------------------------------------------------------
 -- This error signal causes the termination of PCAP operation
 --------------------------------------------------------------------------
@@ -98,6 +100,7 @@ port map (
     ongoing_trig_i      => pcap_dat_valid,
     pcap_armed_o        => pcap_armed,
     pcap_done_o         => pcap_done_o,
+    pcap_start_event_o  => pcap_start_event_o,
     timestamp_o         => timestamp,
     pcap_status_o       => pcap_status
 );

--- a/modules/pcap/hdl/pcap_core_ctrl.vhd
+++ b/modules/pcap/hdl/pcap_core_ctrl.vhd
@@ -21,6 +21,7 @@ use work.support.all;
 use work.addr_defines.all;
 use work.top_defines.all;
 use work.reg_defines.all;
+use work.panda_constants.all;
 
 entity pcap_core_ctrl is
 port (
@@ -176,6 +177,8 @@ begin
             case (read_address) is
                 when DRV_PCAP_IRQ_STATUS =>
                     read_data_o <= IRQ_STATUS;
+                when DRV_COMPAT_VERSION =>
+                    read_data_o <= DRIVER_COMPAT_VERSION;
                 when others =>
                     read_data_o <= (others => '0');
             end case;

--- a/modules/pcap/hdl/pcap_top.vhd
+++ b/modules/pcap/hdl/pcap_top.vhd
@@ -107,6 +107,7 @@ signal dma_error        : std_logic;
 signal pcap_status      : std_logic_vector(2 downto 0);
 signal pcap_active      : std_logic;
 signal pcap_done        : std_logic;
+signal pcap_start_event : std_logic;
 
 signal enable_from_bus  : std_logic;
 signal gate_from_bus    : std_logic;
@@ -264,6 +265,7 @@ port map (
     pcap_dat_valid_o        => pcap_dat_valid,
     pcap_done_o             => pcap_done,
     pcap_actv_o             => pcap_active,
+    pcap_start_event_o      => pcap_start_event,
     pcap_status_o           => pcap_status
 );
 
@@ -283,6 +285,7 @@ port map (
     IRQ_STATUS              => IRQ_STATUS,
     BLOCK_SIZE              => BLOCK_SIZE,
 
+    pcap_start_event_i      => pcap_start_event,
     pcap_done_i             => pcap_done,
     pcap_status_i           => pcap_status,
     dma_error_o             => dma_error,

--- a/tests/python/test_data/app-expected/config_d/registers
+++ b/tests/python/test_data/app-expected/config_d/registers
@@ -1,5 +1,9 @@
 # Register interface definition
 
+# This must be updated when there are changes that require the driver
+# to be updated
+DRIVER_COMPAT_VERSION = 1
+
 # This special register block is not present in the config file and contains
 # fixed register definitions used in the hardware interface.
 *REG        0
@@ -56,6 +60,9 @@
     PCAP_IRQ_STATUS         4
     # DMA block size in bytes
     PCAP_BLOCK_SIZE         6
+    # Kernel driver compatiblity version check register.  The value in this
+    # register must match DRIVER_COMPAT_VERSION.
+    COMPAT_VERSION          7
 
 LUT                 2
     INPA                0 1


### PR DESCRIPTION
This change provide a new interrupt source when PCAP becomes active and enabled, if this condition happens in isolation, the block will not be switched (which was the default in every interrupt before this change).

Additionally, a driver compatibility register was added which is checked when the driver is loaded.

This fixes https://github.com/PandABlocks/PandABlocks-FPGA/issues/88