### PR TITLE
Fix for SSI and BiSS encoder modules to correctly detect encoder loss

### DIFF
--- a/common/hdl/encoders/biss_sniffer.vhd
+++ b/common/hdl/encoders/biss_sniffer.vhd
@@ -128,6 +128,7 @@ begin
         if (reset = '1') then
             biss_fsm <= IDLE;
             biss_frame <= '0';
+            link_up_o <= '0';
         else
             -- Unidirectional point-to-point BiSS communication
             case biss_fsm is
@@ -165,6 +166,7 @@ begin
             -- Set active biss frame flag for link disconnection
             if (biss_fsm = IDLE and serial_clock = '0') then
                 biss_frame <= '1';
+                link_up_o  <= '1';
             elsif (biss_fsm = TIMEOUT) then
                 biss_frame <= '0';
             end if;
@@ -322,7 +324,6 @@ end process;
 --   link_down
 --   Encoder CRC error
 --------------------------------------------------------------------------
-link_up_o <= link_up;
 health_o <= health_biss_sniffer;
 error_o <= crc_strobe when (crc /= crc_calc or nError(1) = '0') else '0';
 

--- a/common/hdl/encoders/ssi_error_detect.vhd
+++ b/common/hdl/encoders/ssi_error_detect.vhd
@@ -1,0 +1,58 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.support.all;
+
+entity ssi_error_detect is
+port ( 
+    clk_i           : in  std_logic;
+    serial_dat_i    : in  std_logic;
+    ssi_frame_i     : in  std_logic;
+    link_up_o       : out std_logic
+);
+end ssi_error_detect;
+
+architecture rtl of ssi_error_detect is
+
+constant ENCODER_TIMEOUT    : natural := 125 * 10; -- 10usec (Minimum timeout/2)
+
+signal ssi_frame_prev       : std_logic;
+signal timeout_cnt_en       : std_logic;
+signal timeout_ctr          : unsigned(LOG2(ENCODER_TIMEOUT-1) downto 0);
+signal frame_start          : std_logic;
+signal frame_end            : std_logic;
+
+begin
+
+frame_err_det: process(clk_i)
+begin
+    if rising_edge(clk_i) then
+
+        ssi_frame_prev <= ssi_frame_i;
+
+        if ssi_frame_i = '1' and ssi_frame_prev = '0' then -- rising edge
+            -- Encoder must drive the line high when IDLE
+            frame_start <= serial_dat_i;
+            timeout_cnt_en <= '0';
+        elsif ssi_frame_i = '0' and ssi_frame_prev = '1' then --falling edge
+            timeout_cnt_en <= '1';
+            timeout_ctr <= (others => '0');
+        elsif timeout_cnt_en = '1' then
+            if timeout_ctr = ENCODER_TIMEOUT-1 then
+                -- Encoder must drive the line low during TIMEOUT dwell time
+                frame_end <= serial_dat_i;
+                timeout_ctr <= (others => '0');
+                timeout_cnt_en <= '0';
+            else
+                timeout_ctr <= timeout_ctr + 1;
+            end if;
+        end if;
+
+        -- Link is up when line is high during IDLE and low during TIMEOUT
+        link_up_o <= frame_start and not frame_end;
+    end if;
+end process;
+
+end rtl;
+

--- a/common/hdl/encoders/ssi_sniffer.vhd
+++ b/common/hdl/encoders/ssi_sniffer.vhd
@@ -24,13 +24,13 @@ port (
     -- Configuration interface
     ENCODING        : in  std_logic_vector(1 downto 0);
     BITS            : in  std_logic_vector(7 downto 0);
-    link_up_o       : out std_logic;
-    error_o         : out std_logic;
+    error_o         : out std_logic := '0';
     -- Physical SSI interface
     ssi_sck_i       : in  std_logic;
     ssi_dat_i       : in  std_logic;
     -- Block outputs
-    posn_o          : out std_logic_vector(31 downto 0)
+    posn_o          : out std_logic_vector(31 downto 0);
+    ssi_frame_o     : out std_logic
 );
 end ssi_sniffer;
 
@@ -44,8 +44,6 @@ signal uBITS                : unsigned(7 downto 0);
 signal intBITS              : natural range 0 to 2**BITS'length-1;
 
 signal reset                : std_logic;
-signal serial_data_prev     : std_logic;
-signal serial_data_rise     : std_logic;
 signal serial_clock         : std_logic;
 signal serial_clock_prev    : std_logic;
 signal link_up              : std_logic;
@@ -58,8 +56,9 @@ signal serial_clock_rise    : std_logic;
 signal shift_counter        : unsigned(7 downto 0);
 signal shift_enabled        : std_logic;
 
-
 begin
+
+ssi_frame_o <= ssi_frame;
 
 --------------------------------------------------------------------------
 -- Internal signal assignments
@@ -76,14 +75,12 @@ process (clk_i)
 begin
     if (rising_edge(clk_i)) then
         serial_clock_prev <= serial_clock;
-        serial_data_prev <= serial_data;
     end if;
 end process;
 
 -- Shift source synchronous data on the Falling egde of clock
 serial_clock_fall <= not serial_clock and serial_clock_prev;
 serial_clock_rise <= serial_clock and not serial_clock_prev;
-serial_data_rise <= serial_data and not serial_data_prev;
 
 --------------------------------------------------------------------------
 -- Detect link if clock is asserted for > 5us.
@@ -178,12 +175,5 @@ begin
     end if;
 end process;
 
---------------------------------------------------------------------------
--- Module status outputs
---   link_down
---   Encoder CRC error
---------------------------------------------------------------------------
-link_up_o <= link_up;
-error_o <= '0'; -- n/a
-
 end rtl;
+

--- a/modules/inenc/inenc.block.ini
+++ b/modules/inenc/inenc.block.ini
@@ -85,7 +85,7 @@ type: read enum
 description: Table status
 0: OK
 1: Linkup error (=not CONN)
-2: Timeout error (for BISS, monitor SSI)
+2: Timeout error (for BISS, SSI)
 3: CRC error (for BISS)
 4: Error bit active (for BISS)
 5: ENDAT not implemented


### PR DESCRIPTION
* Encoder loss deduced from serial data from encoder not clock
* Loss detection common to master and sniffer
* For BiSS, just check for clock at startup as CRC will check data
* integrity. Serial clock is needed to interpret data frame.

CONN signal for SSI and BISS sniffer modules was showing as 1 (connected) when nothing was plugged into DB9 connectors.
This was because the 'serial_link_detect' module was looking for the clock signal staying high for 5us to verify the link, and then checking for rising edges during the active period, following the first falling edge. The RS-485 line drivers read high on the line when nothing is connected, so it satisfied the first condition and the initial falling edge for the frame never arrives.

For SSI_master the CONN signal was previously hard-wired to '0'.

Changed both SSI_master and SSI_sniffer to look at the data signal (not the clock) and check for initial high level, and subsequent low approximately mid-way through the 20 us timeout period. Unfortunately, this still requires the serial clock (to define the frame), so if the clock goes away, CONN will stay high. This is not a problem for the SSI_master as the clock is generated by the FPGA (so can't go away) and for the sniffer this would represent the PMAC being disconnected (so it can not be controlling anything).

For BISS_sniffer, we now just check for the serial clock going low at the start of a frame (avoiding CONN falsely reading high when disconnected). The data integrity is checked by the CRC. If the clock later goes away, CONN will remain high but the same argument as for SSI_sniffer applies.

I would like to have this checked with actual encoders. I have only been able to check behaviour when nothing is connected.

Closes #89 