### PR TITLE
Changes to build system to only generate IP required for App

### DIFF
--- a/CONFIG.example
+++ b/CONFIG.example
@@ -12,6 +12,9 @@ VIVADO_VER = 2020.2
 
 # Definitions needed for FPGA build
 export VIVADO = /scratch/Xilinx/Vivado/\$(VIVADO_VER)/settings64.sh
+# Path to external IP repository (if required)
+#export EXT_IP_REPO =
+
 
 # Specifiy licence server, if required
 # export LM_LICENCE_FILE =

--- a/Makefile
+++ b/Makefile
@@ -261,14 +261,9 @@ else
 	. $(VIVADO) && vivado -mode $(DEP_MODE) $(PS_PROJ)
 endif
 
-edit_ips: DEP_MODE=gui
-ifeq ($(wildcard $(IP_PROJ)), )
-  edit_ips: carrier_ip
-else
-  edit_ips:
-	cd $(TGT_BUILD_DIR)/ip_repo; \
-	. $(VIVADO) && vivado -mode $(DEP_MODE) $(IP_PROJ)
-endif
+edit_ips: carrier_ip
+	cd $(TGT_BUILD_DIR)/ip_repo &&  \
+	. $(VIVADO) && vivado -mode gui $(IP_PROJ)
 
 carrier-fpga_gui: TOP_MODE=gui 
 ifeq ($(wildcard $(TOP_PROJ)), )

--- a/common/fpga.make
+++ b/common/fpga.make
@@ -42,13 +42,12 @@ FPGA_BIN_FILE = $(BUILD_DIR)/panda_top.bin
 VERSION_FILE = $(AUTOGEN)/hdl/version.vhd
 CONSTANT_FILE = $(AUTOGEN)/hdl/panda_constants.vhd
 
-# target_incl.make needs to be included after the VERSION_FILE variable is defined otherwise
-# make does not work out the dependencies properly. I don't understand why exactly!
--include $(TARGET_DIR)/target_incl.make
+IP_PROJ=$(IP_DIR)/managed_ip_project/managed_ip_project.xpr
 
 SDK_EXPORT = $(PS_DIR)/panda_ps.sdk
 HWDEF = $(PS_DIR)/panda_ps.xsa
 
+IP_PROJECT_SCR = $(TOP)/common/scripts/build_ip_proj.tcl
 IP_BUILD_SCR = $(TOP)/common/scripts/build_ip.tcl
 PS_BUILD_SCR = $(TOP)/common/scripts/build_ps.tcl
 PS_CONFIG_SCR = $(TARGET_DIR)/bd/panda_ps.tcl
@@ -82,6 +81,9 @@ ATF_BUILD = $(BOOT_BUILD)/atf
 ATF_ELF = $(ATF_BUILD)/build/zynqmp/release/bl31/bl31.elf
 
 IMAGE_DIR=$(TGT_BUILD_DIR)/boot
+
+# Include auto-generated list of IP required for app
+-include $(AUTOGEN)/ip.make
     
 # ------------------------------------------------------------------------------
 # Helper code lifted from rootfs and other miscellaneous functions
@@ -89,12 +91,11 @@ IMAGE_DIR=$(TGT_BUILD_DIR)/boot
 # Use the rootfs extraction tool to decompress our source trees.
 EXTRACT_FILE = $(ROOTFS_TOP)/scripts/extract-tar $(SRC_ROOT) $1 $2 $(TAR_FILES)
 
-
 #####################################################################
 # BUILD TARGETS includes HW and SW
 fpga-all: fpga-bit boot
 fpga-bit: carrier_fpga
-carrier_ip: $(IP_DIR)/IP_BUILD_SUCCESS
+carrier_ip: $(APP_IP_DEPS)
 ps_core: $(PS_CORE)
 devicetree : $(DEVTREE_DTB)
 fsbl : $(FSBL)
@@ -144,12 +145,16 @@ $(CONSTANT_FILE) : $(TOP)/common/templates/registers_server
 ###########################################################
 # Build Zynq Firmware targets
 
-$(IP_DIR)/IP_BUILD_SUCCESS : $(IP_BUILD_SCR) $(TGT_INCL_SCR)
-	rm -f $@
-	$(RUNVIVADO) -mode $(DEP_MODE) -source $< \
+$(IP_PROJ) : $(IP_PROJECT_SCR) $(TGT_INCL_SCR)
+	$(RUNVIVADO) -mode batch -source $< \
 	  -log $(TGT_BUILD_DIR)/build_ip.log -nojournal \
-	  -tclargs $(TOP) $(TARGET_DIR) $(IP_DIR) $(DEP_MODE)
-	touch $@
+	  -tclargs $(TGT_INCL_SCR) $@ $(EXT_IP_REPO)
+
+$(IP_DIR)/% : $(TOP)/ip_defs/%.tcl $(IP_BUILD_SCR) | $(IP_PROJ)
+	$(RUNVIVADO) -mode batch -source $(IP_BUILD_SCR) \
+	  -applog -log $(TGT_BUILD_DIR)/build_ip.log -nojournal \
+	  -tclargs $(IP_PROJ) $(IP_DIR) $(notdir $@) $<
+	touch $@/IP_DONE
 
 $(PS_CORE) : $(PS_BUILD_SCR) $(PS_CONFIG_SCR) $(TGT_INCL_SCR)
 	$(RUNVIVADO) -mode $(DEP_MODE) -source $< \
@@ -159,7 +164,7 @@ $(PS_CORE) : $(PS_BUILD_SCR) $(PS_CONFIG_SCR) $(TGT_INCL_SCR)
 CARRIER_FPGA_DEPS += $(TOP_BUILD_SCR)
 CARRIER_FPGA_DEPS += $(VERSION_FILE)
 CARRIER_FPGA_DEPS += $(CONSTANT_FILE)
-CARRIER_FPGA_DEPS += $(IP_DIR)/IP_BUILD_SUCCESS
+CARRIER_FPGA_DEPS += $(APP_IP_DEPS)
 CARRIER_FPGA_DEPS += $(PS_CORE)
 CARRIER_FPGA_DEPS += $(TGT_INCL_SCR)
 

--- a/common/fpga.make
+++ b/common/fpga.make
@@ -150,11 +150,11 @@ $(IP_PROJ) : $(IP_PROJECT_SCR) $(TGT_INCL_SCR)
 	  -log $(TGT_BUILD_DIR)/build_ip.log -nojournal \
 	  -tclargs $(TGT_INCL_SCR) $@ $(EXT_IP_REPO)
 
-$(IP_DIR)/% : $(TOP)/ip_defs/%.tcl $(IP_BUILD_SCR) | $(IP_PROJ)
+$(IP_DIR)/%/IP_DONE : $(TOP)/ip_defs/%.tcl $(IP_BUILD_SCR) | $(IP_PROJ)
 	$(RUNVIVADO) -mode batch -source $(IP_BUILD_SCR) \
 	  -applog -log $(TGT_BUILD_DIR)/build_ip.log -nojournal \
-	  -tclargs $(IP_PROJ) $(IP_DIR) $(notdir $@) $<
-	touch $@/IP_DONE
+	  -tclargs $(IP_PROJ) $(IP_DIR) $* $<
+	touch $@
 
 $(PS_CORE) : $(PS_BUILD_SCR) $(PS_CONFIG_SCR) $(TGT_INCL_SCR)
 	$(RUNVIVADO) -mode $(DEP_MODE) -source $< \

--- a/common/python/generate_app.py
+++ b/common/python/generate_app.py
@@ -373,6 +373,8 @@ class AppGenerator(object):
         context = jinja_context(fpga_blocks=self.fpga_blocks, os=os, ips=ips)
         self.expand_template("constraints.tcl.jinja2", context, const_dir,
                              "constraints.tcl")
+        self.expand_template("ip.make.jinja2", context, self.app_build_dir,
+                             "ip.make")
 
     def generate_regdefs(self):
         """generate the registers define file from the registers server file"""

--- a/common/scripts/build_ip.tcl
+++ b/common/scripts/build_ip.tcl
@@ -1,31 +1,28 @@
 #
-# Generate Xilinx IP Cores
+# Generate IP Cores
 #
 
-set TOP [lindex $argv 0]
+set IP_PROJ [lindex $argv 0]
 
-# Source directory
-set TARGET_DIR [lindex $argv 1]
+set BUILD_DIR [lindex $argv 1]
 
-# Build directory
-set BUILD_DIR [lindex $argv 2]
+set IP [lindex $argv 2]
 
-# Vivado run mode - gui or batch mode
-# Now unused
-set MODE [lindex $argv 3]
+set IP_TCL [lindex $argv 3]
 
-set_param board.repoPaths $TOP/common/configs
+# Open Managed IP Project
+open_project $IP_PROJ
 
-source $TARGET_DIR/target_incl.tcl
+#Remove IP from project if already existing
+remove_files -quiet [get_files $BUILD_DIR/$IP/$IP.xci]
+exec rm -rf $BUILD_DIR/$IP
 
-# Create Managed IP Project
-create_project -part $FPGA_PART -force -ip managed_ip_project $BUILD_DIR/managed_ip_project
+#Create and configure XCI file
+source $IP_TCL
 
-set_property target_language VHDL [current_project]
-set_property target_simulator ModelSim [current_project]
+# Generate output products for global synthesis
+set_property generate_synth_checkpoint false [get_files $BUILD_DIR/$IP/$IP.xci]
+generate_target all [get_files $BUILD_DIR/$IP/$IP.xci]
 
-foreach IP $TGT_IP {
-    source $TOP/ip_defs/$IP.tcl
-    set_property GENERATE_SYNTH_CHECKPOINT FALSE [get_files  $BUILD_DIR/$IP/$IP.xci]
-}
+close_project
 

--- a/common/scripts/build_ip_proj.tcl
+++ b/common/scripts/build_ip_proj.tcl
@@ -8,7 +8,7 @@ set TGT_INCL_TCL [lindex $argv 0]
 set PROJ_FILE [lindex $argv 1]
 
 # Set external IP REPO path
-set EXT_IP_REPO [lindex $argv 3]
+set EXT_IP_REPO [lindex $argv 2]
 
 source $TGT_INCL_TCL
 

--- a/common/scripts/build_ip_proj.tcl
+++ b/common/scripts/build_ip_proj.tcl
@@ -1,0 +1,24 @@
+#
+# Generate IP Project
+#
+
+set TGT_INCL_TCL [lindex $argv 0]
+
+# Source directory
+set PROJ_FILE [lindex $argv 1]
+
+# Set external IP REPO path
+set EXT_IP_REPO [lindex $argv 3]
+
+source $TGT_INCL_TCL
+
+# Create Managed IP Project
+create_project -part $FPGA_PART -force -ip $PROJ_FILE
+
+set_property target_language VHDL [current_project]
+set_property target_simulator ModelSim [current_project]
+
+set_property ip_repo_paths $EXT_IP_REPO [current_project]
+
+close_project
+

--- a/common/templates/ip.make.jinja2
+++ b/common/templates/ip.make.jinja2
@@ -1,3 +1,3 @@
 {% for ip in ips %}
-APP_IP_DEPS += $(IP_DIR)/{{ ip }}
+APP_IP_DEPS += $(IP_DIR)/{{ ip }}/IP_DONE
 {% endfor %}

--- a/common/templates/ip.make.jinja2
+++ b/common/templates/ip.make.jinja2
@@ -1,0 +1,3 @@
+{% for ip in ips %}
+APP_IP_DEPS += $(IP_DIR)/{{ ip }}
+{% endfor %}

--- a/ip_defs/eth_mac.tcl
+++ b/ip_defs/eth_mac.tcl
@@ -23,5 +23,3 @@ set_property -dict [list \
     CONFIG.Statistics_Counters {false}   \
 ] [get_ips eth_mac]
 
-generate_target all [get_ips eth_mac]
-

--- a/ip_defs/eth_phy.tcl
+++ b/ip_defs/eth_phy.tcl
@@ -11,5 +11,3 @@ set_property -dict [list \
     CONFIG.EMAC_IF_TEMAC {TEMAC} \
 ] [get_ips eth_phy]
 
-generate_target all [get_ips eth_phy]
-

--- a/ip_defs/event_receiver_mgt.tcl
+++ b/ip_defs/event_receiver_mgt.tcl
@@ -49,5 +49,3 @@ set_property -dict [list \
     CONFIG.gt0_val_clk_cor_seq_2_4 {00000000}                   \
 ] [get_ips event_receiver_mgt]
 
-generate_target all [get_ips event_receiver_mgt]
-

--- a/ip_defs/fifo_1K32.tcl
+++ b/ip_defs/fifo_1K32.tcl
@@ -12,5 +12,4 @@ set_property -dict [list \
     CONFIG.Reset_Type {Synchronous_Reset} \
 ] [get_ips fifo_1K32]
 
-generate_target all [get_ips fifo_1K32]
 

--- a/ip_defs/fifo_1K32_ft.tcl
+++ b/ip_defs/fifo_1K32_ft.tcl
@@ -13,5 +13,3 @@ set_property -dict [list \
     CONFIG.Reset_Type {Synchronous_Reset} \
 ] [get_ips fifo_1K32_ft]
 
-generate_target all [get_ips fifo_1K32_ft]
-

--- a/ip_defs/fmc_acq427_dac_fifo.tcl
+++ b/ip_defs/fmc_acq427_dac_fifo.tcl
@@ -21,5 +21,3 @@ set_property -dict [list \
         CONFIG.Full_Threshold_Negate_Value {12}
 ] [get_ips fmc_acq427_dac_fifo]
 
-generate_target all [get_ips fmc_acq427_dac_fifo]
-

--- a/ip_defs/fmc_acq430_ch_fifo.tcl
+++ b/ip_defs/fmc_acq430_ch_fifo.tcl
@@ -21,5 +21,3 @@ set_property -dict [list \
         CONFIG.Full_Threshold_Negate_Value {252}
 ] [get_ips fmc_acq430_ch_fifo]
 
-generate_target all [get_ips fmc_acq430_ch_fifo]
-

--- a/ip_defs/fmc_acq430_sample_ram.tcl
+++ b/ip_defs/fmc_acq430_sample_ram.tcl
@@ -12,5 +12,3 @@ set_property -dict [list \
         CONFIG.common_output_clk {true}
 ] [get_ips fmc_acq430_sample_ram]
 
-generate_target all [get_ips fmc_acq430_sample_ram]
-

--- a/ip_defs/fmcgtx.tcl
+++ b/ip_defs/fmcgtx.tcl
@@ -14,5 +14,3 @@ set_property -dict [list \
     CONFIG.identical_val_rx_reference_clock {156.250}               \
 ] [get_ips fmcgtx]
 
-generate_target all [get_ips fmcgtx]
-

--- a/ip_defs/ila_0.tcl
+++ b/ip_defs/ila_0.tcl
@@ -18,5 +18,3 @@ set_property -dict [list \
     CONFIG.C_TRIGIN_EN {false}  \
 ] [get_ips ila_0]
 
-generate_target all [get_ips ila_0]
-

--- a/ip_defs/ila_32x8K.tcl
+++ b/ip_defs/ila_32x8K.tcl
@@ -9,5 +9,3 @@ set_property -dict [list \
     CONFIG.C_DATA_DEPTH {8192}  \
 ] [get_ips ila_32x8K]
 
-generate_target all [get_ips ila_32x8K]
-

--- a/ip_defs/pulse_queue.tcl
+++ b/ip_defs/pulse_queue.tcl
@@ -15,5 +15,3 @@ set_property -dict [list \
     CONFIG.Reset_Type {Synchronous_Reset} \
 ] [get_ips pulse_queue]
 
-generate_target all [get_ips pulse_queue]
-

--- a/ip_defs/sfp_panda_sync.tcl
+++ b/ip_defs/sfp_panda_sync.tcl
@@ -52,5 +52,3 @@ CONFIG.gt0_val_clk_cor_seq_2_3 {00000000}               \
 CONFIG.gt0_val_clk_cor_seq_2_4 {00000000}               \
 ] [get_ips sfp_panda_sync]
 
-generate_target all [get_ips sfp_panda_sync]
-

--- a/ip_defs/sfp_transmit_mem.tcl
+++ b/ip_defs/sfp_transmit_mem.tcl
@@ -11,5 +11,3 @@ set_property -dict [list                                                        
     CONFIG.Use_RSTA_Pin {false}                                                     \
 ] [get_ips sfp_transmit_mem]
 
-generate_target all [get_ips sfp_transmit_mem]
-

--- a/ip_defs/sfpgtx.tcl
+++ b/ip_defs/sfpgtx.tcl
@@ -14,5 +14,3 @@ set_property -dict [list \
     CONFIG.identical_val_rx_reference_clock {125.000}               \
 ] [get_ips sfpgtx]
 
-generate_target all [get_ips sfpgtx]
-

--- a/ip_defs/system_cmd_fifo.tcl
+++ b/ip_defs/system_cmd_fifo.tcl
@@ -10,5 +10,3 @@ set_property -dict [list \
     CONFIG.Output_Data_Width {42}   \
 ] [get_ips system_cmd_fifo]
 
-generate_target all [get_ips system_cmd_fifo]
-

--- a/targets/PandABox/target_incl.tcl
+++ b/targets/PandABox/target_incl.tcl
@@ -10,24 +10,3 @@ set CONSTRAINTS {                   \
             PandABox-clks_impl.xdc
 }
 
-# List of IP that can be targeted to this platform.
-# NB: these could built as and when required.
-set TGT_IP {                        \
-            pulse_queue             \
-            fifo_1K32               \
-            fifo_1K32_ft            \
-            fmcgtx                  \
-            sfpgtx                  \
-            eth_phy                 \
-            eth_mac                 \
-            system_cmd_fifo         \
-            fmc_acq430_ch_fifo      \
-            fmc_acq430_sample_ram   \
-            fmc_acq427_dac_fifo     \
-            ila_32x8K               \
-            event_receiver_mgt      \
-            sfp_panda_sync          \
-            ila_0                   \
-            sfp_transmit_mem
-}
-

--- a/targets/ZedBoard/target_incl.tcl
+++ b/targets/ZedBoard/target_incl.tcl
@@ -8,18 +8,3 @@ set CONSTRAINTS { \
             ZedBoard-pins_impl.xdc
 }
 
-# List of IP that can be targeted to this platform.
-# NB: these could built as and when required.
-set TGT_IP {                        \
-            pulse_queue             \
-            fifo_1K32               \
-            fifo_1K32_ft            \
-            eth_phy                 \
-            eth_mac                 \
-            system_cmd_fifo         \
-            fmc_acq430_ch_fifo      \
-            fmc_acq430_sample_ram   \
-            fmc_acq427_dac_fifo     \
-            ila_0
-}
-

--- a/targets/xu5_st1/target_incl.tcl
+++ b/targets/xu5_st1/target_incl.tcl
@@ -7,13 +7,3 @@ set CONSTRAINTS { \
             xu5_st1-pins_impl.xdc
 }
 
-# List of IP that can be targeted to this platform.
-# NB: these could built as and when required.
-set TGT_IP {                        \
-            pulse_queue             \
-            fifo_1K32               \
-            fifo_1K32_ft            \
-            fmc_acq430_ch_fifo      \
-            fmc_acq430_sample_ram
-}
-


### PR DESCRIPTION
* Allows for adding optional IP repos external to Vivado, so not all sites need to generate all IP for a particular target
* Does timestamp/dependency checking of each IP rather than build-once for each target as before, but will only regenerate the new IP when building new app
* At the expense of slightly longer runtime for IP product generation (c. 3-4 mins for no_fmc app, as opposed to 1-2 mins for all PandABox IPs) due to overhead from launching vivado multiple times (if anyone has an idea how to do this better, please suggest)
* Another side-effect is that `make edit_ips` will no longer show all IPs for a target, just those required for the app selected in CONFIG, but `make carrier_ip` can be run again for the other apps to fully populate the IP project.