### PR TITLE
Update upload/download-artifact to v3

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -63,7 +63,7 @@ jobs:
 
       # Artifacts
       - name: Upload boot
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: zpkgs
           path: ./build/boot*.zip
@@ -132,7 +132,7 @@ jobs:
 
       # Artifacts
       - name: Upload zpkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: zpkgs
           path: ./build/panda-fpga@*.zpg
@@ -248,7 +248,7 @@ jobs:
 
       # Artifacts
       - name: Upload zpkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: zpkgs
           path: ./build/panda-fpga@*.zpg
@@ -327,7 +327,7 @@ jobs:
     # make a release on every tag
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: zpkgs
           path: zpkgs


### PR DESCRIPTION
* Temporary measure to restore functioning CI


Using v3 as a work-around to avoid the error:
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
due to breaking change in v4:
https://github.com/actions/upload-artifact#breaking-changes