### PR TITLE
Tidy-up of encoders and slow interface

### DIFF
--- a/modules/inenc/inenc.block.ini
+++ b/modules/inenc/inenc.block.ini
@@ -89,6 +89,7 @@ description: Table status
 3: CRC error (for BISS)
 4: Error bit active (for BISS)
 5: ENDAT not implemented
+6: Protocol readback error
 
 [VAL]
 type: pos_out

--- a/modules/outenc/outenc.block.ini
+++ b/modules/outenc/outenc.block.ini
@@ -68,6 +68,8 @@ description: Table status
 0: OK
 1: Biss timeout error (did not received right number of sck for biss frame)
 2: ENDAT not implemented
+3: OUTENC unused (MONITOR mode)
+4: Protocol readback error
 
 [DCARD_TYPE]
 type: read enum

--- a/modules/system/hdl/system_registers.vhd
+++ b/modules/system/hdl/system_registers.vhd
@@ -26,7 +26,6 @@ entity system_registers is
 port (
     clk_i               : in  std_logic;
     reset_i             : in  std_logic;
-    DCARD_MODE_i        : in  std32_array(ENC_NUM-1 downto 0);
     OUTENC_PROT_i       : in  std32_array(ENC_NUM-1 downto 0);
     OUTENC_PROT_WSTB_i  : in  std_logic_vector(ENC_NUM-1 downto 0);
     INENC_PROT_i        : in  std32_array(ENC_NUM-1 downto 0);
@@ -84,8 +83,6 @@ begin
             slow_tlp_o.address <= (others => '0');
             slow_tlp_o.data <= (others => '0');
         else
-            -- Single clock cycle strobe
-            slow_tlp_o.strobe <= '0';
             -- INENC PROTOCOL Slow Registers
             if (or_reduce(INENC_PROT_WSTB_i) = '1') then
                 inenc_ind := ONEHOT_INDEX(INENC_PROT_WSTB_i);
@@ -96,12 +93,7 @@ begin
             elsif (or_reduce(OUTENC_PROT_WSTB_i) = '1') then
                 outenc_ind := ONEHOT_INDEX(OUTENC_PROT_WSTB_i);
                 slow_tlp_o.strobe <= '1';
-                -- When using a monitor card, the protocol needs to make sure the CLK is enabled.
-                if (DCARD_MODE_i(outenc_ind)(3 downto 1) = DCARD_MONITOR) then
-                    slow_tlp_o.data <= x"0000000" & '0' & OUTENC_PROT_i(outenc_ind)(2) & '1' & OUTENC_PROT_i(outenc_ind)(0);
-                else
-                    slow_tlp_o.data <= OUTENC_PROT_i(outenc_ind);
-                end if;
+                slow_tlp_o.data <= OUTENC_PROT_i(outenc_ind);
                 slow_tlp_o.address <= OUTPROT_ADDR_LIST(outenc_ind);
             -- TTLIN TERM Slow Registers
             elsif (or_reduce(TTLIN_TERM_WSTB_i) = '1') then
@@ -109,9 +101,12 @@ begin
                 slow_tlp_o.strobe <= '1';
                 slow_tlp_o.data <= TTLIN_TERM_i(ttlin_ind);
                 slow_tlp_o.address <= TTLTERM_ADDR_LIST(ttlin_ind);
+            else
+                slow_tlp_o.strobe <= '0';
             end if;
         end if;
     end if;
 end process;
 
 end rtl;
+

--- a/modules/system/hdl/system_top.vhd
+++ b/modules/system/hdl/system_top.vhd
@@ -120,7 +120,6 @@ system_registers : entity work.system_registers
 port map (
     clk_i   => clk_i,
     reset_i => reset_i,
-    DCARD_MODE_i => DCARD_MODE,
     OUTENC_PROT_i => OUTENC_PROT_i,
     OUTENC_PROT_WSTB_i => OUTENC_PROT_WSTB_i,
     INENC_PROT_i => INENC_PROT_i,


### PR DESCRIPTION
* Removed over-riding of protocol codes
* OUTENC forced to follow INENC for MONITOR cards
* Added checking of readback INENC and OUTENC codes

See also corresponding PR in SlowFPGA repO:
https://github.com/PandABlocks/PandABlocks-slowFPGA/pull/1