### PR TITLE
counter: add register to set counter value

### DIFF
--- a/modules/counter/counter.block.ini
+++ b/modules/counter/counter.block.ini
@@ -28,6 +28,11 @@ description: Counter OUT update mode (on internal counter value change or on ENA
 0: On-Change
 1: On-Disable
 
+[SET]
+type: param int
+description: set current value of a counter
+wstb: true
+
 [START]
 type: param int
 description: Counter start value

--- a/modules/counter/counter.timing.ini
+++ b/modules/counter/counter.timing.ini
@@ -203,3 +203,14 @@ scope: counter.block.ini
 11      : TRIG=1            -> OUT=-3
 12      : TRIG=0
 13      : ENABLE=0
+
+[Manual set value]
+3       : START=20
+6       : ENABLE=1           -> OUT=20
+9       : TRIG=1             -> OUT=21
+10      : SET=10, TRIG=0     -> OUT=10
+11      : TRIG=1             -> OUT=11
+12      : TRIG=0, ENABLE=0
+
+[Manual set value disabled]
+3       : SET=42             -> OUT=42

--- a/modules/counter/counter_sim.py
+++ b/modules/counter/counter_sim.py
@@ -16,7 +16,7 @@ NAMES, PROPERTIES = properties_from_ini(__file__, "counter.block.ini")
 
 
 class CounterSimulation(BlockSimulation):
-    ENABLE, TRIG, DIR, TRIG_EDGE, OUT_MODE, START, STEP, MAX, MIN, CARRY, OUT = PROPERTIES
+    ENABLE, TRIG, DIR, TRIG_EDGE, OUT_MODE, SET, START, STEP, MAX, MIN, CARRY, OUT = PROPERTIES
     
     def __init__(self):
         self.counter = 0
@@ -50,6 +50,8 @@ class CounterSimulation(BlockSimulation):
         if self.OUT_MODE == MODE_OnChange:
             if changes.get(NAMES.ENABLE, None) is 1:
                 self.OUT = self.START
+            elif NAMES.SET in changes:
+                self.OUT = self.SET
             elif changes.get(NAMES.ENABLE, None) is 0:
                 self.CARRY = 0
             elif self.ENABLE and NAMES.TRIG in changes:
@@ -75,6 +77,8 @@ class CounterSimulation(BlockSimulation):
             if changes.get(NAMES.ENABLE, None) is 1:
                 self.counter = self.START
                 self.overflow = 0
+            elif NAMES.SET in changes:
+                self.counter = self.SET
             elif self.ENABLE and NAMES.TRIG in changes:
                 # process trigger on selected edge
                 if got_trigger:

--- a/modules/counter/hdl/counter.vhd
+++ b/modules/counter/hdl/counter.vhd
@@ -28,6 +28,8 @@ port (
     TRIG_EDGE           : in  std_logic_vector(31 downto 0) := (others => '0');
     TRIG_EDGE_WSTB      : in  std_logic;
     OUT_MODE            : in  std_logic_vector(31 downto 0);
+    SET                 : in  std_logic_vector(31 downto 0);
+    SET_WSTB            : in  std_logic;
     START               : in  std_logic_vector(31 downto 0);
     START_WSTB          : in  std_logic;
     STEP                : in  std_logic_vector(31 downto 0);
@@ -129,6 +131,9 @@ begin
         -- Re-load on enable rising edge
         if (enable_rise = '1') then
             counter <= signed(START);
+            carry_latch <= '0';
+        elsif (SET_WSTB = '1') then
+            counter <= signed(SET);
             carry_latch <= '0';
         -- Drop the carry signal on falling enable
         elsif (enable_fall = '1') then


### PR DESCRIPTION
- Setting the counter take precedence over a trigger event, that way the block will output the set value at least for one tick
- It is possible to set a value while the block is disabled (this allows to control the pos bus value without having to actually count)
- Timing tests were added for two cases: setting a value while enabled and setting a value while disabled
- Python counter simulation script was updated to consider the set register