### PR TITLE
xu5: show network status on the OLED display

### DIFF
--- a/targets/xu5_st1/etc/target-defs
+++ b/targets/xu5_st1/etc/target-defs
@@ -6,3 +6,22 @@ STA_LED_OFFSET=25
 DIA_LED_OFFSET=24
 
 get_mac_address() { :; }
+
+target_specific_start() {
+    # Show hostname, IP and link status in the OLED display
+    if [ -e /sys/class/graphics/fb0 ]; then
+        cat /sys/class/graphics/fb0/modes > /sys/class/graphics/fb0/mode
+        cat <<EOF > /var/run/show-status.sh
+#!/bin/sh
+while true; do
+    clear; hostname -s
+    ip addr show eth0 | head -n3 | tail -n1 | cut -d' ' -f 6
+    [ \$(cat /sys/class/net/eth0/carrier) -eq 1 ] &&
+        echo "Link up" || echo "Link down"
+    sleep 2
+done
+EOF
+        chmod +x /var/run/show-status.sh
+        fbpad /var/run/show-status.sh &
+    fi
+}

--- a/targets/xu5_st1/target-top.dts
+++ b/targets/xu5_st1/target-top.dts
@@ -3,10 +3,19 @@
 
 &sdhci1 {
 	disable-wp;
+	no-1-8-v;
 };
 
 &i2c0 {
 	clock-frequency = <100000>;
+	ssd1306: oled@0x3c {
+		compatible = "solomon,ssd1306";
+		reg = <0x3c>;
+		solomon,height = <64>;
+		solomon,width = <128>;
+		solomon,page-offset = <0>;
+		solomon,segment-no-remap;
+	};
 };
 
 &qspi {


### PR DESCRIPTION
This change only affect target xu5_st1 but can be easily ported to others. The display controller is a SSD1306.

fbpad(a frame buffer terminal emulator) is expected to by provided by the rootfs.