### PR TITLE
Fix for USB on PandABox

### DIFF
--- a/targets/PandABox/target-top.dts
+++ b/targets/PandABox/target-top.dts
@@ -14,6 +14,13 @@
 		device_type = "memory";
 		reg = <0x0 0x40000000>;
 	};
+	usb_phy0: phy0 {
+		compatible = "ulpi-phy";
+		#phy-cells = <0>;
+		reg = <0xe0002000 0x1000>;
+		view-port = <0x170>;
+		drv-vbus;
+    };
 };
 
 &usb0 {
@@ -21,6 +28,7 @@
 	phy_type = "ulpi";
 	status = "okay";
 	usb-reset = <&gpio0 7 0>;
+	usb-phy = <&usb_phy0>;
 };
 
 &clkc {


### PR DESCRIPTION
Fix for USB on PandABox for PandABlocks v3 (Vivado 2020 and later).

With some help from @EmilioPeJu and the Xilinx wiki:
https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842272/Zynq+Linux+USB+Device+Driver
we added a node for the usb-phy to the devicetree.

The corresponding change for the xu5 was not found to be necessary, as the USB already works fine with v3. Not sure about the ZedBoard but from recollection this did not work in the past, though USB support is not so useful for this target.