### PR TITLE
Clocking changes to allow fine delay and recovered clock

### DIFF
--- a/common/hdl/defines/top_defines.vhd
+++ b/common/hdl/defines/top_defines.vhd
@@ -117,13 +117,13 @@ type SFP_output_interface is
   record
     TXN_OUT     : std_logic;
     TXP_OUT     : std_logic;
-    EVR_REC_CLK : std_logic;
+    MGT_REC_CLK : std_logic;
     LINK_UP     : std_logic;
   end record SFP_output_interface;
 
 constant SFP_o_init : SFP_output_interface := (TXN_OUT => 'Z',
                                                TXP_OUT => 'Z',
-                                               EVR_REC_CLK => '0',
+                                               MGT_REC_CLK => '0',
                                                LINK_UP => '0');
 
 

--- a/common/hdl/mmcm_clkmux.vhd
+++ b/common/hdl/mmcm_clkmux.vhd
@@ -11,7 +11,7 @@ use work.top_defines.all;
 entity mmcm_clkmux is
 port (fclk_clk0_ps_i      : in  std_logic;
       sma_clk_i           : in  std_logic;
-      rxoutclk_i          : in  std_logic;
+      mgt_rec_clk_i          : in  std_logic;
       clk_sel_i           : in  std_logic_vector(1 downto 0);
       linkup_i            : in  std_logic;
       sma_pll_locked_o    : out std_logic;
@@ -213,7 +213,7 @@ secondary_clkmux : BUFGMUX
     port map (
         O => secondary_mux_out,
         I0 => sma_clk_out1,
-        I1 => rxoutclk_i,
+        I1 => mgt_rec_clk_i,
         S => enable_mgt_clk
 );
 

--- a/common/hdl/mmcm_clkmux.vhd
+++ b/common/hdl/mmcm_clkmux.vhd
@@ -209,7 +209,7 @@ clk_mux_bufh: BUFH
 -- Secondary mux switches between external sma clock and mgt recovered clock.
 -- Secondary MUX select checks for MGT link-up.
 
-secondary_clkmux : BUFGMUX
+secondary_clkmux : BUFGMUX_CTRL
     port map (
         O => secondary_mux_out,
         I0 => sma_clk_out1,

--- a/modules/fmc_loopback/const/fmc_loopback_impl.xdc
+++ b/modules/fmc_loopback/const/fmc_loopback_impl.xdc
@@ -3,7 +3,7 @@
 # -------------------------------------------------------------------
 set_clock_groups -asynchronous -group FMC_CLK0_M2C_P
 set_clock_groups -asynchronous -group FMC_CLK1_M2C_P
-set_clock_groups -asynchronous -group [get_clocks \ 
+set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks \ 
 {softblocks_inst/{{ block.name }}_inst/fmcgtx_exdes_i/fmcgtx_support_i/fmcgtx_init_i/U0/fmcgtx_i/gt0_fmcgtx_i/gtxe2_i/TXOUTCLK}]
 
 # -------------------------------------------------------------------

--- a/modules/sfp_dls_eventr/const/sfp_event_receiver_impl.xdc
+++ b/modules/sfp_dls_eventr/const/sfp_event_receiver_impl.xdc
@@ -8,6 +8,6 @@ set_property LOC $SFP{{ block.site }}_GTX_LOC \
 # -------------------------------------------------------------------
 # Define asynchronous clocks
 # -------------------------------------------------------------------
-set_clock_groups -asynchronous -group [get_clocks \ 
+set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks \ 
 {softblocks_inst/{{ block.name }}_inst/sfpgtx_event_receiver_inst/event_receiver_mgt_inst/U0/event_receiver_mgt_i/gt0_event_receiver_mgt_i/gtxe2_i/RXOUTCLK}]
 

--- a/modules/sfp_dls_eventr/hdl/sfp_dls_eventr_wrapper.vhd
+++ b/modules/sfp_dls_eventr/hdl/sfp_dls_eventr_wrapper.vhd
@@ -120,7 +120,7 @@ port map (
 
 -- Assign outputs
 
-SFP_o.EVR_REC_CLK <= rxoutclk;
+SFP_o.MGT_REC_CLK <= rxoutclk;
 SFP_o.LINK_UP <= LINKUP(0);
 
 bit1_o(0) <= bit1;

--- a/modules/sfp_dls_eventr/hdl/sfp_dls_eventr_wrapper.vhd
+++ b/modules/sfp_dls_eventr/hdl/sfp_dls_eventr_wrapper.vhd
@@ -62,8 +62,10 @@ architecture rtl of sfp_dls_eventr_wrapper is
 --end component;
 
 signal mgt_ready_o           : std_logic;
+signal mgt_ready_sync    : std_logic;
 signal event_clk             : std_logic;
 signal rx_link_ok_o          : std_logic;
+signal rx_link_ok_sync    : std_logic;
 signal loss_lock_o           : std_logic;
 signal rx_error_o            : std_logic;
 signal rxcharisk             : std_logic_vector(1 downto 0);
@@ -238,8 +240,24 @@ port map(
 --      probe12 => probe12_slv
 --);
 
+--synchronise rx_link_ok to clk_i
+rx_link_sync : entity work.sync_bit
+    port map(
+     clk_i => clk_i,
+     bit_i => rx_link_ok_o,
+     bit_o => rx_link_ok_sync
+);
+
+--synchronise mgt_ready_o to clk_i
+mgt_rdy_sync : entity work.sync_bit
+    port map(
+     clk_i => clk_i,
+     bit_i => mgt_ready_o,
+     bit_o => mgt_ready_sync
+);
+
 -- MGT ready and link is up
-LINKUP(0) <= mgt_ready_o and rx_link_ok_o;
+LINKUP(0) <= mgt_ready_sync and rx_link_ok_sync;
 ---- Link is up
 --LINKUP(1) <= rx_link_ok_o;
 ---- MGT ready

--- a/modules/sfp_dls_eventr/hdl/sfp_event_receiver.vhd
+++ b/modules/sfp_dls_eventr/hdl/sfp_event_receiver.vhd
@@ -157,6 +157,11 @@ signal gt0_rxcommadet_out            : std_logic;
 signal gt0_qplloutclk_in             : std_logic;
 signal gt0_qplloutrefclk_in          : std_logic;
 
+signal GT0_TX_FSM_RESET_DONE_OUT_sync   : std_logic;
+signal GT0_RX_FSM_RESET_DONE_OUT_sync   : std_logic;
+signal gt0_txresetdone_out_sync         : std_logic;
+signal gt0_rxresetdone_out_sync         : std_logic;
+
 begin
 
 rxcharisk_o <= gt0_rxcharisk_out;
@@ -171,12 +176,41 @@ rxdata_o <= gt0_rxdata_out;
 
 rxnotintable_o <= gt0_rxnotintable_out;
 
+--synchronise signals from MGT clock domains
+TX_FSM_RST_sync : entity work.sync_bit
+    port map(
+     clk_i => event_clk_i,
+     bit_i => GT0_TX_FSM_RESET_DONE_OUT,
+     bit_o => GT0_TX_FSM_RESET_DONE_OUT_sync
+);
+
+RX_FSM_RST_sync : entity work.sync_bit
+    port map(
+     clk_i => event_clk_i,
+     bit_i => GT0_RX_FSM_RESET_DONE_OUT,
+     bit_o => GT0_RX_FSM_RESET_DONE_OUT_sync
+);
+
+txreset_sync : entity work.sync_bit
+    port map(
+     clk_i => event_clk_i,
+     bit_i => gt0_txresetdone_out,
+     bit_o => gt0_txresetdone_out_sync
+);
+
+rxreset_sync : entity work.sync_bit
+    port map(
+     clk_i => event_clk_i,
+     bit_i => gt0_rxresetdone_out,
+     bit_o => gt0_rxresetdone_out_sync
+);
+
 -- Indicates when the link is up when the rx and tx reset have finished
 ps_linkup: process(event_clk_i)
 begin
     if rising_edge(event_clk_i) then
-        if ( GT0_TX_FSM_RESET_DONE_OUT and GT0_RX_FSM_RESET_DONE_OUT and
-             gt0_rxresetdone_out and gt0_txresetdone_out) = '1' then
+        if ( GT0_TX_FSM_RESET_DONE_OUT_sync and GT0_RX_FSM_RESET_DONE_OUT_sync and
+             gt0_rxresetdone_out_sync and gt0_txresetdone_out_sync) = '1' then
             mgt_ready_o <= '1';
         else
             mgt_ready_o <= '0';

--- a/modules/sfp_loopback/const/sfp_loopback_impl.xdc
+++ b/modules/sfp_loopback/const/sfp_loopback_impl.xdc
@@ -9,6 +9,6 @@ set_property LOC $SFP{{ block.site }}_GTX_LOC \
 # -------------------------------------------------------------------
 # Define asynchronous clocks
 # -------------------------------------------------------------------
-set_clock_groups -asynchronous -group [get_clocks \ 
+set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks \ 
 {softblocks_inst/{{ block.name }}_inst/sfpgtx_exdes_i/sfpgtx_support_i/sfpgtx_init_i/U0/sfpgtx_i/gt0_sfpgtx_i/gtxe2_i/TXOUTCLK}]
 

--- a/modules/sfp_panda_sync/const/sfp_panda_sync_impl.xdc
+++ b/modules/sfp_panda_sync/const/sfp_panda_sync_impl.xdc
@@ -8,9 +8,9 @@ set_property LOC $SFP{{ block.site}}_GTX_LOC \
 # -------------------------------------------------------------------
 # Define asynchronous clocks
 # -------------------------------------------------------------------
-set_clock_groups -asynchronous -group [get_clocks \ 
+set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks \ 
 {softblocks_inst/{{ block.name }}_inst/sfp_panda_sync_mgt_interface_inst/sfp_panda_sync_i/U0/sfp_panda_sync_i/gt0_sfp_panda_sync_i/gtxe2_i/TXOUTCLK}]
 
-set_clock_groups -asynchronous -group [get_clocks \ 
+set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks \ 
 {softblocks_inst/{{ block.name }}_inst/sfp_panda_sync_mgt_interface_inst/sfp_panda_sync_i/U0/sfp_panda_sync_i/gt0_sfp_panda_sync_i/gtxe2_i/RXOUTCLK}]
 

--- a/modules/sfp_panda_sync/hdl/sfp_panda_sync_mgt_interface.vhd
+++ b/modules/sfp_panda_sync/hdl/sfp_panda_sync_mgt_interface.vhd
@@ -147,14 +147,48 @@ signal gt0_txoutclkfabric_out        : std_logic;
 signal gt0_txoutclkpcs_out           : std_logic;
 signal gt0_txresetdone_out           : std_logic;
 
+signal GT0_TX_FSM_RESET_DONE_OUT_sync   : std_logic;
+signal GT0_RX_FSM_RESET_DONE_OUT_sync   : std_logic;
+signal gt0_txresetdone_out_sync         : std_logic;
+signal gt0_rxresetdone_out_sync         : std_logic;
+
 begin
+
+--synchronise signals from MGT clock domains
+TX_FSM_RST_sync : entity work.sync_bit
+    port map(
+     clk_i => clk_i,
+     bit_i => GT0_TX_FSM_RESET_DONE_OUT,
+     bit_o => GT0_TX_FSM_RESET_DONE_OUT_sync
+);
+
+RX_FSM_RST_sync : entity work.sync_bit
+    port map(
+     clk_i => clk_i,
+     bit_i => GT0_RX_FSM_RESET_DONE_OUT,
+     bit_o => GT0_RX_FSM_RESET_DONE_OUT_sync
+);
+
+txreset_sync : entity work.sync_bit
+    port map(
+     clk_i => clk_i,
+     bit_i => gt0_txresetdone_out,
+     bit_o => gt0_txresetdone_out_sync
+);
+
+rxreset_sync : entity work.sync_bit
+    port map(
+     clk_i => clk_i,
+     bit_i => gt0_rxresetdone_out,
+     bit_o => gt0_rxresetdone_out_sync
+);
 
 -- Indicates when the link is up when the rx and tx reset have finished
 ps_linkup: process(clk_i)
 begin
-    if rising_edge(clk_i) then
-        if ( GT0_TX_FSM_RESET_DONE_OUT and GT0_RX_FSM_RESET_DONE_OUT and
-             gt0_rxresetdone_out and gt0_txresetdone_out) = '1' then
+    if rising_edge(clk_i) then  
+        if ( GT0_TX_FSM_RESET_DONE_OUT_sync and GT0_RX_FSM_RESET_DONE_OUT_sync and
+             gt0_rxresetdone_out_sync and gt0_txresetdone_out_sync) = '1' then
             mgt_ready_o <= '1';
         else
             mgt_ready_o <= '0';

--- a/modules/sfp_panda_sync/hdl/sfp_panda_sync_transmit.vhd
+++ b/modules/sfp_panda_sync/hdl/sfp_panda_sync_transmit.vhd
@@ -9,7 +9,6 @@ entity sfp_panda_sync_transmit is
         clk_i           : in  std_logic;
         txoutclk_i      : in  std_logic;
         reset_i         : in  std_logic;
-        rx_link_ok_i    : in  std_logic; 
         txcharisk_o     : out std_logic_vector(3 downto 0) := (others => '0');
         POSOUT1_i       : in  std_logic_vector(31 downto 0);
         POSOUT2_i       : in  std_logic_vector(31 downto 0);

--- a/modules/sfp_panda_sync/hdl/sfp_panda_sync_wrapper.vhd
+++ b/modules/sfp_panda_sync/hdl/sfp_panda_sync_wrapper.vhd
@@ -57,6 +57,7 @@ end sfp_panda_sync_wrapper;
 architecture rtl of sfp_panda_sync_wrapper is
 
 signal rx_link_ok         : std_logic;
+signal rx_link_ok_sync    : std_logic;
 signal rxbyteisaligned_o  : std_logic;
 signal rxbyterealign_o    : std_logic;
 signal rxcommadet_o       : std_logic;
@@ -165,7 +166,6 @@ sfp_panda_sync_transmitter_inst : entity work.sfp_panda_sync_transmit
         clk_i             => clk_i,
         txoutclk_i        => txoutclk_i,
         reset_i           => reset_i,
-        rx_link_ok_i      => rx_link_ok,
         txcharisk_o       => txcharisk_i,
         txdata_o          => txdata_i,
         POSOUT1_i         => POSOUT1,
@@ -231,9 +231,16 @@ sfp_panda_sync_mgt_interface_inst : entity work.sfp_panda_sync_mgt_interface
 BITOUT <= BITOUT16 & BITOUT15 & BITOUT14 & BITOUT13 & BITOUT12 & BITOUT11 & BITOUT10 & BITOUT9 & 
           BITOUT8  & BITOUT7  & BITOUT6  & BITOUT5  & BITOUT4  & BITOUT3  & BITOUT2  & BITOUT1;
 
+--synchronise rx_link_ok to clk_i
+rx_link_sync : entity work.sync_bit
+    port map(
+     clk_i => clk_i,
+     bit_i => rx_link_ok,
+     bit_o => rx_link_ok_sync
+);
 
 -- Link up and MGT ready
-LINKUP(0) <= mgt_ready_o and rx_link_ok;
+LINKUP(0) <= mgt_ready_o and rx_link_ok_sync;
 LINKUP(31 downto 1) <= (others => '0');
 
 sfp_panda_sync_ctrl_inst : entity work.sfp_panda_sync_ctrl

--- a/modules/system/hdl/system_top.vhd
+++ b/modules/system/hdl/system_top.vhd
@@ -61,7 +61,7 @@ port (
     -- External Clock
     ext_clk_i           : in  std_logic;
     sma_pll_locked_i    : in  std_logic;
-    ext_clock_o         : out std_logic_vector(1 downto 0);
+    clock_src_o         : out std_logic_vector(1 downto 0);
     clk_sel_stat_i      : in  std_logic_vector(1 downto 0)
 
 );
@@ -80,7 +80,7 @@ signal slow_leds_tlp    : slow_packet;
 signal cmd_ready_n      : std_logic;
 
 signal VEC_PLL_LOCKED   : std_logic_vector(31 downto 0) := (others => '0');
-signal VEC_EXT_CLOCK    : std_logic_vector(31 downto 0);
+signal VEC_CLOCK_SRC    : std_logic_vector(31 downto 0);
 signal VEC_CLK_SEL_STAT : std_logic_vector(31 downto 0) := (others => '0');
 signal write_ack        : std_logic;
 signal test_clocks      : std_logic_vector(0 downto 0);
@@ -156,7 +156,7 @@ port map (
 -- External Clock registers
 ---------------------------------------------------------------------------
 VEC_PLL_LOCKED(0) <= sma_pll_locked_i;
-ext_clock_o <= VEC_EXT_CLOCK(1 downto 0);
+clock_src_o <= VEC_CLOCK_SRC(1 downto 0);
 VEC_CLK_SEL_STAT(1 downto 0) <= clk_sel_stat_i;
 
 --
@@ -169,7 +169,7 @@ ps_ack: process(clk_i)
 begin
     if rising_edge(clk_i)then
         if ((write_strobe_i = '1') and
-          (write_address_i = std_logic_vector(to_unsigned(SYSTEM_EXT_CLOCK_addr,write_address_i'length)))) then
+          (write_address_i = std_logic_vector(to_unsigned(SYSTEM_CLOCK_SOURCE_addr,write_address_i'length)))) then
             write_ack <= '1';
         else
             write_ack <= '0';
@@ -213,8 +213,8 @@ port map (
     ENC_24V             => VOLT_MON(6),
     FMC_12V             => VOLT_MON(7),
     PLL_LOCKED          => VEC_PLL_LOCKED,
-    EXT_CLOCK           => VEC_EXT_CLOCK,
-    EXT_CLOCK_WSTB      => open,
+    CLOCK_SOURCE        => VEC_CLOCK_SRC,
+    CLOCK_SOURCE_WSTB   => open,
     EXT_CLOCK_FREQ      => FREQ_VAL(0),
     CLK_SEL_STAT        => VEC_CLK_SEL_STAT,
     -- Memory Bus Interface

--- a/modules/system/system.block.ini
+++ b/modules/system/system.block.ini
@@ -76,7 +76,7 @@ scale: 0.001494582
 type: read
 description: PLL locked for SMA external clock
 
-[EXT_CLOCK]
+[CLOCK_SOURCE]
 type: param enum
 description: External sma and event receiver clock enables
 0: int clock

--- a/modules/system/system.block.ini
+++ b/modules/system/system.block.ini
@@ -81,7 +81,7 @@ type: param enum
 description: External sma and event receiver clock enables
 0: int clock
 1: sma clock
-2: event receiver
+2: mgt recovered clock
 
 [EXT_CLOCK_FREQ]
 type: read

--- a/modules/system/system.block.ini
+++ b/modules/system/system.block.ini
@@ -81,7 +81,7 @@ type: param enum
 description: External sma and event receiver clock enables
 0: int clock
 1: sma clock
-2: mgt recovered clock
+2: sfp1 recovered clock
 
 [EXT_CLOCK_FREQ]
 type: read

--- a/targets/PandABox/const/PandABox-clks_impl.xdc
+++ b/targets/PandABox/const/PandABox-clks_impl.xdc
@@ -2,25 +2,19 @@
 # Define asynchronous clocks
 # -------------------------------------------------------------------
 
-set_clock_groups -asynchronous -group clk_fpga_0
-set_clock_groups -asynchronous -group clk_fpga_1
-set_clock_groups -asynchronous -group EXTCLK_P
+set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks clk_fpga_0]
+set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks EXTCLK_P]
 set_clock_groups -asynchronous -group GTXCLK0_P
 set_clock_groups -asynchronous -group GTXCLK1_P
 
-create_generated_clock -quiet -name pll2_clkin1_out0 -master_clock sma_clk_out1 \
-    [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT0]
-create_generated_clock -quiet -name pll2_clkin2_out0 -master_clock clk_fpga_0 \
-    [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT0]
+set_clock_groups -quiet -logically_exclusive -group fclk_clk -group fclk_clk_1 -group fclk_clk_2
+set_clock_groups -quiet -logically_exclusive -group fclk_clk_2x -group fclk_clk_2x_1 -group fclk_clk_2x_2
+set_clock_groups -quiet -logically_exclusive -group pll2_clkfbout -group pll2_clkfbout_1 -group pll2_clkfbout_2
 
-create_generated_clock -quiet -name pll2_clkin1_out1 -master_clock sma_clk_out1 \
-    [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT1]
-create_generated_clock -quiet -name pll2_clkin2_out1 -master_clock clk_fpga_0 \
-    [get_pins mmcm_clkmux_inst/plle2_adv_inst2/CLKOUT1]
-
-set_clock_groups -quiet -physically_exclusive -group pll2_clkin1_out0 -group pll2_clkin2_out0
-set_clock_groups -quiet -physically_exclusive -group pll2_clkin1_out1 -group pll2_clkin2_out1
-
-set_clock_groups -quiet -physically_exclusive -group pll2_clkin1_out0 -group pll2_clkin2_out1
-set_clock_groups -quiet -physically_exclusive -group pll2_clkin2_out0 -group pll2_clkin1_out1
+set_clock_groups -quiet -logically_exclusive -group fclk_clk -group fclk_clk_2x_1
+set_clock_groups -quiet -logically_exclusive -group fclk_clk -group fclk_clk_2x_2
+set_clock_groups -quiet -logically_exclusive -group fclk_clk_1 -group fclk_clk_2x
+set_clock_groups -quiet -logically_exclusive -group fclk_clk_1 -group fclk_clk_2x_2
+set_clock_groups -quiet -logically_exclusive -group fclk_clk_2 -group fclk_clk_2x
+set_clock_groups -quiet -logically_exclusive -group fclk_clk_2 -group fclk_clk_2x_1
 

--- a/targets/PandABox/hdl/PandABox_top.vhd
+++ b/targets/PandABox/hdl/PandABox_top.vhd
@@ -323,7 +323,6 @@ port map(
     sma_clk_i         => EXTCLK,
     mgt_rec_clk_i          => SFP1_o.MGT_REC_CLK,
     clk_sel_i         => clk_src_sel,
-    linkup_i             => SFP1_o.LINK_UP,
     sma_pll_locked_o    => sma_pll_locked,
     clk_sel_stat_o        => clk_sel_stat,
     fclk_clk0_o         => FCLK_CLK0,

--- a/targets/PandABox/hdl/PandABox_top.vhd
+++ b/targets/PandABox/hdl/PandABox_top.vhd
@@ -760,7 +760,7 @@ port map (
     -- External clock
     ext_clk_i           => EXTCLK,
     sma_pll_locked_i    => sma_pll_locked,
-    ext_clock_o         => clk_src_sel,
+    clock_src_o         => clk_src_sel,
     clk_sel_stat_i        => clk_sel_stat
 );
 

--- a/targets/PandABox/hdl/PandABox_top.vhd
+++ b/targets/PandABox/hdl/PandABox_top.vhd
@@ -321,7 +321,7 @@ mmcm_clkmux_inst: entity work.mmcm_clkmux
 port map(
     fclk_clk0_ps_i      => FCLK_CLK0_PS,
     sma_clk_i         => EXTCLK,
-    rxoutclk_i          => SFP1_o.EVR_REC_CLK,
+    mgt_rec_clk_i          => SFP1_o.MGT_REC_CLK,
     clk_sel_i         => clk_src_sel,
     linkup_i             => SFP1_o.LINK_UP,
     sma_pll_locked_o    => sma_pll_locked,


### PR DESCRIPTION
Having convinced myself that it is enough to declare the clocks as asynchronous groups with the `-include_generated_clocks` flag (given that the clocks are async and we don't make use of any advanced CDC constraints such as `max_delay -datapathonly`), I eventually conceded and re-added exclusive constraints for the multiplexed clocks (although not-strictly necessary) to appease the `report_cdc` tool. I decided to just use the auto-derived names of these clocks, rather than renaming them with `create_generated_clock` as this causes complications with the recovered clock name and the processing order of the constraint files by Vivado.

Also, for clean living, added synchronisers to some MGT derived signals which are used in the clock mux selection, and renamed clock signals for better clarity.

