### PR TITLE
PandaBrick quDIS Interface - Initial commit

### DIFF
--- a/modules/qudis/hdl/hssl_axis_decoder.vhd
+++ b/modules/qudis/hdl/hssl_axis_decoder.vhd
@@ -1,0 +1,139 @@
+----------------------------------------------------------------------------------
+--
+--  Single Axis quDIS HSSL Decoder.
+--
+--  G.Francis, August 2024.
+-- 
+-- 
+-- quDIS Settings:
+--
+--      Timings below are for 32 bits (for PandABrick)
+-- 
+--      quDIS absolute maximum update rate is about 25kHz...
+--
+--      Example quDIS Daisy Settings (frequencies approximate):
+--
+--          25kHz  :  Clock: 1uS, Gap: 8, Average 80nS.
+--
+--          10kHz  :  Clock: 2uS, Gap: 18, Average 160nS.
+-- 
+--      Slowest mode is Clock 2.48uS, Gap 63, which gives 4.24kHz.
+--
+--
+----------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+
+entity hssl_axis_decoder is
+generic (
+    DATA_LEN            : natural := 32
+);
+Port ( 
+    
+    clk_i               : in  std_logic;                                -- 125MHz Clock 
+    
+    clk_bit_i           : in  std_logic;                                -- HSSL Interface
+    data_bit_i          : in  std_logic;
+    
+    hssl_val_o          : out std_logic_vector(DATA_LEN-1 downto 0);    -- Position Output
+    health_bit_o        : out std_logic
+    
+);
+end hssl_axis_decoder;
+
+
+architecture arch_hssl of hssl_axis_decoder is
+
+
+signal clk_bit          : std_logic := '0';
+signal clk_bit_b        : std_logic := '0';
+signal clk_prev         : std_logic := '0';
+
+signal rx_shift_reg     : std_logic_vector(DATA_LEN-1 downto 0);
+
+signal health_bit       : std_logic := '0';
+
+signal clk_timer        : unsigned(15 downto 0);
+signal bit_count        : unsigned(5 downto 0);
+signal threshold        : unsigned(15 downto 0);
+
+
+
+begin
+
+
+-- Synchronize the hssl clock input
+process (clk_i) is
+begin
+    if rising_edge(clk_i) then
+        clk_bit   <= clk_bit_b;
+        clk_bit_b <= clk_bit_i;
+    end if;
+end process;
+
+
+
+-- Decoder State Machine
+process (clk_i) is
+
+    variable timeout : natural := 0;
+
+begin
+    if rising_edge(clk_i) then
+
+        if clk_bit /= clk_prev then         -- Clock bit has changed...
+
+            if clk_bit = '1' then                -- rising edge...
+                          
+                if clk_timer > threshold then         -- If finished,
+                
+                    if bit_count = DATA_LEN then
+                        hssl_val_o <= rx_shift_reg;        -- output value,
+                        health_bit <= '1';                 -- and flag good data.
+                    else
+                        health_bit <= '0';                 -- or flag bad data if the bit count is wrong.
+                    end if;
+                    
+                    bit_count <= (others => '0');          -- reset bit counter
+                                        
+                end if;
+                
+            else                                 -- falling edge...    
+                
+                rx_shift_reg <= rx_shift_reg(rx_shift_reg'high-1 downto 0) & data_bit_i;   -- sample bit,
+                bit_count    <=  bit_count + 1;                                            -- increment bit counter
+                threshold    <= clk_timer + clk_timer/2;                                   -- Set threshold to 1.5 * (measured clock-low width)
+                clk_timer    <= (others => '0');                                           -- and reset clk-low width counter. 
+                                          
+            end if;
+            
+            timeout := 0;
+
+        else
+        
+            if clk_bit = '0' then 
+                clk_timer <= clk_timer + 1;       -- Clock bit has not changed (and is low), so increment timer.
+            end if;
+            
+        end if;
+        
+        clk_prev  <= clk_bit;                       -- (store new clock level)
+
+        
+        if timeout > 1250000 then                   -- 10mS timeout on clock bit input.
+            health_bit_o <= '0';
+        else
+            health_bit_o <= health_bit;
+            timeout := timeout + 1;
+        end if;
+
+    end if;
+    
+end process;
+
+
+
+end arch_hssl;

--- a/modules/qudis/hdl/qudis.vhd
+++ b/modules/qudis/hdl/qudis.vhd
@@ -1,0 +1,114 @@
+----------------------------------------------------------------------------------
+--
+-- 3-Axis quDIS Interferometer decoder 
+--
+-- G.Francis, August 2024.
+--
+----------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library work;
+use work.top_defines.all;
+use work.addr_defines.all;
+
+
+entity qudis is
+    Port ( 
+    
+        clk_i           : in  std_logic;
+        reset_i         : in  std_logic;
+        bit_bus_i        : in  bit_bus_t;
+        pos_bus_i        : in  pos_bus_t;
+
+        -- HSSL Hardware Interface
+        hssl_clk_pins   : in std_logic_vector(3 downto 1);
+        hssl_data_pins  : in std_logic_vector(3 downto 1);
+        
+        -- Output Positions
+        pos_1_o         : out std_logic_vector(31 downto 0);
+        pos_2_o         : out std_logic_vector(31 downto 0);
+        pos_3_o         : out std_logic_vector(31 downto 0);
+
+        -- Internal read interface
+        read_strobe_i   : in  std_logic;
+        read_address_i  : in  std_logic_vector(BLK_AW-1 downto 0);
+        read_data_o     : out std_logic_vector(31 downto 0);
+        read_ack_o      : out std_logic;
+
+        -- Internal write interface
+        write_strobe_i  : in  std_logic;
+        write_address_i : in  std_logic_vector(BLK_AW-1 downto 0);
+        write_data_i    : in  std_logic_vector(31 downto 0);
+        write_ack_o     : out std_logic
+
+	);
+end qudis;
+
+
+architecture arch_qudis of qudis is
+
+signal hssl_positions       : std32_array(3 downto 1);
+signal health_bits          : std_logic_vector(3 downto 1);
+signal health               : std_logic_vector(31 downto 0);
+
+begin
+
+
+-- Generate the Decoders...
+GEN_DECODERS:
+for axis_num in 1 to 3 generate
+
+   hssl_axis_decoder_inst : entity work.hssl_axis_decoder
+   port map (
+       clk_i        => clk_i,
+       clk_bit_i    => hssl_clk_pins(axis_num),
+       data_bit_i   => hssl_data_pins(axis_num),
+       hssl_val_o   => hssl_positions(axis_num),
+       health_bit_o => health_bits(axis_num)
+   );
+    
+end generate GEN_DECODERS;
+
+
+-- Output positions...
+pos_1_o <= hssl_positions(1);
+pos_2_o <= hssl_positions(2);
+pos_3_o <= hssl_positions(3);
+
+
+-- Health word (bits are 1 for good)...
+health(0) <= not health_bits(1);
+health(1) <= not health_bits(2);
+health(2) <= not health_bits(3);
+health(31 downto 3) <= ( others => '0' );
+
+
+
+qudis_ctrl_inst : entity work.qudis_ctrl
+    port map (
+        -- Clock and Reset
+        clk_i               => clk_i,
+        reset_i             => reset_i,
+        bit_bus_i           => bit_bus_i,
+        pos_bus_i           => pos_bus_i,
+
+        -- Block Parameters
+        HEALTH              => health,
+
+        -- Memory Bus Interface
+        read_strobe_i       => read_strobe_i,
+        read_address_i      => read_address_i,
+        read_data_o         => read_data_o,
+        read_ack_o          => read_ack_o,
+
+        write_strobe_i      => write_strobe_i,
+        write_address_i     => write_address_i,
+        write_data_i        => write_data_i,
+        write_ack_o         => write_ack_o
+        );
+
+
+end arch_qudis;

--- a/modules/qudis/hdl/qudis_top.vhd
+++ b/modules/qudis/hdl/qudis_top.vhd
@@ -1,0 +1,146 @@
+----------------------------------------------------------------------------------
+--
+-- 6-Axis quDIS Interferometer (two 3-Axis blocks) 
+--
+-- G.Francis, August 2024.
+--
+----------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use ieee.std_logic_misc.all;
+
+library work;
+use work.top_defines.all;
+use work.addr_defines.all;
+
+
+entity qudis_top is
+    generic (
+        QUDIS_NUM : natural
+    );
+    Port ( 
+    
+        clk_i           : in  std_logic;
+        reset_i         : in  std_logic;
+        bit_bus_i       : in  bit_bus_t;
+        pos_bus_i       : in  pos_bus_t;
+
+        -- HSSL Hardware Interface
+        hssl_clk_pins   : in std_logic_vector(6 downto 1);
+        hssl_data_pins  : in std_logic_vector(6 downto 1);
+
+        -- Output Positions
+        pos_1_o         : out std_logic_vector(31 downto 0);
+        pos_2_o         : out std_logic_vector(31 downto 0);
+        pos_3_o         : out std_logic_vector(31 downto 0);
+        pos_4_o         : out std_logic_vector(31 downto 0);
+        pos_5_o         : out std_logic_vector(31 downto 0);
+        pos_6_o         : out std_logic_vector(31 downto 0);
+
+        -- Internal read interface
+        read_strobe_i   : in  std_logic;
+        read_address_i  : in  std_logic_vector(PAGE_AW-1 downto 0);
+        read_data_o     : out std_logic_vector(31 downto 0);
+        read_ack_o      : out std_logic;
+
+        -- Internal write interface
+        write_strobe_i  : in  std_logic;
+        write_address_i : in  std_logic_vector(PAGE_AW-1 downto 0);
+        write_data_i    : in  std_logic_vector(31 downto 0);
+        write_ack_o     : out std_logic
+
+	);
+end qudis_top;
+
+architecture arch_qudis_top of qudis_top is
+
+    signal QUDIS_read_strobe    : std_logic_vector(QUDIS_NUM-1 downto 0);
+    signal QUDIS_read_data      : std32_array(QUDIS_NUM-1 downto 0);
+    signal QUDIS_write_strobe   : std_logic_vector(QUDIS_NUM-1 downto 0);
+    signal QUDIS_read_ack       : std_logic_vector(QUDIS_NUM-1 downto 0);
+    signal QUDIS_write_ack      : std_logic_vector(QUDIS_NUM-1 downto 0);
+
+    signal pos_1                : std32_array(QUDIS_NUM-1 downto 0);
+    signal pos_2                : std32_array(QUDIS_NUM-1 downto 0);
+    signal pos_3                : std32_array(QUDIS_NUM-1 downto 0);
+
+    type input_pins is array (1 downto 0) of std_logic_vector(3 downto 1);
+    signal clk_pins             : input_pins;
+    signal data_pins            : input_pins;
+
+begin
+    
+    -- Acknowledgement to AXI Lite interface
+    read_ack_o  <= or_reduce(QUDIS_read_ack);
+    write_ack_o <= or_reduce(QUDIS_write_ack);
+    
+    -- Multiplex read data out from multiple instantiations
+    read_data_o <= QUDIS_read_data(to_integer(unsigned(read_address_i(PAGE_AW-1 downto BLK_AW))));
+    
+    -- Inputs
+    clk_pins(0)  <= hssl_clk_pins(3 downto 1);
+    data_pins(0) <= hssl_data_pins(3 downto 1);
+    more_pins: if QUDIS_NUM=2 generate
+        clk_pins(1)  <= hssl_clk_pins(6 downto 4);
+        data_pins(1) <= hssl_data_pins(6 downto 4);
+    end generate;
+
+    -- Outputs
+    pos_1_o  <= pos_1(0);
+    pos_2_o  <= pos_2(0);
+    pos_3_o  <= pos_3(0);
+
+    one_qudis:
+    if QUDIS_NUM=1 generate
+        pos_4_o  <= (others => '0');
+        pos_5_o  <= (others => '0');
+        pos_6_o  <= (others => '0');
+    end generate one_qudis;
+    
+    two_qudis:
+    if QUDIS_NUM=2 generate
+        pos_4_o  <= pos_1(1);
+        pos_5_o  <= pos_2(1);
+        pos_6_o  <= pos_3(1);
+    end generate two_qudis;
+
+
+    -- Generate 3-axis decoders
+    QUDIS_GEN : FOR I IN 0 TO QUDIS_NUM-1 GENERATE
+
+        -- Sub-module address decoding
+        QUDIS_read_strobe(I) <= compute_block_strobe(read_address_i, I) and read_strobe_i;
+        QUDIS_write_strobe(I) <= compute_block_strobe(write_address_i, I) and write_strobe_i;
+
+
+        -- 3-axis decoders
+        quDIS_inst : entity work.qudis
+        port map (
+            clk_i           => clk_i,
+            reset_i         => reset_i,
+            bit_bus_i       => bit_bus_i,
+            pos_bus_i       => pos_bus_i,
+
+            hssl_clk_pins   => clk_pins(I),
+            hssl_data_pins  => data_pins(I),
+
+            pos_1_o         => pos_1(I),
+            pos_2_o         => pos_2(I),
+            pos_3_o         => pos_3(I),
+
+            read_strobe_i   => QUDIS_read_strobe(I),
+            read_address_i  => read_address_i(BLK_AW-1 downto 0),
+            read_data_o     => QUDIS_read_data(I),
+            read_ack_o      => QUDIS_read_ack(I),
+
+            write_strobe_i  => QUDIS_write_strobe(I),
+            write_address_i => (others => '0'),
+            write_data_i    => (others => '0'),
+            write_ack_o     => QUDIS_write_ack(I)
+        );
+
+    END GENERATE QUDIS_GEN;
+
+end arch_qudis_top;

--- a/modules/qudis/qudis.block.ini
+++ b/modules/qudis/qudis.block.ini
@@ -1,0 +1,27 @@
+[.]
+description: quDIS Interferometer
+entity: qudis
+
+[HEALTH]
+type: read enum
+description: Interferometer status
+0: OK
+1: Axis 1 Error
+2: Axis 2 Error
+3: Axis 1 & 2 Error
+4: Axis 3 Error
+5: Axis 1 & 3 Error
+6: Axis 2 & 3 Error
+7: Axis 1, 2 & 3 Error
+
+[POS1]
+type: pos_out
+description: quDIS Axis 1 Position
+
+[POS2]
+type: pos_out
+description: quDIS Axis 2 Position
+
+[POS3]
+type: pos_out
+description: quDIS Axis 3 Position

--- a/targets/PandABrick/PandABrick.target.ini
+++ b/targets/PandABrick/PandABrick.target.ini
@@ -26,3 +26,5 @@ number: 1
 [PANDABRICK_TEST]
 number: 1
 
+[QUDIS]
+number: 2

--- a/targets/PandABrick/const/PandABrick-pins_impl.xdc
+++ b/targets/PandABrick/const/PandABrick-pins_impl.xdc
@@ -39,6 +39,8 @@ set_property -dict {PACKAGE_PIN AE13  IOSTANDARD LVCMOS18  } [get_ports {IO0_D6_
 set_property -dict {PACKAGE_PIN AF13  IOSTANDARD LVCMOS18  } [get_ports {IO0_D7_N}]
 set_property -dict {PACKAGE_PIN AG13  IOSTANDARD LVCMOS18  } [get_ports {IO0_D8_P}]
 set_property -dict {PACKAGE_PIN AH13  IOSTANDARD LVCMOS18  } [get_ports {IO0_D9_N}]
+set_property -dict {PACKAGE_PIN AB11  IOSTANDARD LVCMOS18  } [get_ports {IO0_D10_P}]
+set_property -dict {PACKAGE_PIN AC11  IOSTANDARD LVCMOS18  } [get_ports {IO0_D11_N}]
 
 set_property -dict {PACKAGE_PIN AG14  IOSTANDARD LVCMOS18  } [get_ports {IO0_D20_P}]
 set_property -dict {PACKAGE_PIN AH14  IOSTANDARD LVCMOS18  } [get_ports {IO0_D21_N}]

--- a/targets/PandABrick/hdl/PandABrick_top.vhd
+++ b/targets/PandABrick/hdl/PandABrick_top.vhd
@@ -42,21 +42,23 @@ port (
     ch1_gthtxp_out                 : out    std_logic;
      
     -- Anios_0
-    IO0_D0_P                       : inout  std_logic;
-    IO0_D1_N                       : out    std_logic;
-    IO0_D2_P                       : inout  std_logic;
-    IO0_D3_N                       : out    std_logic;
-    IO0_D4_P                       : inout  std_logic;
-    IO0_D5_N                       : out    std_logic;
-    IO0_D6_P                       : inout  std_logic;
-    IO0_D7_N                       : out    std_logic;
-    IO0_D8_P                       : out    std_logic;
-    IO0_D9_N                       : inout  std_logic;
+    IO0_D0_P                       : in  std_logic;
+    IO0_D1_N                       : in  std_logic;
+    IO0_D2_P                       : in  std_logic;
+    IO0_D3_N                       : in  std_logic;
+    IO0_D4_P                       : in  std_logic;
+    IO0_D5_N                       : in  std_logic;
+    IO0_D6_P                       : in  std_logic;
+    IO0_D7_N                       : in  std_logic;
+    IO0_D8_P                       : in  std_logic;
+    IO0_D9_N                       : in  std_logic;
+    IO0_D10_P                      : in  std_logic;
+    IO0_D11_N                      : in  std_logic;
 
-    IO0_D20_P                      : in     std_logic;
-    IO0_D21_N                      : in     std_logic;
-    IO0_D22_P                      : out    std_logic;
-    IO0_D23_N                      : out    std_logic;
+    IO0_D20_P                      : in  std_logic;
+    IO0_D21_N                      : in  std_logic;
+    IO0_D22_P                      : out std_logic;
+    IO0_D23_N                      : out std_logic;
 
     -- FMC
     FMC_HA02_N                     : out    std_logic;
@@ -413,6 +415,12 @@ signal inenc_data           : std_logic_vector(ENC_NUM-1 downto 0);
 signal INENC_PROTOCOL       : std32_array(ENC_NUM-1 downto 0);
 signal INENC_PROTOCOL_WSTB  : std_logic_vector(ENC_NUM-1 downto 0);
 
+-- quDIS HSSL Interface
+signal hssl_clk_pins        : std_logic_vector(6 downto 1);
+signal hssl_data_pins       : std_logic_vector(6 downto 1);
+signal hssl_positions       : std32_array(6 downto 1);
+
+
 -- Output Encoder
 signal outenc_clk           : std_logic_vector(ENC_NUM-1 downto 0);
 signal outenc_conn          : std_logic_vector(ENC_NUM-1 downto 0);
@@ -430,33 +438,33 @@ signal uvwt                 : std_logic_vector(7 downto 0);
 
 
 -- AUX IO Board signals
-signal AuxDin1              : std_logic;
-signal AuxDout1             : std_logic;
-signal AuxDir1              : std_logic;
+-- signal AuxDin1              : std_logic;
+-- signal AuxDout1             : std_logic;
+-- signal AuxDir1              : std_logic;
 
-signal AuxDin2              : std_logic;
-signal AuxDout2             : std_logic;
-signal AuxDir2              : std_logic;
+-- signal AuxDin2              : std_logic;
+-- signal AuxDout2             : std_logic;
+-- signal AuxDir2              : std_logic;
 
-signal AuxDin3              : std_logic;
-signal AuxDout3             : std_logic;
-signal AuxDir3              : std_logic;
+-- signal AuxDin3              : std_logic;
+-- signal AuxDout3             : std_logic;
+-- signal AuxDir3              : std_logic;
 
-signal AuxDin4              : std_logic;
-signal AuxDout4             : std_logic;
-signal AuxDir4              : std_logic;
+-- signal AuxDin4              : std_logic;
+-- signal AuxDout4             : std_logic;
+-- signal AuxDir4              : std_logic;
 
-signal AuxDin5              : std_logic;
-signal AuxDout5             : std_logic;
-signal AuxDir5              : std_logic;
+-- signal AuxDin5              : std_logic;
+-- signal AuxDout5             : std_logic;
+-- signal AuxDir5              : std_logic;
 
-signal aux_clk_counter      : unsigned ( 15 downto 0 ) := x"0000";    
+-- signal aux_clk_counter      : unsigned ( 15 downto 0 ) := x"0000";    
 
-signal invAuxDir1           : std_logic;
-signal invAuxDir2           : std_logic;
-signal invAuxDir3           : std_logic;
-signal invAuxDir4           : std_logic;
-signal invAuxDir5           : std_logic;
+-- signal invAuxDir1           : std_logic;
+-- signal invAuxDir2           : std_logic;
+-- signal invAuxDir3           : std_logic;
+-- signal invAuxDir4           : std_logic;
+-- signal invAuxDir5           : std_logic;
 
 -- SFP+ Clock
 signal BUF_GTREFCLK1        : std_logic;
@@ -782,19 +790,36 @@ port map (
   
 -- ========== RIBBON CABLE PINOUTS ==========
 
+-- HSSL Interface Driver Board (40 way ribbon to ST1 IO0)...
+
+hssl_data_pins(1) <= IO0_D0_P;
+hssl_data_pins(2) <= IO0_D2_P;
+hssl_data_pins(3) <= IO0_D4_P;
+hssl_data_pins(4) <= IO0_D6_P;
+hssl_data_pins(5) <= IO0_D8_P;
+hssl_data_pins(6) <= IO0_D10_P;
+
+hssl_clk_pins(1)  <= IO0_D1_N;
+hssl_clk_pins(2)  <= IO0_D3_N;
+hssl_clk_pins(3)  <= IO0_D5_N;
+hssl_clk_pins(4)  <= IO0_D7_N;
+hssl_clk_pins(5)  <= IO0_D9_N;
+hssl_clk_pins(6)  <= IO0_D11_N;
+
+
 -- AUX_IO (SPI/TTL) Board  (40 way ribbon to ST1 IO0)...
 -- 
-AUX_IO_DATA(1)   <= IO0_D0_P;
-AUX_IO_DATA(2)   <= IO0_D2_P;
-AUX_IO_DATA(3)   <= IO0_D4_P;
-AUX_IO_DATA(4)   <= IO0_D6_P;
-AUX_IO_DATA(5)   <= IO0_D9_N;
+-- AUX_IO_DATA(1)   <= IO0_D0_P;
+-- AUX_IO_DATA(2)   <= IO0_D2_P;
+-- AUX_IO_DATA(3)   <= IO0_D4_P;
+-- AUX_IO_DATA(4)   <= IO0_D6_P;
+-- AUX_IO_DATA(5)   <= IO0_D9_N;
 
-IO0_D1_N <= AUX_IO_DIR(1);
-IO0_D3_N <= AUX_IO_DIR(2);
-IO0_D5_N <= AUX_IO_DIR(3);
-IO0_D7_N <= AUX_IO_DIR(4);
-IO0_D8_P <= AUX_IO_DIR(5);
+-- IO0_D1_N <= AUX_IO_DIR(1);
+-- IO0_D3_N <= AUX_IO_DIR(2);
+-- IO0_D5_N <= AUX_IO_DIR(3);
+-- IO0_D7_N <= AUX_IO_DIR(4);
+-- IO0_D8_P <= AUX_IO_DIR(5);
     
 AUX_IO_TTL_IN(0)  <= IO0_D21_N;
 AUX_IO_TTL_IN(1)  <= IO0_D20_P;
@@ -1287,7 +1312,8 @@ bit_bus(BIT_BUS_SIZE-1 downto 0 ) <= pcap_active & outenc_clk & inenc_conn &
                                    inenc_data & inenc_z & inenc_b & inenc_a &
                                    ttlin_val;
 
-pos_bus(POS_BUS_SIZE-1 downto 0) <= inenc_val;
+pos_bus(POS_BUS_SIZE-1 downto 0) <= hssl_positions & inenc_val;
+
 
 ---------------------------------------------------------------------------
 -- Test the Register Interface (provides dummy data)
@@ -1309,6 +1335,44 @@ port map (
     write_data    => write_data,
     write_ack     => write_ack(PANDABRICK_TEST_CS)
 );
+
+
+---------------------------------------------------------------------------
+-- quDIS Interface (provides 6 Axis Positions)
+---------------------------------------------------------------------------
+
+quDIS_inst : entity work.qudis_top
+generic map (
+    QUDIS_NUM => QUDIS_NUM
+)
+port map (
+    clk_i           => FCLK_CLK0,                   -- 125MHz System (AXI) clock.
+    reset_i         => FCLK_RESET0,
+    bit_bus_i       => bit_bus,
+    pos_bus_i       => pos_bus,
+
+    hssl_clk_pins   => hssl_clk_pins,               -- Hardware connections
+    hssl_data_pins  => hssl_data_pins,
+
+    pos_1_o         => hssl_positions(1),           -- 2 groups of three axis outputs
+    pos_2_o         => hssl_positions(3),
+    pos_3_o         => hssl_positions(5),
+    pos_4_o         => hssl_positions(2),
+    pos_5_o         => hssl_positions(4),
+    pos_6_o         => hssl_positions(6),
+
+    read_strobe_i   => read_strobe(QUDIS_CS),       -- Health come back via register interface
+    read_address_i  => read_address,
+    read_data_o     => read_data(QUDIS_CS),
+    read_ack_o      => read_ack(QUDIS_CS),
+
+    write_strobe_i  => write_strobe(QUDIS_CS),      -- Writes are ignored.
+    write_address_i => write_address,
+    write_data_i    => write_data,
+    write_ack_o     => write_ack(QUDIS_CS)
+);
+
+
 
 ---------------------------------------------------------------------------------
 -- Adaptor-Board PIC SPI Interface (relay driver and Quadrature LoS detector.)
@@ -1392,84 +1456,84 @@ port map (
 
 -- Bidirectional IO1...
 
-IOBUF1_inst : IOBUF
-port map (
-    O  => AuxDin1,
-    I  => AuxDout1,
-    IO => AUX_IO_DATA(1),
-    T  => invAuxDir1
-);
+-- IOBUF1_inst : IOBUF
+-- port map (
+--     O  => AuxDin1,
+--     I  => AuxDout1,
+--     IO => AUX_IO_DATA(1),
+--     T  => invAuxDir1
+-- );
 
 -- Bidirectional IO2...
 
-IOBUF2_inst : IOBUF
-port map (
-    O  => AuxDin2,
-    I  => AuxDout2,
-    IO => AUX_IO_DATA(2),
-    T  => invAuxDir2
-);
+-- IOBUF2_inst : IOBUF
+-- port map (
+--     O  => AuxDin2,
+--     I  => AuxDout2,
+--     IO => AUX_IO_DATA(2),
+--     T  => invAuxDir2
+-- );
 
 -- Bidirectional IO3...
 
-IOBUF3_inst : IOBUF
-port map (
-    O  => AuxDin3,
-    I  => AuxDout3,
-    IO => AUX_IO_DATA(3),
-    T  => invAuxDir3
-);
+-- IOBUF3_inst : IOBUF
+-- port map (
+--     O  => AuxDin3,
+--     I  => AuxDout3,
+--     IO => AUX_IO_DATA(3),
+--     T  => invAuxDir3
+-- );
 
 -- Bidirectional IO4...
 
-IOBUF4_inst : IOBUF
-port map (
-    O  => AuxDin4,
-    I  => AuxDout4,
-    IO => AUX_IO_DATA(4),
-    T  => invAuxDir4
-);
+-- IOBUF4_inst : IOBUF
+-- port map (
+--     O  => AuxDin4,
+--     I  => AuxDout4,
+--     IO => AUX_IO_DATA(4),
+--     T  => invAuxDir4
+-- );
 
 -- Bidirectional IO5...
 
-IOBUF5_inst : IOBUF
-port map (
-    O  => AuxDin5,
-    I  => AuxDout5,
-    IO => AUX_IO_DATA(5),
-    T  => invAuxDir5
-);
+-- IOBUF5_inst : IOBUF
+-- port map (
+--     O  => AuxDin5,
+--     I  => AuxDout5,
+--     IO => AUX_IO_DATA(5),
+--     T  => invAuxDir5
+-- );
 
 -- Run a counter...
-process(FCLK_CLK0)
-begin
-    if rising_edge(FCLK_CLK0) then
-        aux_clk_counter <= aux_clk_counter + 1;
-    end if;
-end process;
+-- process(FCLK_CLK0)
+-- begin
+--     if rising_edge(FCLK_CLK0) then
+--         aux_clk_counter <= aux_clk_counter + 1;
+--     end if;
+-- end process;
 
-AuxDir1 <= '1'; -- first three lines set to output
-AuxDir2 <= '1';
-AuxDir3 <= '1';
-AuxDout1 <= aux_clk_counter(15);    -- output a 3-bit count
-AuxDout2 <= aux_clk_counter(14);
-AuxDout3 <= aux_clk_counter(13);
+-- AuxDir1 <= '1'; -- first three lines set to output
+-- AuxDir2 <= '1';
+-- AuxDir3 <= '1';
+-- AuxDout1 <= aux_clk_counter(15);    -- output a 3-bit count
+-- AuxDout2 <= aux_clk_counter(14);
+-- AuxDout3 <= aux_clk_counter(13);
 
-AuxDir4 <= '0';      -- Data4 to input mode
-AuxDir5 <= '1';      -- Data5 to output mode
-AuxDout5 <= AuxDin4; -- Echo Data4 input to Data5 output.
+-- AuxDir4 <= '0';      -- Data4 to input mode
+-- AuxDir5 <= '1';      -- Data5 to output mode
+-- AuxDout5 <= AuxDin4; -- Echo Data4 input to Data5 output.
 
-invAuxDir1 <= not AuxDir1;
-invAuxDir2 <= not AuxDir2;
-invAuxDir3 <= not AuxDir3;
-invAuxDir4 <= not AuxDir4;
-invAuxDir5 <= not AuxDir5;
+-- invAuxDir1 <= not AuxDir1;
+-- invAuxDir2 <= not AuxDir2;
+-- invAuxDir3 <= not AuxDir3;
+-- invAuxDir4 <= not AuxDir4;
+-- invAuxDir5 <= not AuxDir5;
 
-AUX_IO_DIR(1) <= AuxDir1;
-AUX_IO_DIR(2) <= AuxDir2;
-AUX_IO_DIR(3) <= AuxDir3;
-AUX_IO_DIR(4) <= AuxDir4;
-AUX_IO_DIR(5) <= AuxDir5;
+-- AUX_IO_DIR(1) <= AuxDir1;
+-- AUX_IO_DIR(2) <= AuxDir2;
+-- AUX_IO_DIR(3) <= AuxDir3;
+-- AUX_IO_DIR(4) <= AuxDir4;
+-- AUX_IO_DIR(5) <= AuxDir5;
 
 -----------------------------------------------
 -- 1 second heartbeat to front-panel STATUS LED


### PR DESCRIPTION
Remove Aux IO Board and replace it with HSSL quDIS Interface.

- New hardware supports 2 x 3 axis quDIS Interferometer units.

This is definitely not the right way to implement this in PandABrick_top... The majority of PandABricks built will have the AUX IO board, not this interface.  I've just commented that out for now for testing.  This would presumably need to be set up as different apps (in the CONFIG file) to build for different hardware.