### PR TITLE
Remove over-riding of ctrl block ack ports where feasible

### DIFF
--- a/common/hdl/encoders/encoders_top.vhd
+++ b/common/hdl/encoders/encoders_top.vhd
@@ -68,24 +68,26 @@ signal OUTENC_read_strobe       : std_logic_vector(ENC_NUM-1 downto 0);
 signal OUTENC_read_data         : std32_array(ENC_NUM-1 downto 0);
 signal OUTENC_write_strobe      : std_logic_vector(ENC_NUM-1 downto 0);
 signal OUTENC_read_ack          : std_logic_vector(ENC_NUM-1 downto 0);
+signal OUTENC_write_ack         : std_logic_vector(ENC_NUM-1 downto 0);
 
 signal INENC_read_strobe        : std_logic_vector(ENC_NUM-1 downto 0);
 signal INENC_read_data          : std32_array(ENC_NUM-1 downto 0);
 signal INENC_write_strobe       : std_logic_vector(ENC_NUM-1 downto 0);
 signal posn                     : std32_array(ENC_NUM-1 downto 0);
 signal INENC_read_ack           : std_logic_vector(ENC_NUM-1 downto 0);
+signal INENC_write_ack          : std_logic_vector(ENC_NUM-1 downto 0);
 
 begin
 
 -- Acknowledgement to AXI Lite interface
-OUTENC_write_ack_o <= '1';
+OUTENC_write_ack_o <= or_reduce(OUTENC_write_ack);
 OUTENC_read_ack_o <= or_reduce(OUTENC_read_ack);
 
 -- Multiplex read data out from multiple instantiations
 OUTENC_read_data_o <= OUTENC_read_data(to_integer(unsigned(read_address_i(PAGE_AW-1 downto BLK_AW))));
 
 -- Acknowledgement to AXI Lite interface
-INENC_write_ack_o <= '1';
+INENC_write_ack_o <= or_reduce(INENC_write_ack);
 INENC_read_ack_o <= or_reduce(INENC_read_ack);
 
 -- Multiplex read data out from multiple instantiations
@@ -118,14 +120,14 @@ port map (
     OUTENC_read_ack_o       => OUTENC_read_ack(I),
 
     OUTENC_write_strobe_i   => OUTENC_write_strobe(I),
-    OUTENC_write_ack_o      => open,
+    OUTENC_write_ack_o      => OUTENC_write_ack(I),
 
     INENC_read_strobe_i     => INENC_read_strobe(I),
     INENC_read_data_o       => INENC_read_data(I),
     INENC_read_ack_o        => INENC_read_ack(I),
 
     INENC_write_strobe_i    => INENC_write_strobe(I),
-    INENC_write_ack_o       => open,
+    INENC_write_ack_o       => INENC_write_ack(I),
 
     read_address_i          => read_address_i(BLK_AW-1 downto 0),
 

--- a/common/templates/block_ctrl.vhd.jinja2
+++ b/common/templates/block_ctrl.vhd.jinja2
@@ -77,6 +77,8 @@ begin
         DELAY_i       => RD_ADDR2ACK
     );
 
+    write_ack_o <= '1';
+
     -- Control System Register Interface
     REG_WRITE : process(clk_i)
     begin

--- a/common/templates/block_wrapper.vhd.jinja2
+++ b/common/templates/block_wrapper.vhd.jinja2
@@ -80,11 +80,12 @@ signal write_strobe     : std_logic_vector(NUM-1 downto 0);
 signal read_addr        : natural range 0 to (2**read_address_i'length - 1);
 signal write_addr       : natural range 0 to (2**write_address_i'length - 1);
 signal read_ack         : std_logic_vector(NUM-1 downto 0);
+signal write_ack        : std_logic_vector(NUM-1 downto 0);
 
 begin
 
     -- Acknowledgement to AXI Lite interface
-    write_ack_o <= '1';
+    write_ack_o <= or_reduce(write_ack);
     read_ack_o <= or_reduce(read_ack);
     read_data_o <= read_data(to_integer(unsigned(read_address_i(PAGE_AW-1 downto BLK_AW))));
 
@@ -126,7 +127,7 @@ begin
             write_strobe_i      => write_strobe(I),
             write_address_i     => write_address_i(BLK_AW-1 downto 0),
             write_data_i        => write_data_i,
-            write_ack_o         => open
+            write_ack_o         => write_ack(I)
         );
 
         -- Connect to the actual logic entity

--- a/modules/fmc_24vio/hdl/fmc_24vio_wrapper.vhd
+++ b/modules/fmc_24vio/hdl/fmc_24vio_wrapper.vhd
@@ -49,7 +49,7 @@ port (
     write_strobe_i      : in  std_logic;
     write_address_i     : in  std_logic_vector(PAGE_AW-1 downto 0);
     write_data_i        : in  std_logic_vector(31 downto 0);
-    write_ack_o         : out std_logic := '1';
+    write_ack_o         : out std_logic;
     FMC_i               : in  fmc_input_interface;
     FMC_io              : inout fmc_inout_interface := FMC_io_init
 );
@@ -74,18 +74,6 @@ signal fmc_in           : std_logic_vector(7 downto 0);
 signal fmc_out          : std_logic_vector(7 downto 0);
 
 begin
-
--- Acknowledgement to AXI Lite interface
-write_ack_o <= '1';
-
-read_ack_delay : entity work.delay_line
-generic map (DW => 1)
-port map (
-    clk_i       => clk_i,
-    data_i(0)   => read_strobe_i,
-    data_o(0)   => read_ack_o,
-    DELAY_i     => RD_ADDR2ACK
-);
 
 ---------------------------------------------------------------------------
 -- FMC CSR Interface
@@ -125,12 +113,12 @@ port map (
     read_strobe_i       => read_strobe_i,
     read_address_i      => read_address_i(BLK_AW-1 downto 0),
     read_data_o         => read_data_o,
-    read_ack_o          => open,
+    read_ack_o          => read_ack_o,
 
     write_strobe_i      => write_strobe_i,
     write_address_i     => write_address_i(BLK_AW-1 downto 0),
     write_data_i        => write_data_i,
-    write_ack_o         => open
+    write_ack_o         => write_ack_o
 );
 
 ---------------------------------------------------------------------------

--- a/modules/fmc_acq427/hdl/fmc_acq427_wrapper.vhd
+++ b/modules/fmc_acq427/hdl/fmc_acq427_wrapper.vhd
@@ -49,7 +49,7 @@ port (
     write_strobe_i      : in  std_logic;
     write_address_i     : in  std_logic_vector(PAGE_AW-1 downto 0);
     write_data_i        : in  std_logic_vector(31 downto 0);
-    write_ack_o         : out std_logic := '1';
+    write_ack_o         : out std_logic;
     FMC_io              : inout fmc_inout_interface
 );
 end fmc_acq427_wrapper;
@@ -299,12 +299,12 @@ port map (
     read_strobe_i       => read_strobe_i,
     read_address_i      => read_address_i(BLK_AW-1 downto 0),
     read_data_o         => read_data_o,
-    read_ack_o          => open,
+    read_ack_o          => read_ack_o,
 
     write_strobe_i      => write_strobe_i,
     write_address_i     => write_address_i(BLK_AW-1 downto 0),
     write_data_i        => write_data_i,
-    write_ack_o         => open
+    write_ack_o         => write_ack_o
 );
 
 

--- a/modules/fmc_acq430/hdl/fmc_acq430_wrapper.vhd
+++ b/modules/fmc_acq430/hdl/fmc_acq430_wrapper.vhd
@@ -121,10 +121,6 @@ attribute IOB       of s_ADC_SDO        : signal is "true";
 
 begin
 
--- Acknowledgement to AXI Lite interface
-write_ack_o <= '1';
-
-
 -- Control register interface
 -- Not actually used but added for consistency with other modules
 fmc_ctrl: entity work.fmc_acq430_ctrl
@@ -139,12 +135,12 @@ port map(
     read_strobe_i =>    read_strobe_i,
     read_address_i =>   read_address_i(BLK_AW-1 downto 0),
     read_data_o =>      read_data_o,
-    read_ack_o =>       open,
+    read_ack_o =>       read_ack_o,
 
     write_strobe_i =>   write_strobe_i,
     write_address_i =>  write_address_i(BLK_AW-1 downto 0),
     write_data_i =>     write_data_i,
-    write_ack_o =>      open
+    write_ack_o =>      write_ack_o
 );
 
 

--- a/modules/fmc_loopback/hdl/fmc_loopback_wrapper.vhd
+++ b/modules/fmc_loopback/hdl/fmc_loopback_wrapper.vhd
@@ -104,18 +104,6 @@ port map (
     O => FMC_o.TXP_OUT
 );
 
--- Acknowledgement to AXI Lite interface
-write_ack_o <= '1';
-
-read_ack_delay : entity work.delay_line
-generic map (DW => 1)
-port map (
-    clk_i       => clk_i,
-    data_i(0)   => read_strobe_i,
-    data_o(0)   => read_ack_o,
-    DELAY_i     => RD_ADDR2ACK
-);
-
 -- Multiplex read data out from multiple instantiations
 
 -- Generate prescaled clock for internal counter
@@ -260,12 +248,12 @@ port map (
     read_strobe_i       => read_strobe_i,
     read_address_i      => read_address_i(BLK_AW-1 downto 0),
     read_data_o         => read_data_o,
-    read_ack_o          => open,
+    read_ack_o          => read_ack_o,
 
     write_strobe_i      => write_strobe_i,
     write_address_i     => write_address_i(BLK_AW-1 downto 0),
     write_data_i        => write_data_i,
-    write_ack_o         => open
+    write_ack_o         => write_ack_o
 );
 
 end rtl;

--- a/modules/lvdsout/hdl/lvdsout_top.vhd
+++ b/modules/lvdsout/hdl/lvdsout_top.vhd
@@ -50,10 +50,12 @@ signal read_strobe      : std_logic_vector(LVDSOUT_NUM-1 downto 0);
 signal read_data        : std32_array(LVDSOUT_NUM-1 downto 0);
 signal write_strobe     : std_logic_vector(LVDSOUT_NUM-1 downto 0);
 signal read_ack         : std_logic_vector(LVDSOUT_NUM-1 downto 0);
+signal write_ack        : std_logic_vector(LVDSOUT_NUM-1 downto 0);
+
 begin
 
 -- Acknowledgement to AXI Lite interface
-write_ack_o <= '1';
+write_ack_o <= or_reduce(write_ack);
 read_ack_o <= or_reduce(read_ack);
 
 --
@@ -80,7 +82,7 @@ port map (
     write_strobe_i      => write_strobe(I),
     write_address_i     => write_address_i(BLK_AW-1 downto 0),
     write_data_i        => write_data_i,
-    write_ack_o         => open,
+    write_ack_o         => write_ack(I),
     -- Block inputs
     bit_bus_i           => bit_bus_i,
     -- Block outputs

--- a/modules/pcap/hdl/pcap_core_ctrl.vhd
+++ b/modules/pcap/hdl/pcap_core_ctrl.vhd
@@ -63,6 +63,18 @@ signal read_address     : natural range 0 to (2**read_address_i'length - 1);
 
 begin
 
+-- Acknowledgement to AXI Lite interface
+write_ack_o <= '1';
+
+read_ack_delay : entity work.delay_line
+generic map (DW => 1)
+port map (
+    clk_i       => clk_i,
+    data_i(0)   => read_strobe_i(DRV_CS),
+    data_o(0)   => read_ack_o,
+    DELAY_i     => RD_ADDR2ACK
+);
+
 -- Integer conversion for address.
 read_address <= to_integer(unsigned(read_address_i));
 write_address <= to_integer(unsigned(write_address_i));

--- a/modules/pcap/hdl/pcap_top.vhd
+++ b/modules/pcap/hdl/pcap_top.vhd
@@ -123,23 +123,6 @@ signal pos_bus_i_dyd    : pos_bus_t; -- pos_bus_i delayed
 
 begin
 
--- This module handles multiple register address spaces
--- Acknowledgement to AXI Lite interface
-write_ack_0_o <= '1';
-write_ack_1_o <= '1';
-
-
-read_ack_1 : entity work.delay_line
-generic map (DW => 1)
-port map (
-    clk_i       => clk_i,
-    data_i(0)   => read_strobe_i(DRV_CS),
-    data_o(0)   => read_ack_1_o,
-    DELAY_i     => RD_ADDR2ACK
-);
-
--- Multiplex read data out from multiple instantiations
-
 pcap_actv_o <= pcap_active;
 
 --------------------------------------------------------------------------
@@ -170,7 +153,7 @@ port map (
     write_strobe_i      => write_strobe_i(PCAP_CS),
     write_address_i     => write_address_i(BLK_AW-1 downto 0),
     write_data_i        => write_data_i,
-    write_ack_o         => open
+    write_ack_o         => write_ack_0_o
 );
 
 --------------------------------------------------------------------------
@@ -181,15 +164,15 @@ port map (
     clk_i               => clk_i,
     reset_i             => reset_i,
 
-    read_strobe_i       => (others => '0'),
+    read_strobe_i       => read_strobe_i,
     read_address_i      => read_address_i,
     read_data_o         => read_data_1_o,
-    read_ack_o          => open,
+    read_ack_o          => read_ack_1_o,
 
     write_strobe_i      => write_strobe_i,
     write_address_i     => write_address_i,
     write_data_i        => write_data_i,
-    write_ack_o         => open,
+    write_ack_o         => write_ack_1_o,
 
     START_WRITE         => START_WRITE,
     WRITE               => WRITE,

--- a/modules/sfp_eventr/hdl/sfp_dls_eventr_wrapper.vhd
+++ b/modules/sfp_eventr/hdl/sfp_dls_eventr_wrapper.vhd
@@ -31,7 +31,7 @@ port (
     write_strobe_i      : in  std_logic;
     write_address_i     : in  std_logic_vector(PAGE_AW-1 downto 0);
     write_data_i        : in  std_logic_vector(31 downto 0);
-    write_ack_o         : out std_logic := '1';
+    write_ack_o         : out std_logic;
 
     SFP_i               : in SFP_input_interface;
     SFP_o               : out SFP_output_interface
@@ -131,16 +131,6 @@ bit1_o(0) <= bit1;
 bit2_o(0) <= bit2;
 bit3_o(0) <= bit3;
 bit4_o(0) <= bit4;
-
-
-read_ack_delay : entity work.delay_line
-generic map (DW => 1)
-port map (
-    clk_i       => clk_i,
-    data_i(0)   => read_strobe_i,
-    data_o(0)   => read_ack_o,
-    DELAY_i     => RD_ADDR2ACK
-);
 
 sfp_transmitter_inst: entity work.sfp_transmitter
 port map(
@@ -312,12 +302,12 @@ port map (
     read_strobe_i     => read_strobe_i,
     read_address_i    => read_address_i(BLK_AW-1 downto 0),
     read_data_o       => read_data_o,
-    read_ack_o        => open,
+    read_ack_o        => read_ack_o,
 
     write_strobe_i    => write_strobe_i,
     write_address_i   => write_address_i(BLK_AW-1 downto 0),
     write_data_i      => write_data_i,
-    write_ack_o       => open
+    write_ack_o       => write_ack_o
 );
 
 end rtl;

--- a/modules/sfp_loopback/hdl/sfp_loopback_wrapper.vhd
+++ b/modules/sfp_loopback/hdl/sfp_loopback_wrapper.vhd
@@ -24,7 +24,7 @@ port (
     write_strobe_i      : in  std_logic;
     write_address_i     : in  std_logic_vector(PAGE_AW-1 downto 0);
     write_data_i        : in  std_logic_vector(31 downto 0);
-    write_ack_o         : out std_logic := '1';
+    write_ack_o         : out std_logic;
 
     -- SFP Interface
     SFP_i               : in SFP_input_interface;
@@ -58,15 +58,6 @@ txpobuf : obuf
 port map (
     I => TXP,
     O => SFP_o.TXP_OUT
-);
-
-read_ack_delay : entity work.delay_line
-generic map (DW => 1)
-port map (
-    clk_i       => clk_i,
-    data_i(0)   => read_strobe_i,
-    data_o(0)   => read_ack_o,
-    DELAY_i     => RD_ADDR2ACK
 );
 
 --
@@ -129,12 +120,12 @@ port map (
     read_strobe_i               => read_strobe_i,
     read_address_i              => read_address_i(BLK_AW-1 downto 0),
     read_data_o                 => read_data_o,
-    read_ack_o                  => open,
+    read_ack_o                  => read_ack_o,
 
     write_strobe_i              => write_strobe_i,
     write_address_i             => write_address_i(BLK_AW-1 downto 0),
     write_data_i                => write_data_i,
-    write_ack_o                 => open
+    write_ack_o                 => write_ack_o
 );
 
 end rtl;

--- a/modules/sfp_panda_sync/hdl/sfp_panda_sync_wrapper.vhd
+++ b/modules/sfp_panda_sync/hdl/sfp_panda_sync_wrapper.vhd
@@ -110,9 +110,6 @@ port map (
 SFP_o.MGT_REC_CLK <= rxoutclk_buf;
 SFP_o.LINK_UP <= LINKUP(0);
 
-read_ack_o <= '1';
-write_ack_o <= '1';
-
 IN_BIT8_o(0) <= BITIN(7);
 IN_BIT7_o(0) <= BITIN(6);
 IN_BIT6_o(0) <= BITIN(5);
@@ -288,12 +285,12 @@ sfp_panda_sync_ctrl_inst : entity work.sfp_panda_sync_ctrl
         read_strobe_i       => read_strobe_i,
         read_address_i      => read_address_i(BLK_AW-1 downto 0),
         read_data_o         => read_data_o,
-        read_ack_o          => open,
+        read_ack_o          => read_ack_o,
 
         write_strobe_i      => write_strobe_i,
         write_address_i     => write_address_i(BLK_AW-1 downto 0),
         write_data_i        => write_data_i,
-        write_ack_o         => open
+        write_ack_o         => write_ack_o
         );
 
 end rtl;                

--- a/modules/sfp_udpontrig/hdl/sfp_udpontrig_wrapper.vhd
+++ b/modules/sfp_udpontrig/hdl/sfp_udpontrig_wrapper.vhd
@@ -51,7 +51,7 @@ entity sfp_udpontrig_wrapper is
     write_strobe_i      : in  std_logic;
     write_address_i     : in  std_logic_vector(PAGE_AW-1 downto 0);
     write_data_i        : in  std_logic_vector(31 downto 0);
-    write_ack_o         : out std_logic := '1';
+    write_ack_o         : out std_logic;
 
     -- SFP Interface
     SFP_i               : in  SFP_input_interface;
@@ -154,17 +154,6 @@ begin
 TXN_OBUF_i : OBUF port map ( I => TXN_O, O => SFP_o.TXN_OUT );
 TXP_OBUF_I : OBUF port map ( I => TXP_O, O => SFP_o.TXP_OUT );
 
-
-read_ack_delay : entity work.delay_line
-  generic map (
-    DW => 1
-  )
-  port map (
-    clk_i       => clk_i,
-    data_i(0)   => read_strobe_i,
-    data_o(0)   => read_ack_o,
-    DELAY_i     => RD_ADDR2ACK
-  );
 
 our_ip_address    <= our_ip_address_byte1(7 downto 0)  &  our_ip_address_byte2(7 downto 0)  &  our_ip_address_byte3(7 downto 0) &  our_ip_address_byte4(7 downto 0);
 dest_ip_address   <= dest_ip_address_byte1(7 downto 0) & dest_ip_address_byte2(7 downto 0)  & dest_ip_address_byte3(7 downto 0) & dest_ip_address_byte4(7 downto 0);
@@ -284,12 +273,12 @@ sfp_ctrl : entity work.sfp_udpontrig_ctrl
     read_strobe_i               => read_strobe_i,
     read_address_i              => read_address_i(BLK_AW-1 downto 0),
     read_data_o                 => read_data_o,
-    read_ack_o                  => open,
+    read_ack_o                  => read_ack_o,
 
     write_strobe_i              => write_strobe_i,
     write_address_i             => write_address_i(BLK_AW-1 downto 0),
     write_data_i                => write_data_i,
-    write_ack_o                 => open
+    write_ack_o                 => write_ack_o
 );
 
 end rtl;

--- a/modules/ttlin/hdl/ttlin_top.vhd
+++ b/modules/ttlin/hdl/ttlin_top.vhd
@@ -52,11 +52,12 @@ signal read_strobe      : std_logic_vector(TTLIN_NUM-1 downto 0);
 signal read_data        : std32_array(TTLIN_NUM-1 downto 0);
 signal write_strobe     : std_logic_vector(TTLIN_NUM-1 downto 0);
 signal read_ack         : std_logic_vector(TTLIN_NUM-1 downto 0);
+signal write_ack        : std_logic_vector(TTLIN_NUM-1 downto 0);
 
 begin
 
 -- Acknowledgement to AXI Lite interface
-write_ack_o <= '1';
+write_ack_o <= or_reduce(write_ack);
 read_ack_o <= or_reduce(read_ack);
 
 
@@ -81,7 +82,7 @@ port map (
     write_strobe_i      => write_strobe(I),
     write_address_i     => write_address_i(BLK_AW-1 downto 0),
     write_data_i        => write_data_i,
-    write_ack_o         => open,
+    write_ack_o         => write_ack(I),
     -- Block inputs
     bit_bus_i           => bit_bus_i,
     pos_bus_i           => pos_bus_i,

--- a/modules/ttlout/hdl/ttlout_top.vhd
+++ b/modules/ttlout/hdl/ttlout_top.vhd
@@ -51,11 +51,12 @@ signal read_strobe      : std_logic_vector(TTLOUT_NUM-1 downto 0);
 signal read_data        : std32_array(TTLOUT_NUM-1 downto 0);
 signal write_strobe     : std_logic_vector(TTLOUT_NUM-1 downto 0);
 signal read_ack         : std_logic_vector(TTLOUT_NUM-1 downto 0);
+signal write_ack        : std_logic_vector(TTLOUT_NUM-1 downto 0);
 
 begin
 
 -- Acknowledgement to AXI Lite interface
-write_ack_o <= '1';
+write_ack_o <= or_reduce(write_ack);
 read_ack_o <= or_reduce(read_ack);
 
 
@@ -83,7 +84,7 @@ port map (
     write_strobe_i      => write_strobe(I),
     write_address_i     => write_address_i(BLK_AW-1 downto 0),
     write_data_i        => write_data_i,
-    write_ack_o         => open,
+    write_ack_o         => write_ack(I),
     -- Block inputs
     bit_bus_i           => bit_bus_i,
     -- Block outputs

--- a/modules/us_system/hdl/us_system_top.vhd
+++ b/modules/us_system/hdl/us_system_top.vhd
@@ -25,7 +25,6 @@ end us_system_top;
 
 architecture rtl of us_system_top is
 begin
-write_ack_o <= '1';
 
 us_system_ctrl_inst : entity work.us_system_ctrl
 port map(
@@ -42,6 +41,6 @@ port map(
     write_strobe_i      => write_strobe_i,
     write_address_i     => write_address_i(BLK_AW-1 downto 0),
     write_data_i        => write_data_i,
-    write_ack_o         => open
+    write_ack_o         => write_ack_o
 );
 end rtl;

--- a/modules/zedboard_demo/hdl/zedboard_demo_top.vhd
+++ b/modules/zedboard_demo/hdl/zedboard_demo_top.vhd
@@ -39,12 +39,9 @@ signal SWITCH_STAT         : std_logic_vector(31 downto 0);
 
 begin
 
-write_ack_o <= '1';
-
 SWITCH_STAT <= ZEROS(24) & SW;
 
 led <= SW when LED_SELECT(0) = '1' else LED_SET(7 downto 0);
-
 
 zedboard_demo_ctrl_inst : entity work.zedboard_demo_ctrl
 port map(
@@ -67,7 +64,7 @@ port map(
     write_strobe_i      => write_strobe_i,
     write_address_i     => write_address_i(BLK_AW-1 downto 0),
     write_data_i        => write_data_i,
-    write_ack_o         => open
+    write_ack_o         => write_ack_o
 );
 
 end rtl;

--- a/tests/python/test_data/app-expected/hdl/lut_ctrl.vhd
+++ b/tests/python/test_data/app-expected/hdl/lut_ctrl.vhd
@@ -98,6 +98,8 @@ begin
         DELAY_i       => RD_ADDR2ACK
     );
 
+    write_ack_o <= '1';
+
     -- Control System Register Interface
     REG_WRITE : process(clk_i)
     begin

--- a/tests/python/test_data/app-expected/hdl/lut_wrapper.vhd
+++ b/tests/python/test_data/app-expected/hdl/lut_wrapper.vhd
@@ -89,11 +89,12 @@ signal write_strobe     : std_logic_vector(NUM-1 downto 0);
 signal read_addr        : natural range 0 to (2**read_address_i'length - 1);
 signal write_addr       : natural range 0 to (2**write_address_i'length - 1);
 signal read_ack         : std_logic_vector(NUM-1 downto 0);
+signal write_ack        : std_logic_vector(NUM-1 downto 0);
 
 begin
 
     -- Acknowledgement to AXI Lite interface
-    write_ack_o <= '1';
+    write_ack_o <= or_reduce(write_ack);
     read_ack_o <= or_reduce(read_ack);
     read_data_o <= read_data(to_integer(unsigned(read_address_i(PAGE_AW-1 downto BLK_AW))));
 
@@ -138,7 +139,7 @@ begin
             write_strobe_i      => write_strobe(I),
             write_address_i     => write_address_i(BLK_AW-1 downto 0),
             write_data_i        => write_data_i,
-            write_ack_o         => open
+            write_ack_o         => write_ack(I)
         );
 
         -- Connect to the actual logic entity

--- a/tests/python/test_data_calc_extensions/app-expected/hdl/dummy_ctrl.vhd
+++ b/tests/python/test_data_calc_extensions/app-expected/hdl/dummy_ctrl.vhd
@@ -57,6 +57,8 @@ begin
         DELAY_i       => RD_ADDR2ACK
     );
 
+    write_ack_o <= '1';
+
     -- Control System Register Interface
     REG_WRITE : process(clk_i)
     begin

--- a/tests/python/test_data_calc_extensions/app-expected/hdl/fmc_acq427_ctrl.vhd
+++ b/tests/python/test_data_calc_extensions/app-expected/hdl/fmc_acq427_ctrl.vhd
@@ -83,6 +83,8 @@ begin
         DELAY_i       => RD_ADDR2ACK
     );
 
+    write_ack_o <= '1';
+
     -- Control System Register Interface
     REG_WRITE : process(clk_i)
     begin

--- a/tests/python/test_data_calc_extensions/app-expected/hdl/interval_ctrl.vhd
+++ b/tests/python/test_data_calc_extensions/app-expected/hdl/interval_ctrl.vhd
@@ -55,6 +55,8 @@ begin
         DELAY_i       => RD_ADDR2ACK
     );
 
+    write_ack_o <= '1';
+
     -- Control System Register Interface
     REG_WRITE : process(clk_i)
     begin


### PR DESCRIPTION
* write_ack now set in ctrl block and not wrapper
* read_ack over-riding removed for hardware blocks
* read_ack added to modules which did not have one previously

The only blocks which treat the `acks` differenently are `system` due to the slow FPGA registers, and `pcap` due to the DRV block.

NB: I checked this built for all zpkgs and tested one zpkg on hardware and it worked fine, but just noticed this is failing the python tests on PR. I think I can fix this before merging.