### PR TITLE
Sync protocol changes

### DIFF
--- a/modules/sfp_panda_sync/hdl/sfp_panda_sync_mgt_interface.vhd
+++ b/modules/sfp_panda_sync/hdl/sfp_panda_sync_mgt_interface.vhd
@@ -12,7 +12,7 @@ entity sfp_panda_sync_mgt_interface is
 
     port (GTREFCLK          : in  std_logic;
           SYNC_RESET_i      : in  std_logic;
-          sysclk_i             : in  std_logic;
+          sysclk_i          : in  std_logic;
           rxoutclk_i        : in  std_logic;
           txoutclk_i        : in  std_logic;
           rxp_i             : in  std_logic;

--- a/modules/sfp_panda_sync/hdl/sfp_panda_sync_mgt_interface.vhd
+++ b/modules/sfp_panda_sync/hdl/sfp_panda_sync_mgt_interface.vhd
@@ -31,7 +31,8 @@ entity sfp_panda_sync_mgt_interface is
           txoutclk_o        : out std_logic;    
           txdata_i          : in  std_logic_vector(31 downto 0); 
           txcharisk_i       : in  std_logic_vector(3 downto 0);
-          cpll_lock_o       : out std_logic
+          cpll_lock_o       : out std_logic;
+          rx_link_ok_i      : in  std_logic
           );
 
 end sfp_panda_sync_mgt_interface;
@@ -261,7 +262,7 @@ sfp_panda_sync_i : sfp_panda_sync
         DONT_RESET_ON_DATA_ERROR_IN     => '0',
         GT0_TX_FSM_RESET_DONE_OUT       => GT0_TX_FSM_RESET_DONE_OUT,
         GT0_RX_FSM_RESET_DONE_OUT       => GT0_RX_FSM_RESET_DONE_OUT,
-        GT0_DATA_VALID_IN               => '1', -- The data valid has to be high for the receiver to come out of it reset startup 
+        GT0_DATA_VALID_IN               => rx_link_ok_i, -- The data valid has to be high for the receiver to come out of it reset startup 
         --_________________________________________________________________________
         --GT0  (X0Y1)
         --____________________________CHANNEL PORTS________________________________

--- a/modules/sfp_panda_sync/hdl/sfp_panda_sync_receiver.vhd
+++ b/modules/sfp_panda_sync/hdl/sfp_panda_sync_receiver.vhd
@@ -98,8 +98,8 @@ signal deprecated_protocol            : std_logic;
 signal protocol_error                 : std_logic;
 signal deprecated_protocol_prev       : std_logic;
 signal protocol_error_prev            : std_logic;
-signal deprecated_protocol_tog        : std_logic;
-signal protocol_error_tog             : std_logic;
+signal deprecated_protocol_tog        : std_logic := '0';
+signal protocol_error_tog             : std_logic := '0';
 signal deprecated_protocol_sync       : std_logic;
 signal protocol_err_sync            : std_logic;
 signal deprecated_protocol_sync_prev  : std_logic;
@@ -108,7 +108,7 @@ signal deprecated_protocol_sys        : std_logic;
 signal protocol_err_sys             : std_logic;
 signal checkbyte_err                  : std_logic;
 signal checkbyte_err_prev             : std_logic;
-signal checkbyte_err_tog              : std_logic;
+signal checkbyte_err_tog              : std_logic := '0';
 signal checkbyte_err_sync             : std_logic;
 signal checkbyte_err_sync_prev        : std_logic;
 signal checkbyte_err_sys              : std_logic;
@@ -132,9 +132,6 @@ rx_link_sync : entity work.sync_bit
 -- This is a modified version of the code used in the open source event receiver
 -- It is hard to know when the link is up as the only way of doing this is to use
 -- rxnotintable and rxdisperr signals.
--- rxnotintable and rxdisperr errors do occur when the link is up, I run the the event
--- receiver for four days counting the number of times these two errors happened the
--- error rate was days 4 error count 12272
 ps_link_lost:process(rxoutclk_i)
 begin
   if rising_edge(rxoutclk_i) then

--- a/modules/sfp_panda_sync/hdl/sfp_panda_sync_receiver.vhd
+++ b/modules/sfp_panda_sync/hdl/sfp_panda_sync_receiver.vhd
@@ -1,24 +1,26 @@
 library ieee;
-use ieee.numeric_std.all;
 use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.support.all;
 
 entity sfp_panda_sync_receiver is
-
-    port (clk_i             : in  std_logic;
+    port (sysclk_i          : in  std_logic;
           rxoutclk_i        : in  std_logic;   
-          reset_i           : in  std_logic;
           rxdisperr_i       : in  std_logic_vector(3 downto 0);
           rxcharisk_i       : in  std_logic_vector(3 downto 0);
           rxdata_i          : in  std_logic_vector(31 downto 0);
           rxnotintable_i    : in  std_logic_vector(3 downto 0);
+          check_bits_i      : in  std_logic_vector(31 downto 0);
           rx_link_ok_o      : out std_logic;
           loss_lock_o       : out std_logic;
           rx_error_o        : out std_logic;
-          BITIN_o           : out std_logic_vector(15 downto 0);   
+          BITIN_o           : out std_logic_vector(7 downto 0);   
           POSIN1_o          : out std_logic_vector(31 downto 0);
           POSIN2_o          : out std_logic_vector(31 downto 0);
           POSIN3_o          : out std_logic_vector(31 downto 0);
-          POSIN4_o          : out std_logic_vector(31 downto 0)
+          POSIN4_o          : out std_logic_vector(31 downto 0);
+          health_o          : out std_logic_vector(31 downto 0)
           );
 
 end sfp_panda_sync_receiver;
@@ -26,78 +28,103 @@ end sfp_panda_sync_receiver;
 
 architecture rtl of sfp_panda_sync_receiver is
 
--- component ila_0
--- 
---     port (
---           clk     : std_logic;
---           probe0  : std_logic_vector(31 downto 0);
---           probe1  : std_logic_vector(31 downto 0);
---           probe2  : std_logic_vector(31 downto 0);
---           probe3  : std_logic_vector(31 downto 0);
---           probe4  : std_logic_vector(31 downto 0);
---           probe5  : std_logic_vector(31 downto 0);
---           probe6  : std_logic_vector(5 downto 0);
---           probe7  : std_logic_vector(31 downto 0)
--- );
--- 
--- end component;
+-- Timing diagram below assumes both clocks have same frequency and phase.
+-- In reality phase of clocks is arbitrary, and POS data will be 
+-- latched up to one cycle earlier or later wrt TX_DATA
+       
+--    _   _   _   _   _   _   _
+--  _| |_| |_| |_| |_| |_| |_| |_       CLOCK
+--
+--     1   2   3   4   5   6            SEQUENCE 
+--  _ ___ ___ ___ ___ ___ ___ _
+--  _X___X___X___X___X___X___X_         RX_DATA
+--    ___                     _
+-- __|   |___________________|          RXCHARISK
+--        ___
+-- ______|   |_________________         K_SYNC1
+--            ___
+-- __________|   |_____________         K_SYNC2
+--
+-- __________________ _________
+-- __________________X_________         POSIN1
+--
+-- ______________________ _____
+-- ______________________X_____         POSIN2
+--
+-- ______ _____________________
+-- ______X_____________________         POSIN3
+--
+-- __________ _________________
+-- __________X_________________         POSIN4
 
-
-type t_STATE_DATA is (STATE_BITS_START_ALIGN, STATE_POSOUT13, STATE_POSOUT24);
-
-type t_rxdata_bitpos is array(0 to 4) of std_logic_vector(31 downto 0);
---type t_rxdata_bit is array(0 to 1) of std_logic_vector(15 downto 0); 
-
-constant c_kchar_byte_en    : std_logic_vector(3 downto 0) := "0001";
 constant c_zeros            : std_logic_vector(3 downto 0) := "0000";
--- Packet start 
+-- Packet start (deprecated)
 constant c_k28_0            : std_logic_vector(7 downto 0) := x"1C";
 -- Word alignment
 constant c_k28_5            : std_logic_vector(7 downto 0) := x"BC";
 constant c_MGT_RX_PRESCALE  : unsigned(9 downto 0) := to_unsigned(1023,10);
 
+subtype t_RX_STATE is INTEGER range 1 to 6;
 
-signal STATE_DATA            : t_STATE_DATA;   
-signal rxdata_bitpos         : t_rxdata_bitpos := (others => (others => '0'));   
-signal rx_error              : std_logic;
-signal loss_lock             : std_logic;
-signal rx_link_ok            : std_logic := '0';
-signal rx_error_count        : unsigned(5 downto 0);
-signal prescaler             : unsigned(9 downto 0) := (others => '0');
-signal disable_link          : std_logic := '1';
-signal BITIN                 : std_logic_vector(15 downto 0);
-signal POSIN1                : std_logic_vector(31 downto 0);
-signal POSIN2                : std_logic_vector(31 downto 0);
-signal POSIN3                : std_logic_vector(31 downto 0);   
-signal POSIN4                : std_logic_vector(31 downto 0);   
-signal startpkt              : std_logic;
-signal start_nalignment      : std_logic;   
--- Metastable signals
-signal rx_link_ok_meta1      : std_logic;
-signal rx_link_ok_meta2      : std_logic; 
-signal pktstart              : std_logic;
-signal pktstart_xored        : std_logic;
-signal pktstart_xored_pos12  : std_logic;
-signal pktstart_xored_pos34  : std_logic; 
-signal pktstart_meta1        : std_logic;
-signal pktstart_meta2        : std_logic;  
-signal pktstart_dly          : std_logic;
+subtype std8_t is std_logic_vector(7 downto 0);
+type std8_array is array(natural range <>) of std8_t;
 
-attribute ASYNC_REG : string;
-attribute ASYNC_REG of pktstart_meta1   : signal is "TRUE";
-attribute ASYNC_REG of pktstart_meta2   : signal is "TRUE";
-attribute ASYNC_REG of pktstart_dly     : signal is "TRUE";   
-attribute ASYNC_REG of rx_link_ok_meta1 : signal is "TRUE";
-attribute ASYNC_REG of rx_link_ok_meta2 : signal is "TRUE"; 
+signal RX_STATE : t_RX_STATE := 1;
 
-signal probe1                : std_logic_vector(31 downto 0);
+signal rx_error         : std_logic;
+signal loss_lock        : std_logic;
+signal rx_link_ok       : std_logic := '0';
+signal rx_link_ok_sys   : std_logic := '0';
+signal rx_error_count   : unsigned(5 downto 0);
+signal prescaler        : unsigned(9 downto 0) := (others => '0');
+signal disable_link     : std_logic := '1';
+signal POSIN1_l         : std_logic_vector(POSIN1_o'range);
+signal POSIN2_l         : std_logic_vector(POSIN2_o'range);
+signal POSIN3_l         : std_logic_vector(POSIN3_o'range);
+signal POSIN4_l         : std_logic_vector(POSIN4_o'range);
+signal ksync            : std_logic;
+signal ksync_del        : std_logic; 
+signal rxcharisk_tog    : std_logic := '0';
+signal BITIN_l          : std8_array(0 to 5);
+signal seq_num          : unsigned(7 downto 0) := (others => '0');
+signal check_byte       : std_logic_vector(7 downto 0);
+signal check_byte_prev  : unsigned(7 downto 0);
+
+-- signals required for error checking
+signal deprecated_protocol            : std_logic;
+signal protocol_error                 : std_logic;
+signal deprecated_protocol_prev       : std_logic;
+signal protocol_error_prev            : std_logic;
+signal deprecated_protocol_tog        : std_logic;
+signal protocol_error_tog             : std_logic;
+signal deprecated_protocol_sync       : std_logic;
+signal protocol_err_sync            : std_logic;
+signal deprecated_protocol_sync_prev  : std_logic;
+signal protocol_err_sync_prev       : std_logic;
+signal deprecated_protocol_sys        : std_logic;
+signal protocol_err_sys             : std_logic;
+signal checkbyte_err                  : std_logic;
+signal checkbyte_err_prev             : std_logic;
+signal checkbyte_err_tog              : std_logic;
+signal checkbyte_err_sync             : std_logic;
+signal checkbyte_err_sync_prev        : std_logic;
+signal checkbyte_err_sys              : std_logic;
 
 begin
 
+-- Assign outputs
+
 loss_lock_o <= loss_lock;
 rx_error_o <= rx_error;
-rx_link_ok_o <= rx_link_ok;
+rx_link_ok_o <= rx_link_ok_sys;
 
+-- Synchronise rx_link_ok onto sysclk domain
+rx_link_sync : entity work.sync_bit
+    port map(
+     clk_i => sysclk_i,
+     bit_i => rx_link_ok,
+     bit_o => rx_link_ok_sys
+);
 
 -- This is a modified version of the code used in the open source event receiver
 -- It is hard to know when the link is up as the only way of doing this is to use
@@ -107,233 +134,246 @@ rx_link_ok_o <= rx_link_ok;
 -- error rate was days 4 error count 12272
 ps_link_lost:process(rxoutclk_i)
 begin
-    if rising_edge(rxoutclk_i) then
-        if reset_i = '1' then
-            prescaler <= (others => '0');
+  if rising_edge(rxoutclk_i) then
+    -- Check the status of the link every 1023 clocks
+    if prescaler = 0 then
+        -- 0.008441037ms
+        -- The link has gone down or is up
+        if disable_link = '0' then
+            rx_link_ok <= '1';
+        else
+            rx_link_ok <= '0';
+        end if;
+
+        if disable_link = '1' then
+            disable_link <= '0';
+        end if;
+
+    end if;
+
+    -- Check the link status loss_lock if
+    -- not set then set the signal disable_link
+    if disable_link = '0' then
+        if loss_lock = '1' then
             disable_link <= '1';
-        else
-            -- Check the status of the link every 1023 clocks
-            if prescaler = 0 then
-                -- 0.008441037ms
-                -- The link has gone down or is up
-                if disable_link = '0' then
-                    rx_link_ok <= '1';
-                else
-                    rx_link_ok <= '0';
-                end if;
-
-                if disable_link = '1' then
-                    disable_link <= '0';
-                end if;
-
-            end if;
-
-            -- Check the link status loss_lock if
-            -- not set then set the signal disable_link
-            if disable_link = '0' then
-                if loss_lock = '1' then
-                    disable_link <= '1';
-                end if;
-            end if;
-            -- Link is down
-            if rx_link_ok = '0' then
-                loss_lock <= rx_error;
-            else
-                loss_lock <= rx_error_count(5);
-            end if;
-            -- Error has occured
-            -- Check the link for errors
-            if rx_link_ok = '1' then
-                if rx_error = '1' then
-                    -- Subtract one from error count (count down error count)
-                    if rx_error_count(5) = '0' then
-                        rx_error_count <= rx_error_count -1;
-                    end if;
-                else
-                    -- Add one to the error count to handle occasional errors happening
-                    if prescaler = 0 and (rx_error_count(5) = '1' or rx_error_count(4) = '0') then
-                        rx_error_count <= rx_error_count +1;
-                    end if;
-                end if;
-            -- Link up set the count down error count to 31
-            else
-                rx_error_count <= "011111";
-            end if;
-            -- RXNOTINTABLE :- The received data value is not a valid 10b/8b value
-            -- RXDISPERR    :- Indicates data corruption or tranmission of a invalid control character
-            if (rxnotintable_i /= c_zeros or rxdisperr_i /= c_zeros) then
-                rx_error <= '1';
-            else
-                rx_error <= '0';
-            end if;
-            -- 1023 clock count up
-            if prescaler = c_MGT_RX_PRESCALE -1 then
-                prescaler <= (others => '0');
-            else
-                prescaler <= prescaler +1;
-            end if;
         end if;
     end if;
+    -- Link is down
+    if rx_link_ok = '0' then
+        loss_lock <= rx_error;
+    else
+        loss_lock <= rx_error_count(5);
+    end if;
+    -- Error has occured
+    -- Check the link for errors
+    if rx_link_ok = '1' then
+        if rx_error = '1' then
+            -- Subtract one from error count (count down error count)
+            if rx_error_count(5) = '0' then
+                rx_error_count <= rx_error_count -1;
+            end if;
+        else
+            -- Add one to the error count to handle occasional errors happening
+            if prescaler = 0 and (rx_error_count(5) = '1' or rx_error_count(4) = '0') then
+                rx_error_count <= rx_error_count +1;
+            end if;
+        end if;
+    -- Link up set the count down error count to 31
+    else
+        rx_error_count <= "011111";
+    end if;
+    -- RXNOTINTABLE :- The received data value is not a valid 10b/8b value
+    -- RXDISPERR    :- Indicates data corruption or tranmission of a invalid control character
+    if (rxnotintable_i /= c_zeros or rxdisperr_i /= c_zeros) then
+        rx_error <= '1';
+    else
+        rx_error <= '0';
+    end if;
+    -- 1023 clock count up
+    if prescaler = c_MGT_RX_PRESCALE -1 then
+        prescaler <= (others => '0');
+    else
+        prescaler <= prescaler +1;
+    end if;
+  end if;
 end process ps_link_lost;
-
-
--- probe1(3 downto 0) <= rxdisperr_i;
--- probe1(7 downto 4) <= rxnotintable_i;
--- probe1(8) <= rx_link_ok;
--- probe1(9) <= rx_error;
--- probe1(10) <= loss_lock; 
--- probe1(31 downto 11) <= (others => '0');
--- 
--- -- Chipscope
--- ila_rx_inst : ila_0
--- port map (
---       clk     => rxoutclk_i,
---       probe0  => rxdata_i,
---       probe1  => probe1,
---       probe2  => rxdata_bitpos(0),
---       probe3  => rxdata_bitpos(1),
---       probe4  => rxdata_bitpos(2),
---       probe5  => rxdata_bitpos(3),
---       probe6  => (others => '0'),
---       probe7  => rxdata_bitpos(4)
--- );
--- 
-
-
--- Received data          start_nalignment       pktstart 
--- BITIN1 and K28_0             x                   0         
--- POSIN1                       1                   0        
--- POSIN2                       1                   0        
--- BITIN3 and K28_5             x                   1        
--- POSIN3                       0                   1         
--- POSIN4                       0                   1         
--- BITIN1 and K28_o             x                   0      
--- POSIN1                       1                   0        
--- POSIN2                       1                   0        
-
--- Capture the data
-ps_data: process(rxoutclk_i)
+    
+rxdata_reader: process(rxoutclk_i)
+  -- this variable will synthesise as a register
+  variable RX_STATE : t_RX_STATE := 1;
 begin
-    if rising_edge(rxoutclk_i) then
-        if (rx_link_ok = '1') then
+  if rising_edge(rxoutclk_i) then
 
-            case STATE_DATA is
-            
-                -- Packet Start
-                when STATE_BITS_START_ALIGN => 
-                    -- Packet start 16 bits         
-                    -- K28 0 - Packet Start 
-                    -- K28 5 - Packet Alignment          
-                    if (rxcharisk_i = c_kchar_byte_en and rxdata_i(7 downto 0) = c_k28_0) then
-                        start_nalignment <= '1';
-                        rxdata_bitpos(0) <= rxdata_i;
-                        STATE_DATA <= STATE_POSOUT13;                    
-                    elsif                                         
-                       (rxcharisk_i = c_kchar_byte_en and rxdata_i(7 downto 0) = c_k28_5) then 
-                        start_nalignment <= '0';
-                        rxdata_bitpos(0) <= rxdata_i;
-                        STATE_DATA <= STATE_POSOUT13;
-                    end if;
-                    
-                -- POSOUT1 or POSOUT3   
-                when STATE_POSOUT13 =>
-                    if (start_nalignment = '1') then                     
-                        rxdata_bitpos(1) <= rxdata_i;
-                    else
-                        rxdata_bitpos(3) <= rxdata_i;
-                    end if;    
-                    STATE_DATA <= STATE_POSOUT24;
-                                    
-                -- POSOUT2 or POSOUT4
-                when STATE_POSOUT24 =>
-                    if (start_nalignment = '1') then 
-                        rxdata_bitpos(2) <= rxdata_i;
-                    else
-                        rxdata_bitpos(4) <= rxdata_i;
-                    end if;    
-                    pktstart <= not pktstart;                    
-                    STATE_DATA <= STATE_BITS_START_ALIGN;     
-                                     
-            end case;                         
-        else
-            pktstart <= '0';
-            STATE_DATA <= STATE_BITS_START_ALIGN;
-        end if;
+    -- RX sequencer
+    if rxcharisk_i = x"1" then
+      rxcharisk_tog <= not rxcharisk_tog;
+      case (rxdata_i(7 downto 0)) is 
+        when c_k28_5 => 
+          RX_STATE := 1;
+          deprecated_protocol <= '0';
+          protocol_error <= '0';
+        when c_k28_0 => 
+          deprecated_protocol <= '1';
+          protocol_error <= '0';
+        when others  =>
+          deprecated_protocol <= '0'; 
+          protocol_error <= '1';
+      end case;
+    elsif RX_STATE = 6 then
+      -- this statement should never be reached
+      protocol_error <= '1'; 
+      deprecated_protocol <= '0';
+    else
+      RX_STATE := RX_STATE + 1;
     end if;
-end process ps_data;    
-    
 
+    BITIN_l(RX_STATE-1) <= rxdata_i(31 downto 24);
 
-BITIN_o  <= BITIN;
-POSIN1_o <= POSIN1;
-POSIN2_o <= POSIN2;
-POSIN3_o <= POSIN3;
-POSIN4_o <= POSIN4; 
+    case (RX_STATE) is
+      when 1 =>
+        POSIN1_l(31 downto 16) <= rxdata_i(23 downto  8);
+      when 2 =>
+        POSIN1_l(15 downto  0) <= rxdata_i(23 downto  8);
+        POSIN2_l(31 downto 24) <= rxdata_i(7  downto  0);
+      when 3 =>
+        POSIN2_l(23 downto  0) <= rxdata_i(23 downto  0);
+      when 4 => 
+        POSIN3_l(31 downto  8) <= rxdata_i(23 downto  0);
+      when 5 =>
+        POSIN3_l(7  downto  0) <= rxdata_i(23 downto 16);
+        POSIN4_l(31 downto 16) <= rxdata_i(15 downto  0);
+      when 6 =>
+        POSIN4_l(15 downto  0) <= rxdata_i(23 downto  8);
+        check_byte             <= rxdata_i(7  downto  0);
+        check_byte_prev        <= unsigned(check_byte);
+    end case;
 
+    -- Do some error checking on the check-byte
+    if to_integer(unsigned(check_bits_i)) = 1 and check_byte /= std_logic_vector(check_byte_prev + 1) then
+      checkbyte_err <= '1';
+    elsif to_integer(unsigned(check_bits_i)) = 0 and check_byte /= x"00" then
+      checkbyte_err <= '1';
+    else
+      checkbyte_err <= '0';
+    end if;
 
+    -- Capture the rising egde of the error flags
+    deprecated_protocol_prev <= deprecated_protocol;
+    if deprecated_protocol = '1' and deprecated_protocol_prev = '0' then
+      deprecated_protocol_tog <= not deprecated_protocol_tog;
+    end if;
 
--- BITIN(start packet k character), POSIN1, BITIN, POSIN2, BITIN, POSIN3, BITIN(alignment k character), POSIN4
+    protocol_error_prev <= protocol_error;
+    if protocol_error = '1' and protocol_error_prev = '0' then
+      protocol_error_tog <= not protocol_error_tog;
+    end if;
 
--- BITIN                           1   0   0   0   0   
--- POSIN1                          0   1   0   0   0                         
--- POSIN2                          0   0   1   0   0    
--- BITIN                           1   0   0   0   0            
--- POSOUT3                         0   0   0   1   0   
--- POSOUT4                         0   0   0   0   1     
+    checkbyte_err_prev <= checkbyte_err;
+    if checkbyte_err = '1' and checkbyte_err_prev = '0' then
+       checkbyte_err_tog <= not checkbyte_err_tog;
+    end if;
 
+  end if;
+end process;
 
---pktstart_xored <= pktstart_dly xor pktstart_meta2;
+-- Synchronise kchar edge onto sysclk domain
+ksyncer: entity work.sync_bit
+port map(
+    clk_i => sysclk_i,
+    bit_i => rxcharisk_tog,
+    bit_o => ksync
+);
 
-
-ps_meta_data: process(clk_i)
+-- Read the POS and BIT signals on the sysclk domain
+read_latched_vals: process(sysclk_i)
+  -- this variable will synthesise as a shift register
+  variable ksync_sr   : std_logic_vector(5 downto 0);
 begin
-    if rising_edge(clk_i) then
-        rx_link_ok_meta1 <= rx_link_ok;
-        rx_link_ok_meta2 <= rx_link_ok_meta1;    
-        -- The receuver is up and running 
-        pktstart_meta1 <= pktstart;    
-        pktstart_meta2 <= pktstart_meta1;
-        pktstart_dly <= pktstart_meta2;
-        pktstart_xored <= pktstart_dly xor pktstart_meta2;
-        pktstart_xored_pos12 <= pktstart_xored;
-        pktstart_xored_pos34 <= pktstart_xored_pos12;
-        -- Link up 
-        if (rx_link_ok_meta2 = '1') then
-            -- Pass out the BITIN 16 bits data
-            if pktstart_xored = '1' then
-                -- Need to know if POS1 and POS2 or POS3 and POS4 are ready
-                -- POS1 and POS2 
-                if pktstart_meta2 = '1' then
-                    startpkt <= '1';
-                -- POS3 and POS4
-                else
-                    startpkt <= '0';
-                end if;         
-                BITIN <= rxdata_bitpos(0)(31 downto 16);
-            end if;
-            -- Pass out the POSIN1
-            if pktstart_xored_pos12 = '1' and startpkt = '1' then    
-                POSIN1 <= rxdata_bitpos(1);
-            end if;
-            -- Pass out the POSIN2
-            if pktstart_xored_pos34 = '1' and startpkt = '1' then    
-                POSIN2 <= rxdata_bitpos(2);
-                
-            end if;    
-            -- Pass out the POSIN3
-            if pktstart_xored_pos12 = '1' and startpkt = '0' then                
-                POSIN3 <= rxdata_bitpos(3);
-            end if;
-            -- Pass out the POSIN4
-            if pktstart_xored_pos34 = '1' and startpkt = '0' then    
-                POSIN4 <= rxdata_bitpos(4);
-            end if;                        
-        else
-            startpkt <= '0';
-        end if;
-    end if;
-end process ps_meta_data;    
-    
-    
+  if rising_edge(sysclk_i) then
+    ksync_del <= ksync; 
+    ksync_sr := ksync_sr(4 downto 0) & (ksync xor ksync_del);
+    if (rx_link_ok_sys = '1') then
+      if ksync_sr(1) = '1' then
+        POSIN1_o <= POSIN1_l; 
+      end if;
+      if ksync_sr(2) = '1' then
+        POSIN2_o <= POSIN2_l; 
+      end if;
+      if ksync_sr(4) = '1' then
+        POSIN3_o <= POSIN3_l; 
+      end if;
+      if ksync_sr(5) = '1' then
+        POSIN4_o <= POSIN4_l; 
+      end if;
 
+      for i in 0 to 5 loop
+        if ksync_sr(i) = '1' then
+          BITIN_o <= BITIN_l(i);
+        end if;
+      end loop;
+    end if;
+  end if;
+end process;
+
+-- Latch errors on sysclk domain
+
+depr_prot_sync: entity work.sync_bit
+port map(
+    clk_i => sysclk_i,
+    bit_i => deprecated_protocol_tog,
+    bit_o => deprecated_protocol_sync
+);
+
+prot_err_sync: entity work.sync_bit
+port map(
+    clk_i => sysclk_i,
+    bit_i => protocol_error_tog,
+    bit_o => protocol_err_sync
+);
+
+chckbyte_sync: entity work.sync_bit
+port map(
+    clk_i => sysclk_i,
+    bit_i => checkbyte_err_tog,
+    bit_o => checkbyte_err_sync
+);
+
+health_sys: process(sysclk_i)
+begin
+  if rising_edge(sysclk_i) then
+    if rx_link_ok_sys = '0' then
+      deprecated_protocol_sys <= '0';
+      protocol_err_sys <= '0';
+      checkbyte_err_sys <= '0';
+    else
+      if (deprecated_protocol_sync xor deprecated_protocol_sync_prev) = '1' then
+        deprecated_protocol_sys <= '1';
+      end if;
+      if (protocol_err_sync xor protocol_err_sync_prev) = '1' then
+        protocol_err_sys <= '1';
+      end if;
+      if (checkbyte_err_sync xor checkbyte_err_sync_prev) = '1' then
+        checkbyte_err_sys <= '1';
+      end if;
+    end if;
+
+    deprecated_protocol_sync_prev <= deprecated_protocol_sync;
+    protocol_err_sync_prev <= protocol_err_sync;
+    checkbyte_err_sync_prev <= checkbyte_err_sync;
+
+    if rx_link_ok_sys = '0' then
+      health_o <= std_logic_vector(to_unsigned(1,32));
+    elsif deprecated_protocol_sys = '1' then
+      health_o <= std_logic_vector(to_unsigned(2,32));
+    elsif protocol_err_sys = '1' then
+      health_o <= std_logic_vector(to_unsigned(3,32));
+    elsif checkbyte_err_sys = '1' then
+      health_o <= std_logic_vector(to_unsigned(4,32));
+    else
+      health_o <= std_logic_vector(to_unsigned(0,32));
+    end if;
+  end if;
+end process;
+  
 end rtl;
+

--- a/modules/sfp_panda_sync/hdl/sfp_panda_sync_transmit.vhd
+++ b/modules/sfp_panda_sync/hdl/sfp_panda_sync_transmit.vhd
@@ -1,205 +1,148 @@
 library ieee;
-use ieee.numeric_std.all;
 use ieee.std_logic_1164.all;
-
+use ieee.numeric_std.all;
 
 entity sfp_panda_sync_transmit is
-
     port (
-        clk_i           : in  std_logic;
+        sysclk_i        : in  std_logic;
+        rst_sys_i       : in  std_logic;
         txoutclk_i      : in  std_logic;
-        reset_i         : in  std_logic;
         txcharisk_o     : out std_logic_vector(3 downto 0) := (others => '0');
+        check_bits_i    : in  std_logic_vector(31 downto 0);
         POSOUT1_i       : in  std_logic_vector(31 downto 0);
         POSOUT2_i       : in  std_logic_vector(31 downto 0);
         POSOUT3_i       : in  std_logic_vector(31 downto 0);
         POSOUT4_i       : in  std_logic_vector(31 downto 0);
-        BITOUT_i        : in  std_logic_vector(15 downto 0); 
+        BITOUT_i        : in  std_logic_vector(7 downto 0); 
         txdata_o        : out std_logic_vector(31 downto 0) := (others => '0')
         );
 
 end sfp_panda_sync_transmit;        
 
-
-
 architecture rtl of sfp_panda_sync_transmit is
 
+-- Timing diagram below assumes both clocks have same frequency and phase.
+-- In reality phase of clocks is arbitrary, and POS data will be 
+-- latched up to one cycle earlier or later wrt TX_DATA
+       
+--    _   _   _   _   _   _   _
+--  _| |_| |_| |_| |_| |_| |_| |_       CLOCK
+--
+--     1   2   3   4   5   6            SEQUENCE 
+--  _ ___ ___ ___ ___ ___ ___ _
+--  _X___X___X___X___X___X___X_         TX_DATA
+--    ___                     _
+-- __|   |___________________|          TXCHARISK
+--        ___
+-- ______|   |_________________         K_SYNC1
+--            ___
+-- __________|   |_____________         K_SYNC2
+--
+-- __________________ _________
+-- __________________X_________         POS1_LATCH
+--
+-- ______________________ _____
+-- ______________________X_____         POS2_LATCH
+--
+-- ______ _____________________
+-- ______X_____________________         POS3_LATCH
+--
+-- __________ _________________
+-- __________X_________________         POS4_LATCH
 
--- component ila_0
--- 
---     port (
---           clk     : std_logic;
---           probe0  : std_logic_vector(31 downto 0);
---           probe1  : std_logic_vector(31 downto 0);
---           probe2  : std_logic_vector(31 downto 0);
---           probe3  : std_logic_vector(31 downto 0);
---           probe4  : std_logic_vector(31 downto 0);
---           probe5  : std_logic_vector(31 downto 0);
---           probe6  : std_logic_vector(5 downto 0);
---           probe7  : std_logic_vector(31 downto 0)
--- );
--- 
--- end component;
 
+subtype t_TX_STATE is INTEGER range 1 to 6;
 
-type t_SM_DATA is (STATE_BITIN, STATE_POSIN13, STATE_POSIN24);
+subtype std8_t is std_logic_vector(7 downto 0);
+type std8_array is array(natural range <>) of std8_t;
 
-type t_data is array(5 downto 0) of std_logic_vector(31 downto 0);
+constant c_k28_5      : std_logic_vector(7 downto 0) := x"BC";
 
-constant c_k28_5                      : std_logic_vector(7 downto 0) := x"BC";
-constant c_k28_0                      : std_logic_vector(7 downto 0) := x"1C";   
-constant c_zeros                      : std_logic_vector(7 downto 0) := x"00";
-constant c_kchar                      : std_logic_vector(3 downto 0) := x"1";
+signal POSOUT1_l      : std_logic_vector(POSOUT1_i'range);
+signal POSOUT2_l      : std_logic_vector(POSOUT2_i'range);
+signal POSOUT3_l      : std_logic_vector(POSOUT3_i'range);
+signal POSOUT4_l      : std_logic_vector(POSOUT4_i'range);
+signal ksync          : std_logic;
+signal ksync_del      : std_logic; 
+signal txcharisk_tog  : std_logic := '0';
+signal BITOUT_l       : std8_array(0 to 5);
 
-signal SM_DATA                        : t_SM_DATA;
-signal data_buf                       : t_data := (others => (others => '0'));
-signal start_in                       : std_logic := '0';
-signal start_in_meta1                 : std_logic;
-signal start_in_meta2                 : std_logic;
-signal start_in_dly                   : std_logic;
-signal start_in_xored                 : std_logic;
-signal start_in_xored_pos12           : std_logic;
-signal start_in_xored_pos34           : std_logic;    
-signal bit_ored                       : std_logic_vector(15 downto 0);  
-signal txdata                         : std_logic_vector(31 downto 0);  
-
-signal probe1                         : std_logic_vector(31 downto 0);
-signal probe2                         : std_logic_vector(31 downto 0);
-signal probe3                         : std_logic_vector(31 downto 0);
-signal probe4                         : std_logic_vector(31 downto 0);
-signal probe5                         : std_logic_vector(31 downto 0);
-signal probe6                         : std_logic_vector(5 downto 0);  
-signal probe7                         : std_logic_vector(31 downto 0);
-
-attribute ASYNC_REG : string;
-attribute ASYNC_REG of start_in_meta1  : signal is "TRUE";
-attribute ASYNC_REG of start_in_meta2  : signal is "TRUE";
-attribute ASYNC_REG of start_in_dly    : signal is "TRUE"; 
+signal seq_num        : unsigned(7 downto 0) := (others => '0');
+signal check_byte      : std_logic_vector(7 downto 0);
 
 
 begin
 
-    
--- Store              start_in    meta1   meta2   dly   xor   xor12   xor34     TX                                    
---                       0          0       0      0     0      0       0      POSOUT3 
---                       1          0       0      0     0      0       0      POSOUT4 
---                       1          1       0      0     0      0       0      BITOUT(PKT ALIGN)  
--- BITOUT(PKT START)     1          1       1      0     1      0       0      POSOUT1                       
--- POSOUT1               0          1       1      1     0      1       0      POSOUT2
--- POSOUT2               0          0       1      1     0      0       1      BITOUT(PKT START)
--- BITOUT(PKT ALIGN)     0          0       0      1     1      0       0      POSOUT3
--- POSOUT3               1          0       0      0     0      1       0      POSOUT4     
--- POSOUT4               1          1       0      0     0      0       1      BITOUT(PKT SLIGN) 
--- BITOUT(PKT START)     1          1       1      0     1      0       0      POSOUT1                                   
+check_byte <= std_logic_vector(seq_num) when to_integer(unsigned(check_bits_i)) = 1 else x"00";
 
--- XOR for edge detection find both edges 
-start_in_xored <= start_in_dly xor start_in_meta2;
-    
-    
-ps_data_in: process(clk_i)
+-- TX Sequencer
+txdata_driver: process(txoutclk_i)
+  -- this variable will synthesise as a register
+  variable TX_STATE : t_TX_STATE := 1;
 begin
-    if rising_edge(clk_i) then
-          -- Synchronous the signal from the other clock domain  
-          start_in_meta1 <= start_in;
-          start_in_meta2 <= start_in_meta1;          
-          start_in_dly <= start_in_meta2;
-          start_in_xored_pos12 <= start_in_xored;
-          start_in_xored_pos34 <= start_in_xored_pos12;
-        -- Detect the edges BIT              
-        if (start_in_xored = '1') then
-            bit_ored <= (others => '0');                
-            data_buf(0) <= (bit_ored or BITOUT_i) & x"0000";
-        else
-            bit_ored <= bit_ored or BITOUT_i;              
-        end if;                
-        -- POSOUT13                           
-        if (start_in_xored_pos12 = '1') then
-            data_buf(1) <= POSOUT1_i;
-            data_buf(3) <= POSOUT3_i;
-        end if;
-        -- POSOUT24
-        if (start_in_xored_pos34 = '1') then    
-            data_buf(2) <= POSOUT2_i;                 
-            data_buf(4) <= POSOUT4_i;
-        end if;
+  if rising_edge(txoutclk_i) then
+
+    if TX_STATE = 1 then
+        txcharisk_o <= x"1";
+        txcharisk_tog <= not txcharisk_tog;
+        seq_num       <= seq_num + 1;
+    else
+        txcharisk_o <= (others => '0');
     end if;
-end process ps_data_in;        
 
-
- -- 
- -- probe1 <= (others => '0'); 
- -- probe2 <= (others => '0');
- -- probe3 <= (others => '0');
- -- probe4 <= (others => '0');
- -- probe5 <= (others => '0'); 
- -- probe6 <= (others => '0');
- -- probe7 <= (others => '0');
- -- 
- -- 
- -- -- Chipscope
- -- ila_tx_inst : ila_0
- -- port map (
- --       clk     => txoutclk_i,
- --       probe0  => txdata,
- --       probe1  => probe1,
- --       probe2  => probe2,
- --       probe3  => probe3,
- --       probe4  => probe4,
- --       probe5  => probe5,
- --       probe6  => probe6,
- --       probe7  => probe7
- -- );
- -- 
-
-
-txdata_o <= txdata;
-
-
-ps_data_out: process(txoutclk_i)
-begin
-    if rising_edge(txoutclk_i) then
-                
-        case SM_DATA is
-                    
-            -- 16 bits plus the k character or just zeros
-            when STATE_BITIN =>
-                txcharisk_o <= c_kchar;
-                -- Packet start bit
-                if (start_in = '0') then
-                    txdata <= data_buf(0)(31 downto 16) & x"00" & c_k28_0;     
-                -- Packet Alignment
-                else
-                    txdata <= data_buf(0)(31 downto 16) & x"00" & c_k28_5;
-                end if;        
-                SM_DATA <= STATE_POSIN13;
-                        
-            -- POSOUT1 or POSOUT3
-            when STATE_POSIN13 => 
-                txcharisk_o <= (others => '0');
-                if (start_in = '0') then
-                    txdata <= data_buf(1); 
-                else
-                    txdata <= data_buf(3);
-                end if;                    
-                SM_DATA <= STATE_POSIN24;
-                    
-            -- POSOUT2 or POSOUT     
-            when STATE_POSIN24 => 
-                start_in <= not start_in;
-                txcharisk_o <= (others => '0');
-                if (start_in = '0') then                
-                    txdata <= data_buf(2);
-                else
-                    txdata <= data_buf(4);
-                end if;        
-                SM_DATA <= STATE_BITIN;
-                        
-        end case;                             
+    case TX_STATE is            
+      when 1 => txdata_o <= BITOUT_l(0) & POSOUT1_l(31 downto 16) & c_k28_5;
+      when 2 => txdata_o <= BITOUT_l(1) & POSOUT1_l(15 downto 0) & POSOUT2_l(31 downto 24);
+      when 3 => txdata_o <= BITOUT_l(2) & POSOUT2_l(23 downto 0);
+      when 4 => txdata_o <= BITOUT_l(3) & POSOUT3_l(31 downto 8);
+      when 5 => txdata_o <= BITOUT_l(4) & POSOUT3_l(7 downto 0) & POSOUT4_l(31 downto 16);
+      when 6 => txdata_o <= BITOUT_l(5) & POSOUT4_l(15 downto 0) & check_byte;
+    end case;
+    
+    if TX_STATE = 6 then
+      TX_STATE := 1;
+    else
+      TX_STATE := TX_STATE + 1;
     end if;
-end process ps_data_out;    
-        
-        
-        
+ end if;
+end process;
 
+ksyncer: entity work.sync_bit
+port map(
+    clk_i => sysclk_i,
+    bit_i => txcharisk_tog,
+    bit_o => ksync
+);
+
+-- Latch the values of the BITBUS and POSBUS signals
+latch_positions: process(sysclk_i)
+  -- this variable will synthesise as a shift register
+  variable ksync_sr   : std_logic_vector(5 downto 0);
+begin
+  if rising_edge(sysclk_i) then
+    --Detect change of txcharisk and shift into SR
+    ksync_del <= ksync;
+    ksync_sr := ksync_sr(4 downto 0) & (ksync xor ksync_del);
+    if ksync_sr(1) = '1' then 
+      POSOUT1_l <= POSOUT1_i;
+    end if;
+    if ksync_sr(2) = '1' then 
+      POSOUT2_l <= POSOUT2_i;
+    end if;
+    if ksync_sr(4) = '1' then 
+      POSOUT3_l <= POSOUT3_i;
+    end if;
+    if ksync_sr(5) = '1' then 
+      POSOUT4_l <= POSOUT4_i;
+    end if;
+  
+    for i in 0 to 5 loop
+      if ksync_sr(i) = '1' then
+        BITOUT_l(i) <= BITOUT_i;
+      end if;
+    end loop;
+  end if;
+end process;
 
 end rtl;
+

--- a/modules/sfp_panda_sync/hdl/sfp_panda_sync_wrapper.vhd
+++ b/modules/sfp_panda_sync/hdl/sfp_panda_sync_wrapper.vhd
@@ -24,14 +24,6 @@ entity sfp_panda_sync_wrapper is
         IN_BIT6_o         : out std_logic_vector(0 downto 0);
         IN_BIT7_o         : out std_logic_vector(0 downto 0);
         IN_BIT8_o         : out std_logic_vector(0 downto 0);
-        IN_BIT9_o         : out std_logic_vector(0 downto 0);
-        IN_BIT10_o        : out std_logic_vector(0 downto 0);
-        IN_BIT11_o        : out std_logic_vector(0 downto 0);
-        IN_BIT12_o        : out std_logic_vector(0 downto 0);
-        IN_BIT13_o        : out std_logic_vector(0 downto 0);
-        IN_BIT14_o        : out std_logic_vector(0 downto 0);
-        IN_BIT15_o        : out std_logic_vector(0 downto 0);
-        IN_BIT16_o        : out std_logic_vector(0 downto 0);
         IN_POS1_o         : out std32_array(0 downto 0);
         IN_POS2_o         : out std32_array(0 downto 0);
         IN_POS3_o         : out std32_array(0 downto 0);
@@ -57,28 +49,22 @@ end sfp_panda_sync_wrapper;
 architecture rtl of sfp_panda_sync_wrapper is
 
 signal rx_link_ok         : std_logic;
-signal rx_link_ok_sync    : std_logic;
-signal rxbyteisaligned_o  : std_logic;
-signal rxbyterealign_o    : std_logic;
-signal rxcommadet_o       : std_logic;
-signal loss_lock_o        : std_logic;
-signal rx_error_o         : std_logic;
-signal rxoutclk_o         : std_logic;
-signal txoutclk_o         : std_logic;
-signal rxoutclk_i         : std_logic;
-signal txoutclk_i         : std_logic;   
-signal rxdata_o           : std_logic_vector(31 downto 0); 
-signal rxcharisk_o        : std_logic_vector(3 downto 0); 
-signal rxdisperr_o        : std_logic_vector(3 downto 0); 
-signal mgt_ready_o        : std_logic;
-signal rxnotintable_o     : std_logic_vector(3 downto 0);
-signal txdata_i           : std_logic_vector(31 downto 0);
-signal txcharisk_i        : std_logic_vector(3 downto 0);
+signal rxoutclk           : std_logic;
+signal txoutclk           : std_logic;
+signal rxoutclk_buf       : std_logic;
+signal txoutclk_buf       : std_logic;   
+signal rxdata             : std_logic_vector(31 downto 0); 
+signal rxcharisk          : std_logic_vector(3 downto 0); 
+signal rxdisperr          : std_logic_vector(3 downto 0); 
+signal mgt_ready          : std_logic;
+signal rxnotintable       : std_logic_vector(3 downto 0);
+signal txdata             : std_logic_vector(31 downto 0);
+signal txcharisk          : std_logic_vector(3 downto 0);
 signal POSIN1             : std_logic_vector(31 downto 0); 
 signal POSIN2             : std_logic_vector(31 downto 0);
 signal POSIN3             : std_logic_vector(31 downto 0);  
 signal POSIN4             : std_logic_vector(31 downto 0);  
-signal BITIN              : std_logic_vector(15 downto 0);  
+signal BITIN              : std_logic_vector(7 downto 0);  
 signal BITOUT1            : std_logic;  
 signal BITOUT2            : std_logic;  
 signal BITOUT3            : std_logic;  
@@ -87,23 +73,18 @@ signal BITOUT5            : std_logic;
 signal BITOUT6            : std_logic;  
 signal BITOUT7            : std_logic;  
 signal BITOUT8            : std_logic;  
-signal BITOUT9            : std_logic;  
-signal BITOUT10           : std_logic;  
-signal BITOUT11           : std_logic;  
-signal BITOUT12           : std_logic;  
-signal BITOUT13           : std_logic;  
-signal BITOUT14           : std_logic;  
-signal BITOUT15           : std_logic;  
-signal BITOUT16           : std_logic;  
 signal POSOUT1            : std_logic_vector(31 downto 0);
 signal POSOUT2            : std_logic_vector(31 downto 0);
 signal POSOUT3            : std_logic_vector(31 downto 0);
 signal POSOUT4            : std_logic_vector(31 downto 0);
-signal BITOUT             : std_logic_vector(15 downto 0);
+signal BITOUT             : std_logic_vector(7 downto 0);
 signal LINKUP             : std_logic_vector(31 downto 0);
 signal SYNC_RESET         : std_logic;
 signal TXN                : std_logic;
 signal TXP                : std_logic;
+signal rx_check_bits      : std_logic_vector(31 downto 0);
+signal tx_check_bits      : std_logic_vector(31 downto 0);
+signal health             : std_logic_vector(31 downto 0);
 
 signal cpll_lock          : std_logic_vector(31 downto 0);
 
@@ -121,21 +102,12 @@ port map (
     O => SFP_o.TXP_OUT
 );
 
-SFP_o.MGT_REC_CLK <= rxoutclk_i;
+SFP_o.MGT_REC_CLK <= rxoutclk_buf;
 SFP_o.LINK_UP <= LINKUP(0);
 
 read_ack_o <= '1';
 write_ack_o <= '1';
 
-
-IN_BIT16_o(0) <= BITIN(15);
-IN_BIT15_o(0) <= BITIN(14);
-IN_BIT14_o(0) <= BITIN(13);
-IN_BIT13_o(0) <= BITIN(12);
-IN_BIT12_o(0) <= BITIN(11);
-IN_BIT11_o(0) <= BITIN(10);
-IN_BIT10_o(0) <= BITIN(9);
-IN_BIT9_o(0) <= BITIN(8);
 IN_BIT8_o(0) <= BITIN(7);
 IN_BIT7_o(0) <= BITIN(6);
 IN_BIT6_o(0) <= BITIN(5);
@@ -145,34 +117,30 @@ IN_BIT3_o(0) <= BITIN(2);
 IN_BIT2_o(0) <= BITIN(1);
 IN_BIT1_o(0) <= BITIN(0);
 
-
-
 rxoutclk_bufg : BUFG
 port map(
-    O => rxoutclk_i,
-    I => rxoutclk_o
+    O => rxoutclk_buf,
+    I => rxoutclk
 );
-
 
 txoutclk_bufg : BUFG
 port map(
-    O => txoutclk_i,
-    I => txoutclk_o
+    O => txoutclk_buf,
+    I => txoutclk
 );
 
 -- Transmitter 
 -- The transmit side transmits regardless of the state of the receiver rx_link_ok signal 
 -- txoutclk is the clock used for the TX side
--- 1. BITOUT and pkt_start K character  2. POSOUT1  3. POSOUT2   
--- 1. BITOUT and alignment K character  2. POSOUT3  3. POSOUT4
 sfp_panda_sync_transmitter_inst : entity work.sfp_panda_sync_transmit
 
     port map (
-        clk_i             => clk_i,
-        txoutclk_i        => txoutclk_i,
-        reset_i           => reset_i,
-        txcharisk_o       => txcharisk_i,
-        txdata_o          => txdata_i,
+        sysclk_i          => clk_i,
+        txoutclk_i        => txoutclk_buf,
+        rst_sys_i         => reset_i,
+        txcharisk_o       => txcharisk,
+        txdata_o          => txdata,
+        check_bits_i      => tx_check_bits,
         POSOUT1_i         => POSOUT1,
         POSOUT2_i         => POSOUT2,
         POSOUT3_i         => POSOUT3,
@@ -186,21 +154,22 @@ sfp_panda_sync_transmitter_inst : entity work.sfp_panda_sync_transmit
 sfp_panda_sync_receiver_inst : entity work.sfp_panda_sync_receiver
 
     port map (
-        clk_i             => clk_i,
-        rxoutclk_i        => rxoutclk_i,
-        reset_i           => reset_i,
-        rxdisperr_i       => rxdisperr_o,
-        rxcharisk_i       => rxcharisk_o,
-        rxdata_i          => rxdata_o,
-        rxnotintable_i    => rxnotintable_o,
+        sysclk_i          => clk_i,
+        rxoutclk_i        => rxoutclk_buf,
+        rxdisperr_i       => rxdisperr,
+        rxcharisk_i       => rxcharisk,
+        rxdata_i          => rxdata,
+        rxnotintable_i    => rxnotintable,
+        check_bits_i      => rx_check_bits,
         rx_link_ok_o      => rx_link_ok,
-        loss_lock_o       => loss_lock_o,
-        rx_error_o        => rx_error_o,
+        loss_lock_o       => open,
+        rx_error_o        => open,
         BITIN_o           => BITIN,
         POSIN1_o          => IN_POS1_o(0),
         POSIN2_o          => IN_POS2_o(0),
         POSIN3_o          => IN_POS3_o(0),
-        POSIN4_o          => IN_POS4_o(0)
+        POSIN4_o          => IN_POS4_o(0),
+        health_o          => health
         );
 
 
@@ -211,86 +180,72 @@ sfp_panda_sync_mgt_interface_inst : entity work.sfp_panda_sync_mgt_interface
         GTREFCLK          => SFP_i.GTREFCLK,
         SYNC_RESET_i      => SYNC_RESET,
         sysclk_i          => clk_i,
-        rxoutclk_i        => rxoutclk_i,
-        txoutclk_i        => txoutclk_i,
+        rxoutclk_i        => rxoutclk_buf,
+        txoutclk_i        => txoutclk_buf,
         rxp_i             => SFP_i.RXP_IN,
         rxn_i             => SFP_i.RXN_IN,
         txp_o             => TXP,
         txn_o             => TXN,
-        rxbyteisaligned_o => rxbyteisaligned_o,
-        rxbyterealign_o   => rxbyterealign_o,
-        rxcommadet_o      => rxcommadet_o,
-        rxdata_o          => rxdata_o,
-        rxoutclk_o        => rxoutclk_o,            -- RX recovered clock
-        rxcharisk_o       => rxcharisk_o,
-        rxdisperr_o       => rxdisperr_o,
-        mgt_ready_o       => mgt_ready_o,
-        rxnotintable_o    => rxnotintable_o,
-        txoutclk_o        => txoutclk_o,            -- TX reference clock
-        txdata_i          => txdata_i,
-        txcharisk_i       => txcharisk_i,
+        rxbyteisaligned_o => open,
+        rxbyterealign_o   => open,
+        rxcommadet_o      => open,
+        rxdata_o          => rxdata,
+        rxoutclk_o        => rxoutclk,            -- RX recovered clock
+        rxcharisk_o       => rxcharisk,
+        rxdisperr_o       => rxdisperr,
+        mgt_ready_o       => mgt_ready,
+        rxnotintable_o    => rxnotintable,
+        txoutclk_o        => txoutclk,            -- TX reference clock
+        txdata_i          => txdata,
+        txcharisk_i       => txcharisk,
         cpll_Lock_o       => cpll_lock(0)
         );
 
 
 -- Make a vector out of all the bits from the bit bus
-BITOUT <= BITOUT16 & BITOUT15 & BITOUT14 & BITOUT13 & BITOUT12 & BITOUT11 & BITOUT10 & BITOUT9 & 
-          BITOUT8  & BITOUT7  & BITOUT6  & BITOUT5  & BITOUT4  & BITOUT3  & BITOUT2  & BITOUT1;
-
---synchronise rx_link_ok to clk_i
-rx_link_sync : entity work.sync_bit
-    port map(
-     clk_i => clk_i,
-     bit_i => rx_link_ok,
-     bit_o => rx_link_ok_sync
-);
+BITOUT <= BITOUT8  & BITOUT7  & BITOUT6  & BITOUT5  & BITOUT4  & BITOUT3  & BITOUT2  & BITOUT1;
 
 -- Link up and MGT ready
-LINKUP(0) <= mgt_ready_o and rx_link_ok_sync;
+LINKUP(0) <= mgt_ready and rx_link_ok;
 LINKUP(31 downto 1) <= (others => '0');
 
 sfp_panda_sync_ctrl_inst : entity work.sfp_panda_sync_ctrl
     port map (
         -- Clock and Reset
-        clk_i             => clk_i,
-        reset_i           => reset_i,
-        bit_bus_i         => bit_bus_i,
-        pos_bus_i         => pos_bus_i,
+        clk_i               => clk_i,
+        reset_i             => reset_i,
+        bit_bus_i           => bit_bus_i,
+        pos_bus_i           => pos_bus_i,
         -- Block Parameters
-        IN_LINKUP            => LINKUP,
-        IN_SYNC_RESET        => open,
-        IN_SYNC_RESET_wstb   => SYNC_RESET,
+        IN_LINKUP           => LINKUP,
+        IN_SYNC_RESET       => open,
         IN_CPLL_LOCK         => CPLL_LOCK,
-        OUT_BIT1_from_bus  => BITOUT1,
-        OUT_BIT2_from_bus  => BITOUT2,
-        OUT_BIT3_from_bus  => BITOUT3,
-        OUT_BIT4_from_bus  => BITOUT4,
-        OUT_BIT5_from_bus  => BITOUT5,
-        OUT_BIT6_from_bus  => BITOUT6,
-        OUT_BIT7_from_bus  => BITOUT7,
-        OUT_BIT8_from_bus  => BITOUT8,
-        OUT_BIT9_from_bus  => BITOUT9,
-        OUT_BIT10_from_bus => BITOUT10,
-        OUT_BIT11_from_bus => BITOUT11,
-        OUT_BIT12_from_bus => BITOUT12,
-        OUT_BIT13_from_bus => BITOUT13,
-        OUT_BIT14_from_bus => BITOUT14,
-        OUT_BIT15_from_bus => BITOUT15,
-        OUT_BIT16_from_bus => BITOUT16,
-        OUT_POS1_from_bus  => POSOUT1,
-        OUT_POS2_from_bus  => POSOUT2,
-        OUT_POS3_from_bus  => POSOUT3,
-        OUT_POS4_from_bus  => POSOUT4,
+        IN_SYNC_RESET_wstb  => SYNC_RESET,
+        IN_CHECK_BITS       => rx_check_bits,
+        IN_HEALTH           => health,
+        OUT_CHECK_BITS      => tx_check_bits,
+        OUT_BIT1_from_bus   => BITOUT1,
+        OUT_BIT2_from_bus   => BITOUT2,
+        OUT_BIT3_from_bus   => BITOUT3,
+        OUT_BIT4_from_bus   => BITOUT4,
+        OUT_BIT5_from_bus   => BITOUT5,
+        OUT_BIT6_from_bus   => BITOUT6,
+        OUT_BIT7_from_bus   => BITOUT7,
+        OUT_BIT8_from_bus   => BITOUT8,
+        OUT_POS1_from_bus   => POSOUT1,
+        OUT_POS2_from_bus   => POSOUT2,
+        OUT_POS3_from_bus   => POSOUT3,
+        OUT_POS4_from_bus   => POSOUT4,
         -- Memory Bus Interface
-        read_strobe_i     => read_strobe_i,
-        read_address_i    => read_address_i(BLK_AW-1 downto 0),
-        read_data_o       => read_data_o,
-        read_ack_o        => open,
+        read_strobe_i       => read_strobe_i,
+        read_address_i      => read_address_i(BLK_AW-1 downto 0),
+        read_data_o         => read_data_o,
+        read_ack_o          => open,
 
-        write_strobe_i    => write_strobe_i,
-        write_address_i   => write_address_i(BLK_AW-1 downto 0),
-        write_data_i      => write_data_i,
-        write_ack_o       => open
+        write_strobe_i      => write_strobe_i,
+        write_address_i     => write_address_i(BLK_AW-1 downto 0),
+        write_data_i        => write_data_i,
+        write_ack_o         => open
         );
 
 end rtl;                

--- a/modules/sfp_panda_sync/hdl/sim/pandaSync_rx_TB.vhd
+++ b/modules/sfp_panda_sync/hdl/sim/pandaSync_rx_TB.vhd
@@ -1,0 +1,118 @@
+library ieee;
+use ieee.numeric_std.all;
+use ieee.std_logic_1164.all;
+
+
+entity pandaSync_rx_TB is
+end pandaSync_rx_TB;
+
+architecture rtl of pandaSync_rx_TB is
+
+constant c_k28_5            : std_logic_vector(7 downto 0) := x"BC";
+
+-- clks in anti-phase
+signal clk : std_logic := '0';
+signal rxoutclk : std_logic := '0';
+
+signal rxcharisk : std_logic_vector(3 downto 0);
+signal rxdata    : std_logic_vector(31 downto 0);
+
+signal POSIN1   : std_logic_vector(31 downto 0);
+signal POSIN2   : std_logic_vector(31 downto 0);
+signal POSIN3   : std_logic_vector(31 downto 0);
+signal POSIN4   : std_logic_vector(31 downto 0);
+signal BITIN    : std_logic_vector(7 downto 0);
+
+signal POSOUT1   : std_logic_vector(31 downto 0);
+signal POSOUT2   : std_logic_vector(31 downto 0);
+signal POSOUT3   : std_logic_vector(31 downto 0);
+signal POSOUT4   : std_logic_vector(31 downto 0);
+signal BITOUT    : std_logic_vector(7 downto 0);
+
+signal count : natural;
+signal rst : std_logic;
+signal stop : boolean := false;
+
+begin
+
+uut : entity work.sfp_panda_sync_receiver
+    port map(
+          sysclk_i          => clk,
+          rxoutclk_i        => rxoutclk,   
+          rxdisperr_i       => (others => '0'),
+          rxcharisk_i       => rxcharisk,
+          check_bits_i      => (others => '0'),
+          rxdata_i          => rxdata,
+          rxnotintable_i    => (others => '0'),
+          rx_link_ok_o      => open,
+          loss_lock_o       => open,
+          rx_error_o        => open,
+          BITIN_o           => BITIN,   
+          POSIN1_o          => POSIN1,
+          POSIN2_o          => POSIN2,
+          POSIN3_o          => POSIN3,
+          POSIN4_o          => POSIN4
+          );
+
+clk_gen: process
+begin
+    while not stop loop
+        clk <= not clk;
+        --rxoutclk <= not rxoutclk after 1 ns;
+        wait for 4 ns;
+    end loop;
+    wait;
+end process;
+
+rxclk_gen: process
+begin
+  while not stop loop
+    rxoutclk <= not rxoutclk after 0 ns;
+    wait for 4 ns;
+  end loop;
+  wait;
+end process;
+
+BITOUT <= std_logic_vector(to_unsigned(count,8));
+POSOUT1 <= X"00000" & "00" & std_logic_vector(to_unsigned(count,10));
+POSOUT2 <= X"00000" & "01" & std_logic_vector(to_unsigned(count,10));
+POSOUT3 <= X"00000" & "10" & std_logic_vector(to_unsigned(count,10));
+POSOUT4 <= X"00000" & "11" & std_logic_vector(to_unsigned(count,10));
+ 
+stim : process
+begin
+    count <= 0;
+    wait for 100 ns;
+    rst <= '1';
+    wait for 100 ns;
+    wait until rising_edge(clk);
+    rst <= '0';
+    count <= 100;
+    while count < 1024 loop
+        rxdata <= BITOUT & POSOUT1(31 downto 16) & c_k28_5;
+        rxcharisk <= x"1";
+        wait until rising_edge(clk);
+        count <= count + 1; 
+        rxdata <= BITOUT & POSOUT1(15 downto 0) & POSOUT2(31 downto 24);
+        rxcharisk <= x"0";
+        wait until rising_edge(clk);
+        count <= count + 1;
+        rxdata <= BITOUT & POSOUT2(23 downto 0);
+        wait until rising_edge(clk);
+        count <= count + 1;
+        rxdata <= BITOUT & POSOUT3(31 downto 8);
+        wait until rising_edge(clk);
+        count <= count + 1;
+        rxdata <= BITOUT & POSOUT3(7 downto 0) & POSOUT4(31 downto 16);
+        wait until rising_edge(clk);
+        count <= count + 1;
+        rxdata <= BITOUT & POSOUT4(15 downto 0) & x"00";
+        wait until rising_edge(clk);
+        count <= count + 1;
+    end loop;
+    stop <= true;
+    wait;
+end process;
+
+end rtl;
+

--- a/modules/sfp_panda_sync/hdl/sim/pandaSync_tx_TB.vhd
+++ b/modules/sfp_panda_sync/hdl/sim/pandaSync_tx_TB.vhd
@@ -1,0 +1,107 @@
+library ieee;
+use ieee.numeric_std.all;
+use ieee.std_logic_1164.all;
+
+
+entity pandaSync_tx_TB is
+end pandaSync_tx_TB;
+
+architecture rtl of pandaSync_tx_TB is
+
+-- clks in anti-phase
+signal clk : std_logic := '0';
+signal txoutclk : std_logic := '0';
+
+signal txcharisk : std_logic_vector(3 downto 0);
+signal txdata    : std_logic_vector(31 downto 0);
+
+signal POSOUT1   : std_logic_vector(31 downto 0);
+signal POSOUT2   : std_logic_vector(31 downto 0);
+signal POSOUT3   : std_logic_vector(31 downto 0);
+signal POSOUT4   : std_logic_vector(31 downto 0);
+signal BITOUT    : std_logic_vector(7 downto 0);
+
+signal count : natural;
+signal rst : std_logic;
+signal stop : boolean := false;
+
+begin
+
+uut : entity work.sfp_panda_sync_transmit
+
+    port map (
+        sysclk_i          => clk,
+        rst_sys_i         => rst,
+        txoutclk_i        => txoutclk,
+        txcharisk_o       => txcharisk,
+        txdata_o          => txdata,
+        check_bits_i      => (others => '0'),
+        POSOUT1_i         => POSOUT1,
+        POSOUT2_i         => POSOUT2,
+        POSOUT3_i         => POSOUT3,
+        POSOUT4_i         => POSOUT4,
+        BITOUT_i          => BITOUT
+        );
+
+clk_gen: process
+begin
+    while not stop loop
+        clk <= not clk;
+        --txoutclk <= not txoutclk after 1 ns;
+        wait for 4 ns;
+    end loop;
+    wait;
+end process;
+
+txclk_gen: process
+begin
+  while not stop loop
+    txoutclk <= not txoutclk after 1 ns;
+    wait for 4 ns;
+  end loop;
+  wait;
+end process;
+
+BITOUT <= std_logic_vector(to_unsigned(count,8));
+POSOUT1 <= X"00000" & "00" & std_logic_vector(to_unsigned(count,10));
+POSOUT2 <= X"00000" & "01" & std_logic_vector(to_unsigned(count,10));
+POSOUT3 <= X"00000" & "10" & std_logic_vector(to_unsigned(count,10));
+POSOUT4 <= X"00000" & "11" & std_logic_vector(to_unsigned(count,10));
+
+stim : process
+begin
+    count <= 0;
+    wait for 100 ns;
+    rst <= '1';
+    wait for 100 ns;
+    wait until rising_edge(clk);
+    rst <= '0';
+    count <= 100;
+    while count < 1024 loop
+        --wait for 8 ns;
+        wait until rising_edge(clk);
+        if count = 200 then   
+          --<<signal .uut.wren_low : std_logic>> <= force '1';  -- if only this were supported for simulation
+        elsif count = 400 then
+          --<<signal .uut.wren_low : std_logic>> <= release;
+        end if;
+        count <= count + 1;    
+    end loop;
+    stop <= true;
+    wait;
+end process;
+
+/*
+fifo_rst : process
+begin
+  rst <= '1';
+  for i in 0 to 5 loop
+    wait until rising_edge(clk);
+  end loop;
+  rst <= '0';
+  wait;
+end process;
+*/
+
+end rtl;
+

--- a/modules/sfp_panda_sync/hdl/sim/run_xsim_rx.sh
+++ b/modules/sfp_panda_sync/hdl/sim/run_xsim_rx.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/sh
+
+VIVADO=/dls_sw/FPGA/Xilinx/Vivado/2022.2
+
+. $VIVADO/settings64.sh
+
+mkdir -p build && cd build
+
+xvhdl ../../../../../common/hdl/sync_bit.vhd &&
+xvhdl -2008 ../../sfp_panda_sync_receiver.vhd ../pandaSync_rx_TB.vhd &&
+xelab -debug typical pandaSync_rx_TB &&
+xsim pandaSync_rx_TB -gui --autoloadwcfg -t ../xsim.tcl
+

--- a/modules/sfp_panda_sync/hdl/sim/run_xsim_tx.sh
+++ b/modules/sfp_panda_sync/hdl/sim/run_xsim_tx.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/sh
+
+VIVADO=/dls_sw/FPGA/Xilinx/Vivado/2022.2
+
+. $VIVADO/settings64.sh
+
+mkdir -p build && cd build
+
+xvhdl ../../../../../common/hdl/sync_bit.vhd &&
+xvhdl -2008 ../../sfp_panda_sync_transmit.vhd ../pandaSync_tx_TB.vhd &&
+xelab -debug typical pandaSync_tx_TB &&
+xsim pandaSync_tx_TB -gui --autoloadwcfg -t ../xsim.tcl
+

--- a/modules/sfp_panda_sync/hdl/sim/xsim.tcl
+++ b/modules/sfp_panda_sync/hdl/sim/xsim.tcl
@@ -1,0 +1,6 @@
+#open_wave_config {/scratch/clm61942/PandA_tmp/fmc_panda_sync/sync-fix/PandABlocks-FPGA/modules/sfp_panda_sync/hdl/sim/build/work.pandaSync_tx_TB_work.glbl.wcfg}
+#add_force /pandaSync_tx_TB/uut/wren_low 1 496 -cancel_after 696
+#add_force /pandaSync_tx_TB/uut/rden_low 1 896 -cancel_after 1096
+add_force /pandaSync_rx_TB/uut/rx_link_ok 1 100
+run all
+

--- a/modules/sfp_panda_sync/sfp_panda_sync.block.ini
+++ b/modules/sfp_panda_sync/sfp_panda_sync.block.ini
@@ -10,11 +10,17 @@ block_suffixes: IN OUT
 
 [IN.SYNC_RESET]
 type: write action
-description: Resets the event receiver
+description: Local reset
 
 [IN.LINKUP]
 type: read
-description: GTX_SPS link status
+description: GTX link status
+
+[IN.CHECK_BITS]
+type: param enum
+description: Content of Check byte
+0: Zeros
+1: Sequence Number
 
 [IN.CPLL_LOCK]
 type: read
@@ -52,38 +58,6 @@ description: SFP panda sync bit 7 input
 type: bit_out
 description: SFP panda sync bit 8 input
 
-[IN.BIT9]
-type: bit_out
-description: SFP panda sync bit 9 input
-
-[IN.BIT10]
-type: bit_out
-description: SFP panda sync bit 10 input
-
-[IN.BIT11]
-type: bit_out
-description: SFP panda sync bit 11 input
-
-[IN.BIT12]
-type: bit_out
-description: SFP panda sync bit 12 input
-
-[IN.BIT13]
-type: bit_out
-description: SFP panda sync bit 13 input
-
-[IN.BIT14]
-type: bit_out
-description: SFP panda sync bit 14 input
-
-[IN.BIT15]
-type: bit_out
-description: SFP panda sync bit 15 input
-
-[IN.BIT16]
-type: bit_out
-description: SFP panda sync bit 16 input 
-
 [IN.POS1]
 type: pos_out
 description: SFP panda sync pos 1 input
@@ -99,6 +73,21 @@ description: SFP panda sync pos 3 input
 [IN.POS4]
 type: pos_out
 description: SFP panda sync pos 4 input
+
+[IN.HEALTH]
+type: read enum
+description: Error status
+0: OK
+1: Linkup error
+2: Deprecated protocol
+3: Protocol error
+4: Check-bits error
+
+[OUT.CHECK_BITS]
+type: param enum
+description: Content of Check byte
+0: Zeros
+1: Sequence Number
 
 [OUT.BIT1]
 type: bit_mux
@@ -132,38 +121,6 @@ description: SFP panda sync bit 7 output
 type: bit_mux
 description: SFP panda sync bit 8 output
  
-[OUT.BIT9]
-type: bit_mux
-description: SFP panda sync bit 9 output
- 
-[OUT.BIT10]
-type: bit_mux
-description: SFP panda sync bit 10 output
- 
-[OUT.BIT11]
-type: bit_mux
-description: SFP panda sync bit 11 output
- 
-[OUT.BIT12]
-type: bit_mux
-description: SFP panda sync bit 12 output
- 
-[OUT.BIT13]
-type: bit_mux
-description: SFP panda sync bit 13 output
- 
-[OUT.BIT14]
-type: bit_mux
-description: SFP panda sync bit 14 output
- 
-[OUT.BIT15]
-type: bit_mux
-description: SFP panda sync bit 15 output
- 
-[OUT.BIT16]
-type: bit_mux
-description: SFP panda sync bit 16 output 
-
 [OUT.POS1]
 type: pos_mux
 description: SFP panda sync pos 1 output

--- a/modules/sfp_panda_sync/sfp_panda_sync.block.ini
+++ b/modules/sfp_panda_sync/sfp_panda_sync.block.ini
@@ -83,6 +83,14 @@ description: Error status
 3: Protocol error
 4: Check-bits error
 
+[IN.CTR_RST]
+type: write action
+description: Reset the error count
+
+[IN.ERR_CNT]
+type: read uint
+description: Number of not-in-table or disparity errors
+
 [OUT.CHECK_BITS]
 type: param enum
 description: Content of Check byte


### PR DESCRIPTION
 Major change to PandASync protocol

* 8 bit-bus entries are transmitted each clock tick
* Packing as follows:

| BITS[7:0] | POS1[31:16] | K28.5  |
| BITS[7:0] | POS1[15:0]  | POS2[31:24] |
| BITS[7:0] | POS2[23:0]  |
| BITS[7:0] | POS3[31:8]  |
| BITS[7:0] | POS3[7:0]   | POS4[31:16] |
| BITS[7:0] | POS4[15:0]  | CHECKBYTE   |

CHECKBYTE currently holds either all zeros, or a sequence number (which is checked for consecutive values). It could also hold some kind of checksum but does not currently.

Remaining issues:
* Link still requires resetting manually after initialisation
* Bogus(?) protocol-error detected after plugging fibre, requires manual reset to clear

I tried adding a settling-time delay to hold the MGT in reset until after the link has stabilised. This has no effect for small delays (<10 microsec), but for delays >100 microsec the MGT never comes out of reset. This approach works on other designs with similar MGTs.
