### PR TITLE
Allow each target to define the way to obtain its MAC address

### DIFF
--- a/common/fpga.make
+++ b/common/fpga.make
@@ -99,7 +99,7 @@ carrier_ip: $(APP_IP_DEPS)
 ps_core: $(PS_CORE)
 devicetree : $(DEVTREE_DTB)
 fsbl : $(FSBL)
-boot : $(BOOT_ZIP) $(IMAGE_DIR)/boot.bin $(DEVTREE_DTB)
+boot : $(BOOT_ZIP) $(IMAGE_DIR)/boot.bin $(DEVTREE_DTB) $(IMAGE_DIR)/target-defs
 u-boot: $(U_BOOT_ELF)
 atf: $(ATF_ELF)
 dtc: $(DEVTREE_DTC)
@@ -246,6 +246,9 @@ $(DEVTREE_DTB): $(SDK_EXPORT) $(TARGET_DTS) $(DEVTREE_DTC)
 	  -o $(DEVTREE_DTS)/system-top.dts.tmp $(DEVTREE_DTS)/system-top.dts
 	@echo "Building DEVICE TREE blob ..."
 	$(DEVTREE_DTC) -f -I dts -O dtb -o $@ $(DEVTREE_DTS)/$(notdir $(TARGET_DTS))
+
+$(IMAGE_DIR)/target-defs: $(TARGET_DIR)/etc/target-defs
+	cp $< $@
 
 $(DEVTREE_DTC): $(DTC_SRC)
 	$(MAKE) -C $(SRC_ROOT)/dtc-$(DTC_TAG) NO_PYTHON=1

--- a/targets/PandABox/etc/target-defs
+++ b/targets/PandABox/etc/target-defs
@@ -1,4 +1,8 @@
 #!/bin/sh
+# LED daemon definitions
+LED_GPIO_BASE=906
+STA_LED_OFFSET=51
+DIA_LED_OFFSET=50
 
 get_mac_address()
 {

--- a/targets/PandABox/etc/target-defs
+++ b/targets/PandABox/etc/target-defs
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+get_mac_address()
+{
+    cat /qspi/MAC
+}

--- a/targets/PandABox/target-top.dts
+++ b/targets/PandABox/target-top.dts
@@ -61,10 +61,6 @@
 };
 
 / {
-	led_daemon: led_daemon {
-		sta-led = "51";
-		dia-led = "50";
-	};
 	amba_pl: amba_pl {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/targets/PandABrick/etc/atsha240a-gen.py
+++ b/targets/PandABrick/etc/atsha240a-gen.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# this script generates a read command's data for the secure EEPROM atsha240a
+#
+# Find datasheet in:
+# https://ww1.microchip.com/downloads/en/DeviceDoc/ATSHA204A-Data-Sheet-40002025A.pdf
+# Product page:
+# https://www.microchip.com/en-us/product/ATSHA204A
+
+import argparse
+
+# Usual request is form of:
+# WORD_ADDRESS + SIZE + OPCODE + PARAM1 + PARAM2 + CRC16
+SIZE_OF_WORD_ADDRESS = 1
+SIZE_OF_SIZE = 1
+SIZE_OF_OPCODE = 1
+SIZE_OF_PARAM1 = 1
+SIZE_OF_PARAM2 = 2
+SIZE_OF_CHECKSUM = 2
+
+# Word address byte
+# "Reset the address counter. The next read or write transaction starts with the
+#  beginning of the I/O buffer.", this could be useful to reread the data
+WORD_ADDRESS_RESET = 0x0
+# "Write subsequent bytes to sequential addresses in the input command buffer
+#  that follow previous writes. This is the normal operation."
+WORD_ADDRESS_COMMAND = 0x3
+WORD_ADDRESS_SIZE = 1
+
+# Opcode byte
+# Read 4 or 32 bytes from the device
+OPCODE_READ = 0x2
+# Write 4 or 32 bytes from the device
+OPCODE_WRITE = 0x12
+
+# Size byte
+READ_REQUEST_SIZE = SIZE_OF_SIZE + SIZE_OF_OPCODE \
+    + SIZE_OF_PARAM1 + SIZE_OF_PARAM2 + SIZE_OF_CHECKSUM
+
+
+PARAM1_ZONE_CONFIG = 0x00
+PARAM1_ZONE_OTP = 0x01
+PARAM1_ZONE_DATA = 0x02
+PARAM1_32B_REQUEST = 0x80
+
+PARAM2_BLOCK_BIT_OFFSET = 3
+PARAM2_OFFSET_BIT_OFFSET = 0
+# Second byte of param2 is always 0
+PARAM2_BYTE2 = 0
+
+
+def zone_arg_to_param1(opt):
+    if opt == 'config':
+        return PARAM1_ZONE_CONFIG
+
+    if opt == 'data':
+        return PARAM1_ZONE_DATA
+
+    return PARAM1_ZONE_OTP
+
+
+def int_or_hex(opt):
+    if opt.startswith('0x'):
+        return int(opt, 16)
+    else:
+        return int(opt)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--zone', choices=['config', 'otp', 'data'],
+                        default='otp')
+    parser.add_argument('--block', type=int_or_hex, default=0,
+                        help='Specify the block to read or write')
+    return parser.parse_args()
+
+
+def crc16(data):
+    res = 0
+    for b in data:
+        for i in range(8):
+            data_bit = (b >> i) & 1
+            crc_bit = (res >> 15) & 1
+            res <<= 1
+            if data_bit ^ crc_bit:
+                res ^= 0x8005
+
+    return res & 0xffff
+
+
+def main():
+    args = parse_args()
+    data = bytearray()
+    data.append(WORD_ADDRESS_COMMAND)
+    data.append(READ_REQUEST_SIZE)
+    data.append(OPCODE_READ)
+    data.append(PARAM1_32B_REQUEST | zone_arg_to_param1(args.zone))
+    # Given we are reading 32 bytes, offset is 0 (alignment is mandatory)
+    data.append(args.block << PARAM2_BLOCK_BIT_OFFSET)
+    data.append(PARAM2_BYTE2)
+    # crc doesn't cover the first byte
+    crc_val = crc16(bytes(data[1:]))
+    data.append(crc_val & 0xff)
+    data.append((crc_val >> 8) & 0xff)
+    # print the result hex-formatted
+    for item in bytes(data):
+        print(f'0x{item:02x} ', end='')
+    print()
+
+
+if __name__ == '__main__':
+    main()

--- a/targets/PandABrick/etc/target-defs
+++ b/targets/PandABrick/etc/target-defs
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+get_mac_address() {
+    # Trying to address 0 sends a 0 byte which wakes up the EEPROM
+    i2ctransfer -a -y 0 r1@0x0 &>/dev/null
+    # Send command to read 32 bytes of OTP zone starting at offset 0
+    # See script atsha240a-gen for more information, it was used to
+    # generate the bytes in the request
+    i2ctransfer -y 0 w8@0x64  0x3 0x7 0x2 0x81 0x0 0x0 0x0a 0x27
+    # Reply structure: length(1b) + data(32b) + crc16(2b)
+    resp=$(i2ctransfer -y 0 r35@0x64)
+    # Extract the MAC address and format it
+    resp=${resp:85:29}
+    resp=${resp//0x/}
+    echo ${resp// /:}
+}

--- a/targets/PandABrick/etc/target-defs
+++ b/targets/PandABrick/etc/target-defs
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# LED daemon definitions
+LED_GPIO_BASE=334
+STA_LED_OFFSET=25
+DIA_LED_OFFSET=24
+
 get_mac_address() {
     # Trying to address 0 sends a 0 byte which wakes up the EEPROM
     i2ctransfer -a -y 0 r1@0x0 &>/dev/null

--- a/targets/ZedBoard/etc/target-defs
+++ b/targets/ZedBoard/etc/target-defs
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+# Disable led-daemon
+LED_GPIO_BASE=
+
 get_mac_address() { :; }

--- a/targets/ZedBoard/etc/target-defs
+++ b/targets/ZedBoard/etc/target-defs
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+get_mac_address() { :; }

--- a/targets/xu5_st1/etc/target-defs
+++ b/targets/xu5_st1/etc/target-defs
@@ -1,3 +1,8 @@
 #!/bin/sh
 
+# LED daemon definitions
+LED_GPIO_BASE=334
+STA_LED_OFFSET=25
+DIA_LED_OFFSET=24
+
 get_mac_address() { :; }

--- a/targets/xu5_st1/etc/target-defs
+++ b/targets/xu5_st1/etc/target-defs
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+get_mac_address() { :; }

--- a/targets/xu5_st1/target-top.dts
+++ b/targets/xu5_st1/target-top.dts
@@ -36,10 +36,6 @@
 };
 
 / {
-	led_daemon: led_daemon {
-		sta-led = "25";
-		dia-led = "24";
-	};
 	amba_pl: amba_pl {
 		#address-cells = <1>;
 		#size-cells = <1>;


### PR DESCRIPTION
At the moment only 2 targets define it:
PandABox: MAC from a qspi memory
PandABrick: MAC from a secure EEPROM

This is part of a solution for issue PandABlocks/PandABlocks-FPGA#167 and it's related to https://github.com/PandABlocks/PandABlocks-rootfs/pull/49