### PR TITLE
Sequencer block modifications

### DIFF
--- a/modules/seq/hdl/sequencer_double_table.vhd
+++ b/modules/seq/hdl/sequencer_double_table.vhd
@@ -55,15 +55,19 @@ architecture rtl of sequencer_double_table is
     signal has_written_last : std_logic := '0';
     signal error_cond : std_logic := '0';
     signal read_error : std_logic := '0';
-    signal read_invalid_error : std_logic := '0';
-    signal read_underrun_error : std_logic := '0';
+    signal read_invalid_error : boolean := false;
+    signal read_underrun_error : boolean := false;
     signal entry_zero_history : std_logic_vector(3 downto 0) := (others => '0');
+    signal load_next_table : boolean := false;
 begin
     can_write_next_o <=
         to_std_logic(wrtable_index /= rdtable_index) and not has_written_last;
     next_expected_o <=
         to_std_logic(table_state(to_integer(rdtable_index)) = TABLE_CONT);
     last_o <= last_mux(to_integer(rdtable_index));
+    load_next_table <= load_next_i = '1'
+        and last_mux(to_integer(rdtable_index)) = '1'
+        and table_state(to_integer(rdtable_index)) = TABLE_CONT;
 
     -- if the table contains a continuation mark, substract 1 to avoid
     -- spending time on iterating that entry
@@ -118,14 +122,19 @@ begin
     begin
         if rising_edge(clk_i) then
             if reset_tables_i = '1' then
-                wrtable_index <= rdtable_index;
-                if table_state(to_integer(rdtable_index)) /= TABLE_LAST then
-                    -- only a valid table without continuation mark can be
-                    -- reused
-                    table_state(to_integer(rdtable_index)) <= TABLE_INVALID;
+                -- 3 cases need to be considered while resetting:
+                --   - case 1: if both table indexes are the same, no index is
+                --             updated
+                --   - case 2: if we are loading a table, then table read index
+                --             needs to be set to write index, so the next run
+                --             starts in the proper table
+                --   - case 3: if we are not loading and we have a valid
+                --             reading table, then table write index is set to
+                --             read index and that way, it can be reused in
+                --             next run
+                if table_state(to_integer(wrtable_index)) /= TABLE_LOADING then
+                        wrtable_index <= rdtable_index;
                 end if;
-                -- invalidate the other table
-                table_state(to_integer(rdtable_index + 1)) <= TABLE_INVALID;
             elsif TABLE_START = '1' then
                 table_state(to_integer(wrtable_index)) <= TABLE_LOADING;
             elsif TABLE_LENGTH_WSTB = '1' and
@@ -149,13 +158,13 @@ begin
     process (clk_i) is
     begin
         if rising_edge(clk_i) then
-            if load_next_i = '1' then
-                -- switching to next table if current contains
-                -- continuation mark
-                if last_mux(to_integer(rdtable_index)) = '1'
-                        and table_state(to_integer(rdtable_index)) = TABLE_CONT then
-                    rdtable_index <= rdtable_index + 1;
+            if reset_tables_i = '1' then
+                if table_state(to_integer(wrtable_index)) = TABLE_LOADING then
+                    rdtable_index <= wrtable_index;
                 end if;
+            -- switching to next table if current contains continuation mark
+            elsif load_next_table then
+                rdtable_index <= rdtable_index + 1;
             end if;
         end if;
     end process;
@@ -164,7 +173,7 @@ begin
     process (clk_i) is
     begin
         if rising_edge(clk_i) then
-            if read_invalid_error = '1' or read_underrun_error = '1' then
+            if read_invalid_error or read_underrun_error then
                 read_error <= '1';
                 error_type_o <= c_table_error_underrun;
             elsif reset_error_i = '1' then
@@ -174,14 +183,11 @@ begin
         end if;
     end process;
 
-    read_invalid_error <= load_next_i and
-        (to_std_logic(table_state(to_integer(rdtable_index)) = TABLE_LOADING) or
-         to_std_logic(table_state(to_integer(rdtable_index)) = TABLE_INVALID));
+    read_invalid_error <= load_next_i = '1'
+        and (table_state(to_integer(rdtable_index)) = TABLE_LOADING or
+             table_state(to_integer(rdtable_index)) = TABLE_INVALID);
 
-    read_underrun_error <= load_next_i and last_mux(to_integer(rdtable_index)) and
-        to_std_logic(rdtable_index + 1 = wrtable_index) and
-        to_std_logic(table_state(to_integer(rdtable_index)) = TABLE_CONT) and
-        to_std_logic(table_state(to_integer(wrtable_index)) /= TABLE_LAST);
+    read_underrun_error <= load_next_table and rdtable_index + 1 = wrtable_index;
 
     -- detect zero entry (continuation mark)
     has_cont_mark <= to_std_logic(entry_zero_history = "1111");

--- a/modules/seq/hdl/sequencer_table.vhd
+++ b/modules/seq/hdl/sequencer_table.vhd
@@ -79,10 +79,14 @@ signal seq_wren                 : std_logic_vector(3 downto 0);
 signal seq_di                   : std_logic_vector(31 downto 0);
 signal table_ready              : std_logic := '0';
 signal table_frames_reg : std_logic_vector(15 downto 0) := (others => '0');
+signal table_frames_now : std_logic_vector(15 downto 0) := (others => '0');
 
 begin
 
 table_ready_o <= table_ready;
+table_frames_now <=
+    TABLE_FRAMES when TABLE_LENGTH_WSTB = '1' and TABLE_FRAMES /= x"0000"
+    else table_frames_reg;
 
 --------------------------------------------------------------------------
 -- Table configuration starts with applying are reset with a write to
@@ -169,7 +173,7 @@ seq_raddr <= (others => '0') when reset_raddr_i = '1' or TABLE_START = '1' else
 FRAME_CTRL : process(clk_i)
 begin
     if rising_edge(clk_i) then
-        if (seq_raddr = unsigned(table_frames_reg) - 1) then
+        if (seq_raddr = unsigned(table_frames_now) - 1) then
             seq_raddr_next <= (others => '0');
             last_o <= '1';
         else

--- a/modules/seq/seq.timing.ini
+++ b/modules/seq/seq.timing.ini
@@ -343,22 +343,22 @@ scope: seq.block.ini
 13  : ENABLE=1          -> STATE=3, ACTIVE=1, TABLE_REPEAT=1, OUTA=1, TABLE_LINE=1, LINE_REPEAT=1
 18  :                   -> STATE=4, OUTA=0
 23  :                   -> STATE=3, OUTA=1, TABLE_REPEAT=2
-25  : TABLE_START=1     -> STATE=0, OUTA=0, TABLE_REPEAT=0, LINE_REPEAT=0, TABLE_LINE=0, HEALTH=2, ACTIVE=0
+25  : TABLE_START=1
 26  : TABLE_START=0
 
 # OUT = 0x1 (OUT1=A)
 # TRIGGER = 0x0 (Immediate)
 # REPEATS = 0x0001
 27  : TABLE_DATA=0x100001
-28  : TABLE_DATA=0
+28  : TABLE_DATA=0     -> STATE=4, OUTA=0, TABLE_REPEAT=2
 29  : TABLE_DATA=8
 30  : TABLE_DATA=2
 31  : TABLE_LENGTH=4
-32  : ENABLE=0          -> STATE=1
-33  : ENABLE=1          -> STATE=3, TABLE_LINE=1, LINE_REPEAT=1, TABLE_REPEAT=1, OUTA=1, HEALTH=0, ACTIVE=1
-41  :                   -> STATE=4, OUTA=0
-43  :                   -> STATE=3, TABLE_REPEAT=2, OUTA=1
-46  : ENABLE=0          -> STATE=1, ACTIVE=0, OUTA=0
+32  :                  -> STATE=3, OUTA=1, TABLE_REPEAT=1
+40  :                  -> STATE=4, OUTA=0
+42  :                  -> STATE=3, OUTA=1, TABLE_REPEAT=2
+43  : ENABLE=0         -> STATE=1, OUTA=0, ACTIVE=0
+
 
 [Rewriting table whilst in wait for position trigger]
 3   : TABLE_START=1
@@ -391,7 +391,7 @@ scope: seq.block.ini
 25  : ENABLE=1          -> STATE=3, ACTIVE=1, TABLE_REPEAT=1, OUTA=1, LINE_REPEAT=1, TABLE_LINE=1
 28  :                   -> STATE=4, OUTA=0
 31  :                   -> STATE=2, TABLE_LINE=2
-34  : TABLE_START=1     -> STATE=0, OUTA=0, TABLE_REPEAT=0, LINE_REPEAT=0, TABLE_LINE=0, ACTIVE=0, HEALTH=2
+34  : TABLE_START=1
 37  : TABLE_START=0
 # OUT = 0x8 (OUT1=D)
 # TRIGGER = 0x0 (Immediate)
@@ -411,25 +411,24 @@ scope: seq.block.ini
 59  : TABLE_DATA=1
 
 65  : TABLE_LENGTH=8
-66  : ENABLE=0          -> STATE=1
-67  : ENABLE=1          -> STATE=3, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1, ACTIVE=1, HEALTH=0
-70  :                   -> OUTD=0, STATE=4
-76  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-79  :                   -> OUTC=0, STATE=4
-82  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-85  :                   -> OUTC=0, STATE=4
-88  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-91  :                   -> OUTC=0, STATE=4
-94  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
-97  :                   -> OUTD=0, STATE=4
-103 :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-106 :                   -> OUTC=0, STATE=4
-109 :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-112 :                   -> OUTC=0, STATE=4
-115 :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-118 :                   -> OUTC=0, STATE=4
-121 :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
-124 : ENABLE=0          -> STATE=1, ACTIVE=0, OUTD=0
+66  :                   -> STATE=3, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1
+69  :                   -> OUTD=0, STATE=4
+75  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+78  :                   -> OUTC=0, STATE=4
+81  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+84  :                   -> OUTC=0, STATE=4
+87  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+90  :                   -> OUTC=0, STATE=4
+93  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
+96  :                   -> OUTD=0, STATE=4
+102 :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+105 :                   -> OUTC=0, STATE=4
+108 :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+111 :                   -> OUTC=0, STATE=4
+114 :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+117 :                   -> OUTC=0, STATE=4
+120 :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
+123 : ENABLE=0          -> STATE=1, ACTIVE=0, OUTD=0
 
 [Time set to 1 clock pulse]
 3   : TABLE_START=1
@@ -462,7 +461,7 @@ scope: seq.block.ini
 25  : ENABLE=1          -> STATE=3, ACTIVE=1, TABLE_REPEAT=1, OUTA=1, LINE_REPEAT=1, TABLE_LINE=1
 26  :                   -> STATE=4, OUTA=0
 27  :                   -> STATE=2, TABLE_LINE=2
-36  : TABLE_START=1     -> STATE=0, OUTA=0, TABLE_REPEAT=0, LINE_REPEAT=0, TABLE_LINE=0, ACTIVE=0, HEALTH=2
+36  : TABLE_START=1
 37  : TABLE_START=0
 # OUT = 0x8 (OUT1=D)
 # TRIGGER = 0x0 (Immediate)
@@ -482,25 +481,25 @@ scope: seq.block.ini
 59  : TABLE_DATA=1
 
 65  : TABLE_LENGTH=8
-66  : ENABLE=0          -> STATE=1
-67  : ENABLE=1          -> STATE=3, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1, HEALTH=0, ACTIVE=1
-68  :                   -> OUTD=0, STATE=4
-70  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-71  :                   -> OUTC=0, STATE=4
-72  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-73  :                   -> OUTC=0, STATE=4
-74  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-75  :                   -> OUTC=0, STATE=4
-76  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
-77  :                   -> OUTD=0, STATE=4
-79  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-80  :                   -> OUTC=0, STATE=4
-81  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-82  :                   -> OUTC=0, STATE=4
-83  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-84  :                   -> OUTC=0, STATE=4
-85  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
-86 : ENABLE=0           -> STATE=1, ACTIVE=0, OUTD=0
+66  :                   -> STATE=3, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1, HEALTH=0, ACTIVE=1
+67  :                   -> OUTD=0, STATE=4
+69  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+70  :                   -> OUTC=0, STATE=4
+71  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+72  :                   -> OUTC=0, STATE=4
+73  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+74  :                   -> OUTC=0, STATE=4
+75  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
+76  :                   -> OUTD=0, STATE=4
+78  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+79  :                   -> OUTC=0, STATE=4
+80  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+81  :                   -> OUTC=0, STATE=4
+82  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+83  :                   -> OUTC=0, STATE=4
+84  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
+85  : ENABLE=0           -> STATE=1, ACTIVE=0, OUTD=0
+
 
 [Prescale set to 1, time1 and time2 > 1]
 3   : TABLE_START=1
@@ -533,7 +532,7 @@ scope: seq.block.ini
 25  : ENABLE=1          -> STATE=3, ACTIVE=1, TABLE_REPEAT=1, OUTA=1, LINE_REPEAT=1, TABLE_LINE=1
 27  :                   -> STATE=4, OUTA=0
 30  :                   -> STATE=2, TABLE_LINE=2
-36  : TABLE_START=1     -> STATE=0, OUTA=0, TABLE_REPEAT=0, LINE_REPEAT=0, TABLE_LINE=0, ACTIVE=0, HEALTH=2
+36  : TABLE_START=1
 37  : TABLE_START=0
 # OUT = 0x8 (OUT1=D)
 # TRIGGER = 0x0 (Immediate)
@@ -553,25 +552,24 @@ scope: seq.block.ini
 59  : TABLE_DATA=4
 
 65  : TABLE_LENGTH=8
-66  : ENABLE=0          -> STATE=1
-67  : ENABLE=1          -> STATE=3, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1, HEALTH=0, ACTIVE=1
-70  :                   -> OUTD=0, STATE=4
-72  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-76  :                   -> OUTC=0, STATE=4
-80  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-84  :                   -> OUTC=0, STATE=4
-88  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-92  :                   -> OUTC=0, STATE=4
-96  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
-99  :                   -> OUTD=0, STATE=4
-101 :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-105 :                   -> OUTC=0, STATE=4
-109 :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-113 :                   -> OUTC=0, STATE=4
-117 :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-121 :                   -> OUTC=0, STATE=4
-125 :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
-126 : ENABLE=0          -> STATE=1, ACTIVE=0, OUTD=0
+66  : ENABLE=1          -> STATE=3, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1, HEALTH=0, ACTIVE=1
+69  :                   -> OUTD=0, STATE=4
+71  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+75  :                   -> OUTC=0, STATE=4
+79  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+83  :                   -> OUTC=0, STATE=4
+87  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+91  :                   -> OUTC=0, STATE=4
+95  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
+98  :                   -> OUTD=0, STATE=4
+100 :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+104 :                   -> OUTC=0, STATE=4
+108 :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+112 :                   -> OUTC=0, STATE=4
+116 :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+120 :                   -> OUTC=0, STATE=4
+124 :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
+125 : ENABLE=0          -> STATE=1, ACTIVE=0, OUTD=0
 
 [Time2 set to 0]
 3   : TABLE_START=1
@@ -604,7 +602,7 @@ scope: seq.block.ini
 25  : ENABLE=1          -> STATE=3, ACTIVE=1, TABLE_REPEAT=1, LINE_REPEAT=1, TABLE_LINE=1, OUTA=1
 26  :                   -> OUTA=0, STATE=4
 27  :                   -> STATE=2, TABLE_LINE=2
-36  : TABLE_START=1     -> STATE=0, OUTA=0, TABLE_REPEAT=0, LINE_REPEAT=0, TABLE_LINE=0, ACTIVE=0, HEALTH=2
+36  : TABLE_START=1
 37  : TABLE_START=0
 # OUT = 0x8 (OUT1=D)
 # TRIGGER = 0x0 (Immediate)
@@ -624,25 +622,24 @@ scope: seq.block.ini
 59  : TABLE_DATA=0
 
 65  : TABLE_LENGTH=8
-66  : ENABLE=0          -> STATE=1
-67  : ENABLE=1          -> STATE=3, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1, ACTIVE=1, HEALTH=0
-68  :                   -> OUTD=0, STATE=4
-70  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-71  :                   -> OUTC=0, STATE=4
-72  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-73  :                   -> OUTC=0, STATE=4
-74  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-75  :                   -> OUTC=0, STATE=4
-76  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
-77  :                   -> OUTD=0, STATE=4
-79  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-80  :                   -> OUTC=0, STATE=4
-81  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-82  :                   -> OUTC=0, STATE=4
-83  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-84  :                   -> OUTC=0, STATE=4
-85  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
-86 : ENABLE=0           -> STATE=1, ACTIVE=0, OUTD=0
+66  :                   -> STATE=3, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1, ACTIVE=1, HEALTH=0
+67  :                   -> OUTD=0, STATE=4
+69  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+70  :                   -> OUTC=0, STATE=4
+71  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+72  :                   -> OUTC=0, STATE=4
+73  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+74  :                   -> OUTC=0, STATE=4
+75  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
+76  :                   -> OUTD=0, STATE=4
+78  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+79  :                   -> OUTC=0, STATE=4
+80  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+81  :                   -> OUTC=0, STATE=4
+82  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+83  :                   -> OUTC=0, STATE=4
+84  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
+85 : ENABLE=0           -> STATE=1, ACTIVE=0, OUTD=0
 
 [Time1 and Time2 set to 0]
 3   : TABLE_START=1
@@ -676,7 +673,7 @@ scope: seq.block.ini
 26  :                   -> STATE=4, OUTA=0, OUTB=1
 27  :                   -> TABLE_LINE=2, OUTA=1, OUTB=0
 28  :                   -> STATE=2, TABLE_LINE=3
-36  : TABLE_START=1     -> STATE=0, OUTA=0, TABLE_REPEAT=0, LINE_REPEAT=0, TABLE_LINE=0, ACTIVE=0, HEALTH=2
+36  : TABLE_START=1
 37  : TABLE_START=0
 # OUT = 0x8 (OUT1=D)
 # TRIGGER = 0x0 (Immediate)
@@ -696,25 +693,24 @@ scope: seq.block.ini
 59  : TABLE_DATA=0
 
 65  : TABLE_LENGTH=8
-66  : ENABLE=0          -> STATE=1
-67  : ENABLE=1          -> STATE=3, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1, ACTIVE=1, HEALTH=0
-68  :                   -> OUTD=0, STATE=4
-70  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-71  :                   -> OUTC=0, STATE=4
-72  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-73  :                   -> OUTC=0, STATE=4
-74  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-75  :                   -> OUTC=0, STATE=4
-76  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
-77  :                   -> OUTD=0, STATE=4
-79  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-80  :                   -> OUTC=0, STATE=4
-81  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-82  :                   -> OUTC=0, STATE=4
-83  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-84  :                   -> OUTC=0, STATE=4
-85  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
-86 : ENABLE=0           -> STATE=1, ACTIVE=0, OUTD=0
+66  :                   -> STATE=3, OUTA=0, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1, ACTIVE=1, HEALTH=0
+67  :                   -> OUTD=0, STATE=4
+69  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+70  :                   -> OUTC=0, STATE=4
+71  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+72  :                   -> OUTC=0, STATE=4
+73  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+74  :                   -> OUTC=0, STATE=4
+75  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
+76  :                   -> OUTD=0, STATE=4
+78  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+79  :                   -> OUTC=0, STATE=4
+80  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+81  :                   -> OUTC=0, STATE=4
+82  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+83  :                   -> OUTC=0, STATE=4
+84  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
+85 : ENABLE=0           -> STATE=1, ACTIVE=0, OUTD=0
 
 [Time1 set to 0]
 3   : TABLE_START=1
@@ -746,7 +742,7 @@ scope: seq.block.ini
 18  :                   -> STATE=1
 25  : ENABLE=1          -> STATE=4, ACTIVE=1, TABLE_REPEAT=1, LINE_REPEAT=1, TABLE_LINE=1, OUTB=1
 28  :                   -> STATE=2, TABLE_LINE=2, OUTB=1
-36  : TABLE_START=1     -> STATE=0, OUTA=0, OUTB=0, TABLE_REPEAT=0, LINE_REPEAT=0, TABLE_LINE=0, ACTIVE=0, HEALTH=2
+36  : TABLE_START=1
 37  : TABLE_START=0
 # OUT = 0x8 (OUT1=D)
 # TRIGGER = 0x0 (Immediate)
@@ -766,27 +762,24 @@ scope: seq.block.ini
 59  : TABLE_DATA=4
 
 65  : TABLE_LENGTH=8
-66  : ENABLE=0          -> STATE=1
-67  : ENABLE=1          -> STATE=3, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1, ACTIVE=1, HEALTH=0
-70  :                   -> OUTD=0, STATE=4
-72  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-76  :                   -> OUTC=0, STATE=4
-80  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-84  :                   -> OUTC=0, STATE=4
-88  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-92  :                   -> OUTC=0, STATE=4
-96  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
-99  :                   -> OUTD=0, STATE=4
-101 :                   -> OUTC=1, STATE=3, TABLE_LINE=2
-105 :                   -> OUTC=0, STATE=4
-109 :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
-113 :                   -> OUTC=0, STATE=4
-117 :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
-121 :                   -> OUTC=0, STATE=4
-125 :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
-126 : ENABLE=0          -> STATE=1, ACTIVE=0, OUTD=0
-
-
+66  :                   -> STATE=3, OUTB=0, TABLE_REPEAT=1, OUTD=1, TABLE_LINE=1, LINE_REPEAT=1, ACTIVE=1, HEALTH=0
+69  :                   -> OUTD=0, STATE=4
+71  :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+75  :                   -> OUTC=0, STATE=4
+79  :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+83  :                   -> OUTC=0, STATE=4
+87  :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+91  :                   -> OUTC=0, STATE=4
+95  :                   -> OUTD=1, STATE=3, TABLE_REPEAT=2, LINE_REPEAT=1, TABLE_LINE=1
+98  :                   -> OUTD=0, STATE=4
+100 :                   -> OUTC=1, STATE=3, TABLE_LINE=2
+104 :                   -> OUTC=0, STATE=4
+108 :                   -> OUTC=1, STATE=3, LINE_REPEAT=2
+112 :                   -> OUTC=0, STATE=4
+116 :                   -> OUTC=1, STATE=3, LINE_REPEAT=3
+120 :                   -> OUTC=0, STATE=4
+124 :                   -> OUTD=1, STATE=3, TABLE_REPEAT=3, LINE_REPEAT=1, TABLE_LINE=1
+125 : ENABLE=0          -> STATE=1, ACTIVE=0, OUTD=0
 
 [Test case for issue #38]
 1   : ENABLE=1
@@ -815,7 +808,6 @@ scope: seq.block.ini
 38  : TABLE_LENGTH=0
 41  : ENABLE=1
 43  : ENABLE=0
-
 
 [Test case for issue #41]
 4   : REPEATS=1

--- a/modules/seq/seq.timing.ini
+++ b/modules/seq/seq.timing.ini
@@ -857,3 +857,47 @@ scope: seq.block.ini
 36  :                   -> OUTC=0, OUTD=1, TABLE_LINE=4
 40  :                   -> OUTD=0, ACTIVE=0, STATE=1
 48  : ENABLE=0
+
+[Disabling doesn't mess a table loading]
+3   : TABLE_START=1
+4   : TABLE_START=0
+
+# OUT = 0x1 (OUT1=A)
+# TRIGGER = 0x0 (Immediate)
+# REPEATS = 0x0001
+5   : TABLE_DATA=0x100001
+6   : TABLE_DATA=0
+7   : TABLE_DATA=5
+8   : TABLE_DATA=5
+
+9   : TABLE_LENGTH=4
+10  :                   -> STATE=1
+13  : ENABLE=1          -> STATE=3, ACTIVE=1, TABLE_REPEAT=1, OUTA=1, TABLE_LINE=1, LINE_REPEAT=1
+18  :                   -> STATE=4, OUTA=0
+
+19  : TABLE_START=1
+20  : TABLE_START=0
+
+# OUT = 0x1 (OUT1=A)
+# TRIGGER = 0x0 (Immediate)
+# REPEATS = 0x0001
+21  : TABLE_DATA=0x100001
+22  : TABLE_DATA=0
+23  : TABLE_DATA=8     -> STATE=3, OUTA=1, TABLE_REPEAT=2
+24  : TABLE_DATA=2
+25  : ENABLE=0         -> STATE=1, OUTA=0, ACTIVE=0
+# OUT = 0x2 (OUT1=B)
+# TRIGGER = 0x0 (Immediate)
+# REPEATS = 0x0001
+26  : TABLE_DATA=0x200001 -> STATE=0
+27  : TABLE_DATA=0
+28  : TABLE_DATA=1
+29  : TABLE_DATA=1
+
+30  : TABLE_LENGTH=8
+31  :                  -> STATE=1
+32  : ENABLE=1         -> STATE=3, OUTA=1, ACTIVE=1, TABLE_REPEAT=1
+40  :                  -> STATE=4, OUTA=0
+42  :                  -> STATE=3, OUTB=1, TABLE_LINE=2
+43  :                  -> STATE=4, OUTB=0
+44  : ENABLE=0         -> STATE=1, ACTIVE=0


### PR DESCRIPTION
- A new table can be loaded while a table without continuation mark is running, data can be loaded concurrently and when the new table is fully written, the sequencer switches inmediately without stopping
- bug fix: disabling the sequencer while loading a table was messing the table status, a test for this was added
- Tests were adapted to the modifications