### PR TITLE
Don't waste time in `pcap_dma`

### DIFF
--- a/modules/pcap/hdl/pcap_dma.vhd
+++ b/modules/pcap/hdl/pcap_dma.vhd
@@ -337,7 +337,7 @@ if rising_edge(clk_i) then
                         goto_do_dma;
                     end if;
                 -- At least 1 TLP in available the queue
-                elsif (fifo_count >= AXI_BURST_LEN and writing_sample = '0') then
+                elsif (fifo_count >= AXI_BURST_LEN) then
                     goto_do_dma;
                 -- Position compare completed
                 elsif (pcap_completed = '1' and writing_sample = '0') then


### PR DESCRIPTION
There is no reason to not start transfering to memory if we have more than 1 burst worth of data in the fifo.