### PR TITLE
Pandabrick encoders

### DIFF
--- a/apps/PandABrick.app.ini
+++ b/apps/PandABrick.app.ini
@@ -4,7 +4,7 @@ description:
         - built-in FMC encoder card
         - PandA synchroniser on SFP on-board FMC
 target: PandABrick
-includes: common_soft_blocks.include.ini
+includes: pandabrick_soft_blocks.include.ini
 
 [SFP_SYNC]
 module: sfp_panda_sync

--- a/common/hdl/encoders/biss_sniffer.vhd
+++ b/common/hdl/encoders/biss_sniffer.vhd
@@ -128,6 +128,7 @@ begin
         if (reset = '1') then
             biss_fsm <= IDLE;
             biss_frame <= '0';
+            link_up_o <= '0';
         else
             -- Unidirectional point-to-point BiSS communication
             case biss_fsm is
@@ -165,6 +166,7 @@ begin
             -- Set active biss frame flag for link disconnection
             if (biss_fsm = IDLE and serial_clock = '0') then
                 biss_frame <= '1';
+                link_up_o  <= '1';
             elsif (biss_fsm = TIMEOUT) then
                 biss_frame <= '0';
             end if;
@@ -322,7 +324,6 @@ end process;
 --   link_down
 --   Encoder CRC error
 --------------------------------------------------------------------------
-link_up_o <= link_up;
 health_o <= health_biss_sniffer;
 error_o <= crc_strobe when (crc /= crc_calc or nError(1) = '0') else '0';
 

--- a/common/hdl/encoders/encoders.vhd
+++ b/common/hdl/encoders/encoders.vhd
@@ -60,7 +60,7 @@ port (
     SETP_i              : in  std_logic_vector(31 downto 0);
     SETP_WSTB_i         : in  std_logic;
     RST_ON_Z_i          : in  std_logic_vector(31 downto 0);
-    STATUS_o            : out std_logic_vector(31 downto 0);
+    STATUS_o            : out std_logic;
     INENC_HEALTH_o      : out std_logic_vector(31 downto 0);
     HOMED_o             : out std_logic_vector(31 downto 0);
     -- Block Outputs
@@ -95,7 +95,6 @@ signal bits_not_used        : unsigned(4 downto 0);
 
 signal homed_qdec           : std_logic_vector(31 downto 0);
 signal linkup_incr          : std_logic;
-signal linkup_incr_std32    : std_logic_vector(31 downto 0);
 signal linkup_ssi           : std_logic;
 signal ssi_frame            : std_logic;
 signal ssi_frame_sniffer    : std_logic;
@@ -206,9 +205,7 @@ port map (
 );
 
 --------------------------------------------------------------------------
--- Position Data and STATUS readback multiplexer
---
---  Link status information is valid only for loopback configuration
+-- OUTENC Health multiplexer
 --------------------------------------------------------------------------
 
 OUTENC_PROTOCOL_rb <= DCARD_MODE_i(18 downto 16);
@@ -280,7 +277,7 @@ qdec : entity work.qdec
 port map (
     clk_i           => clk_i,
 --  reset_i         => reset_i,
-    LINKUP_INCR     => linkup_incr_std32,
+    LINKUP_INCR     => linkup_incr,
     a_i             => A_IN,
     b_i             => B_IN,
     z_i             => Z_IN,
@@ -292,7 +289,6 @@ port map (
 );
 
 linkup_incr <= not DCARD_MODE_i(0);
-linkup_incr_std32 <= x"0000000"&"000"&linkup_incr;
 
 --------------------------------------------------------------------------
 -- SSI Instantiations
@@ -377,8 +373,6 @@ port map (
 
 --------------------------------------------------------------------------
 -- Position Data and STATUS readback multiplexer
---
---  Link status information is valid only for loopback configuration
 --------------------------------------------------------------------------
 
 INENC_PROTOCOL_rb <= DCARD_MODE_i(10 downto 8);
@@ -392,7 +386,7 @@ begin
             case (INENC_PROTOCOL_i) is
                 when "000"  =>              -- INC
                     posn <= posn_incr;
-                    STATUS_o(0) <= linkup_incr;
+                    STATUS_o <= linkup_incr;
                     INENC_HEALTH_o(0) <= not(linkup_incr);
                     INENC_HEALTH_o(31 downto 1)<= (others=>'0');
                     HOMED_o <= homed_qdec;
@@ -404,7 +398,7 @@ begin
                         posn <= posn_ssi;
                     end if;
                     HOMED_o <= TO_SVECTOR(1,32);
-                    STATUS_o(0) <= linkup_ssi;
+                    STATUS_o <= linkup_ssi;
                     if (linkup_ssi = '0') then
                         INENC_HEALTH_o <= TO_SVECTOR(2,32);
                     else
@@ -414,11 +408,11 @@ begin
                 when "010"  =>              -- BISS & Loopback
                     if (DCARD_MODE_i(3 downto 1) = DCARD_MONITOR) then
                         posn <= posn_biss_sniffer;
-                        STATUS_o(0) <= linkup_biss_sniffer;
+                        STATUS_o <= linkup_biss_sniffer;
                         INENC_HEALTH_o <= health_biss_sniffer;
                     else  -- DCARD_CONTROL
                         posn <= posn_biss;
-                        STATUS_o(0) <= linkup_biss_master;
+                        STATUS_o <= linkup_biss_master;
                         INENC_HEALTH_o<=health_biss_master;
                     end if;
                     HOMED_o <= TO_SVECTOR(1,32);
@@ -426,7 +420,7 @@ begin
                 when others =>
                     INENC_HEALTH_o <= TO_SVECTOR(5,32);
                     posn <= (others => '0');
-                    STATUS_o <= (others => '0');
+                    STATUS_o <= '0';
                     HOMED_o <= TO_SVECTOR(1,32);
             end case;
         end if;

--- a/common/hdl/encoders/encoders_block.vhd
+++ b/common/hdl/encoders/encoders_block.vhd
@@ -100,7 +100,7 @@ signal INENC_BITS_WSTB          : std_logic;
 signal SETP                     : std_logic_vector(31 downto 0);
 signal SETP_WSTB                : std_logic;
 signal RST_ON_Z                 : std_logic_vector(31 downto 0);
-signal STATUS                   : std_logic_vector(31 downto 0);
+signal STATUS                   : std_logic;
 signal read_ack                 : std_logic;
 signal LSB_DISCARD              : std_logic_vector(31 downto 0);
 signal MSB_DISCARD              : std_logic_vector(31 downto 0);
@@ -122,8 +122,8 @@ OUTENC_CONN_OUT_o <= enable;
 
 -- Input encoder connection status comes from either
 --  * Dcard pin [12] for incremental, or
---  * link_up status for absolute in loopback mode
-INENC_CONN_OUT_o <= STATUS(0);
+--  * link_up status for absolute
+INENC_CONN_OUT_o <= STATUS;
 
 -- Certain parameter changes must initiate a block reset.
 reset <= reset_i or OUTENC_PROTOCOL_WSTB or OUTENC_BITS_WSTB or INENC_PROTOCOL_WSTB

--- a/common/hdl/encoders/ssi_error_detect.vhd
+++ b/common/hdl/encoders/ssi_error_detect.vhd
@@ -1,0 +1,58 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.support.all;
+
+entity ssi_error_detect is
+port ( 
+    clk_i           : in  std_logic;
+    serial_dat_i    : in  std_logic;
+    ssi_frame_i     : in  std_logic;
+    link_up_o       : out std_logic
+);
+end ssi_error_detect;
+
+architecture rtl of ssi_error_detect is
+
+constant ENCODER_TIMEOUT    : natural := 125 * 10; -- 10usec (Minimum timeout/2)
+
+signal ssi_frame_prev       : std_logic;
+signal timeout_cnt_en       : std_logic;
+signal timeout_ctr          : unsigned(LOG2(ENCODER_TIMEOUT-1) downto 0);
+signal frame_start          : std_logic;
+signal frame_end            : std_logic;
+
+begin
+
+frame_err_det: process(clk_i)
+begin
+    if rising_edge(clk_i) then
+
+        ssi_frame_prev <= ssi_frame_i;
+
+        if ssi_frame_i = '1' and ssi_frame_prev = '0' then -- rising edge
+            -- Encoder must drive the line high when IDLE
+            frame_start <= serial_dat_i;
+            timeout_cnt_en <= '0';
+        elsif ssi_frame_i = '0' and ssi_frame_prev = '1' then --falling edge
+            timeout_cnt_en <= '1';
+            timeout_ctr <= (others => '0');
+        elsif timeout_cnt_en = '1' then
+            if timeout_ctr = ENCODER_TIMEOUT-1 then
+                -- Encoder must drive the line low during TIMEOUT dwell time
+                frame_end <= serial_dat_i;
+                timeout_ctr <= (others => '0');
+                timeout_cnt_en <= '0';
+            else
+                timeout_ctr <= timeout_ctr + 1;
+            end if;
+        end if;
+
+        -- Link is up when line is high during IDLE and low during TIMEOUT
+        link_up_o <= frame_start and not frame_end;
+    end if;
+end process;
+
+end rtl;
+

--- a/common/hdl/encoders/ssi_sniffer.vhd
+++ b/common/hdl/encoders/ssi_sniffer.vhd
@@ -24,13 +24,13 @@ port (
     -- Configuration interface
     ENCODING        : in  std_logic_vector(1 downto 0);
     BITS            : in  std_logic_vector(7 downto 0);
-    link_up_o       : out std_logic;
-    error_o         : out std_logic;
+    error_o         : out std_logic := '0';
     -- Physical SSI interface
     ssi_sck_i       : in  std_logic;
     ssi_dat_i       : in  std_logic;
     -- Block outputs
-    posn_o          : out std_logic_vector(31 downto 0)
+    posn_o          : out std_logic_vector(31 downto 0);
+    ssi_frame_o     : out std_logic
 );
 end ssi_sniffer;
 
@@ -44,8 +44,6 @@ signal uBITS                : unsigned(7 downto 0);
 signal intBITS              : natural range 0 to 2**BITS'length-1;
 
 signal reset                : std_logic;
-signal serial_data_prev     : std_logic;
-signal serial_data_rise     : std_logic;
 signal serial_clock         : std_logic;
 signal serial_clock_prev    : std_logic;
 signal link_up              : std_logic;
@@ -58,8 +56,9 @@ signal serial_clock_rise    : std_logic;
 signal shift_counter        : unsigned(7 downto 0);
 signal shift_enabled        : std_logic;
 
-
 begin
+
+ssi_frame_o <= ssi_frame;
 
 --------------------------------------------------------------------------
 -- Internal signal assignments
@@ -76,14 +75,12 @@ process (clk_i)
 begin
     if (rising_edge(clk_i)) then
         serial_clock_prev <= serial_clock;
-        serial_data_prev <= serial_data;
     end if;
 end process;
 
 -- Shift source synchronous data on the Falling egde of clock
 serial_clock_fall <= not serial_clock and serial_clock_prev;
 serial_clock_rise <= serial_clock and not serial_clock_prev;
-serial_data_rise <= serial_data and not serial_data_prev;
 
 --------------------------------------------------------------------------
 -- Detect link if clock is asserted for > 5us.
@@ -178,12 +175,5 @@ begin
     end if;
 end process;
 
---------------------------------------------------------------------------
--- Module status outputs
---   link_down
---   Encoder CRC error
---------------------------------------------------------------------------
-link_up_o <= link_up;
-error_o <= '0'; -- n/a
-
 end rtl;
+

--- a/common/hdl/qdec.vhd
+++ b/common/hdl/qdec.vhd
@@ -21,7 +21,7 @@ port (
     -- Clock and reset signals
     clk_i               : in  std_logic;
 --    reset_i             : in  std_logic;
-    LINKUP_INCR         : in  std_logic_vector(31 downto 0);
+    LINKUP_INCR         : in  std_logic;
     --Quadrature A,B and Z input
     a_i                 : in  std_logic;
     b_i                 : in  std_logic;
@@ -68,7 +68,7 @@ process(clk_i) begin
         if (reset = '1') then
             HOMED(0) <= '0';
         else
-            if (LINKUP_INCR(0) = '0') then
+            if (LINKUP_INCR = '0') then
                 HOMED(0) <= '0';
             elsif (RST_ON_Z(0) = '1' and z_i = '1') then
                 quad_count <= (others => '0');

--- a/includes/pandabrick_soft_blocks.include.ini
+++ b/includes/pandabrick_soft_blocks.include.ini
@@ -1,0 +1,35 @@
+[BITS]
+number: 1
+
+[CALC]
+number: 2
+
+[CLOCK]
+number: 2
+
+[COUNTER]
+number: 4
+
+[DIV]
+number: 2
+
+[FILTER]
+number: 2
+
+[LUT]
+number: 8
+
+[PCOMP]
+number: 2
+
+[PGEN]
+number: 2
+
+[PULSE]
+number: 4
+
+[SEQ]
+number: 2
+
+[SRGATE]
+number: 4

--- a/modules/absenc/absenc.block.ini
+++ b/modules/absenc/absenc.block.ini
@@ -13,9 +13,9 @@ description: Type of absolute/incremental protocol
 1: BISS
 2: enDat
 
-[ENABLE]
-type: bit_mux
-description: Halt on falling edge, reset and enable on rising
+[ENABLED]
+type: read bit
+description: Is ABSENC enabled?
 
 [ENCODING]
 type: param enum

--- a/modules/absenc/absenc.block.ini
+++ b/modules/absenc/absenc.block.ini
@@ -77,15 +77,3 @@ description: Table status
 [VAL]
 type: pos_out
 description: Current position
-
-[DCARD_TYPE]
-type: read enum
-description: Daughter card jumper mode
-0: DCARD id 0
-1: Encoder Control
-2: DCARD id 2
-3: Encoder Monitor
-4: DCARD id 3
-5: DCARD id 4
-6: DCARD id 5
-7: Unplugged

--- a/modules/absenc/absenc.block.ini
+++ b/modules/absenc/absenc.block.ini
@@ -1,0 +1,91 @@
+[.]
+description: Absolute encoder
+entity: absenc
+
+[CLK]
+type: bit_mux
+description: Clock output to slave encoder
+
+[PROTOCOL]
+type: param enum
+description: Type of absolute/incremental protocol
+0: SSI
+1: BISS
+2: enDat
+
+[ENABLE]
+type: bit_mux
+description: Halt on falling edge, reset and enable on rising
+
+[ENCODING]
+type: param enum
+description: Position encoding (for absolute encoders)
+0: Unsigned Binary
+1: Unsigned Gray
+2: Signed Binary
+3: Signed Gray
+
+[CLK_SRC]
+type: param enum
+description: Bypass/Pass Through encoder signals
+0: Internally Generated
+1: From CLK
+
+[CLK_PERIOD]
+type: param time
+description: Clock rate
+
+[FRAME_PERIOD]
+type: param time
+description: Frame rate
+
+[BITS]
+type: param uint 63
+description: Number of bits
+
+[LSB_DISCARD]
+type: param uint 31
+description: Number of LSB bits to discard
+
+[MSB_DISCARD]
+type: param uint 31
+description: Number of MSB bits to discard
+
+[DATA]
+type: bit_out
+description: Data input from slave encoder
+
+[CONN]
+type: bit_out
+description: Signal detected
+
+[HOMED]
+type: read bit
+description: Quadrature homed status
+
+[HEALTH]
+type: read enum
+description: Table status
+0: OK
+1: Linkup error (=not CONN)
+2: Timeout error (for BISS, monitor SSI)
+3: CRC error (for BISS)
+4: Error bit active (for BISS)
+5: ENDAT not implemented
+6: Protocol readback error
+
+[VAL]
+type: pos_out
+description: Current position
+
+[DCARD_TYPE]
+type: read enum
+description: Daughter card jumper mode
+0: DCARD id 0
+1: Encoder Control
+2: DCARD id 2
+3: Encoder Monitor
+4: DCARD id 3
+5: DCARD id 4
+6: DCARD id 5
+7: Unplugged

--- a/modules/absenc/absenc_doc.rst
+++ b/modules/absenc/absenc_doc.rst
@@ -1,0 +1,8 @@
+ABSENC - Absolute encoder
+=========================
+The ABSENC block handles the Absolute encoder signals
+
+Fields
+------
+
+.. block_fields:: modules/absenc/absenc.block.ini

--- a/modules/absenc/hdl
+++ b/modules/absenc/hdl
@@ -1,0 +1,1 @@
+../../common/hdl/encoders

--- a/modules/incenc/hdl
+++ b/modules/incenc/hdl
@@ -1,0 +1,1 @@
+../../common/hdl/encoders

--- a/modules/incenc/incenc.block.ini
+++ b/modules/incenc/incenc.block.ini
@@ -48,6 +48,17 @@ description: Signal detected
 type: read bit
 description: Quadrature homed status
 
+[QPERIOD]
+type: param time
+description: Quadrature prescaler
+
+[QSTATE]
+type: read enum
+description: Quadrature state
+0: Disabled
+1: At position
+2: Slewing
+
 [HEALTH]
 type: read enum
 description: Table status

--- a/modules/incenc/incenc.block.ini
+++ b/modules/incenc/incenc.block.ini
@@ -1,0 +1,65 @@
+[.]
+description: Incremental encoder
+entity: incenc
+
+[PROTOCOL]
+type: param enum
+description: Type of absolute/incremental protocol
+0: Quadrature
+1: Step/Direction
+
+[BITS]
+type: param uint 63
+description: Number of bits
+
+[LSB_DISCARD]
+type: param uint 31
+description: Number of LSB bits to discard
+
+[MSB_DISCARD]
+type: param uint 31
+description: Number of MSB bits to discard
+
+[SETP]
+type: write int
+description: Set point
+
+[RST_ON_Z]
+type: param bit
+description: Zero position on Z rising edge
+
+[A]
+type: bit_out
+description: Quadrature A if in incremental mode
+
+[B]
+type: bit_out
+description: Quadrature B if in incremental mode
+
+[Z]
+type: bit_out
+description: Z index channel if in incremental mode
+
+[CONN]
+type: bit_out
+description: Signal detected
+
+[HOMED]
+type: read bit
+description: Quadrature homed status
+
+[HEALTH]
+type: read enum
+description: Table status
+0: OK
+1: Linkup error (=not CONN)
+2: Timeout error (for BISS, monitor SSI)
+3: CRC error (for BISS)
+4: Error bit active (for BISS)
+5: ENDAT not implemented
+6: Protocol readback error
+
+[VAL]
+type: pos_out
+description: Current position
+

--- a/modules/incenc/incenc.block.ini
+++ b/modules/incenc/incenc.block.ini
@@ -28,17 +28,17 @@ description: Set point
 type: param bit
 description: Zero position on Z rising edge
 
-[A]
-type: bit_out
-description: Quadrature A if in incremental mode
+; [A]
+; type: bit_out
+; description: Quadrature A if in incremental mode
 
-[B]
-type: bit_out
-description: Quadrature B if in incremental mode
+; [B]
+; type: bit_out
+; description: Quadrature B if in incremental mode
 
-[Z]
-type: bit_out
-description: Z index channel if in incremental mode
+; [Z]
+; type: bit_out
+; description: Z index channel if in incremental mode
 
 [CONN]
 type: bit_out

--- a/modules/incenc/incenc_doc.rst
+++ b/modules/incenc/incenc_doc.rst
@@ -1,0 +1,8 @@
+INENC - Input encoder
+=====================
+The INENC block handles the encoder input signals
+
+Fields
+------
+
+.. block_fields:: modules/inenc/inenc.block.ini

--- a/modules/inenc/inenc.block.ini
+++ b/modules/inenc/inenc.block.ini
@@ -85,7 +85,7 @@ type: read enum
 description: Table status
 0: OK
 1: Linkup error (=not CONN)
-2: Timeout error (for BISS, monitor SSI)
+2: Timeout error (for BISS, SSI)
 3: CRC error (for BISS)
 4: Error bit active (for BISS)
 5: ENDAT not implemented

--- a/modules/pmacenc/hdl
+++ b/modules/pmacenc/hdl
@@ -1,0 +1,1 @@
+../../common/hdl/encoders

--- a/modules/pmacenc/pmacenc.block.ini
+++ b/modules/pmacenc/pmacenc.block.ini
@@ -1,0 +1,87 @@
+[.]
+entity: pmacenc
+description: Pmac encoder
+
+[ENABLE]
+type: bit_mux
+description: Halt of falling edge, reset and enable on rising
+
+[GENERATOR_ERROR]
+type: param enum
+description: generate error on output
+0: No
+1: BISS frame error bit
+
+[DATA]
+type: bit_mux
+description: Data output to master encoder
+
+[PROTOCOL]
+type: param enum
+description: Type of absolute/incremental protocol
+0: Passthrough - UVWT
+1: Passthrough - Absolute
+2: Read - Step/Direction
+3: Generate - SSI
+4: Generate - enDat
+5: Generate - Biss
+
+[ENCODING]
+type: param enum
+description: Position encoding (for absolute encoders)
+0: Unsigned Binary
+1: Unsigned Gray
+2: Signed Binary
+3: Signed Gray
+
+[BITS]
+type: param uint 32
+description: Number of bits
+
+[QPERIOD]
+type: param time
+description: Quadrature prescaler
+
+[QSTATE]
+type: read enum
+description: Quadrature state
+0: Disabled
+1: At position
+2: Slewing
+
+[CLK]
+type: bit_out
+description: Clock input from encoder
+
+; [STEP]
+; type: bit_out
+; description: STEP input from encoder
+
+; [DIR]
+; type: bit_out
+; description: Direction input from encoder
+
+[VAL]
+type: pos_mux
+description: Input for position (all other protocols)
+
+[HEALTH]
+type: read enum
+description: Table status
+0: OK
+1: Biss timeout error (did not received right number of sck for biss frame)
+2: ENDAT not implemented
+3: OUTENC unused (MONITOR mode)
+4: Protocol readback error
+
+[DCARD_TYPE]
+type: read enum
+description: Daughter card jumper mode
+0: DCARD id 0
+1: Encoder Control
+2: DCARD id 2
+3: Encoder Monitor
+4: DCARD id 3
+5: DCARD id 4
+6: DCARD id 5
+7: Unplugged

--- a/modules/pmacenc/pmacenc.block.ini
+++ b/modules/pmacenc/pmacenc.block.ini
@@ -38,17 +38,6 @@ description: Position encoding (for absolute encoders)
 type: param uint 32
 description: Number of bits
 
-[QPERIOD]
-type: param time
-description: Quadrature prescaler
-
-[QSTATE]
-type: read enum
-description: Quadrature state
-0: Disabled
-1: At position
-2: Slewing
-
 [CLK]
 type: bit_out
 description: Clock input from encoder

--- a/modules/pmacenc/pmacenc.block.ini
+++ b/modules/pmacenc/pmacenc.block.ini
@@ -62,15 +62,3 @@ description: Table status
 2: ENDAT not implemented
 3: OUTENC unused (MONITOR mode)
 4: Protocol readback error
-
-[DCARD_TYPE]
-type: read enum
-description: Daughter card jumper mode
-0: DCARD id 0
-1: Encoder Control
-2: DCARD id 2
-3: Encoder Monitor
-4: DCARD id 3
-5: DCARD id 4
-6: DCARD id 5
-7: Unplugged

--- a/modules/pmacenc/pmacenc_doc.rst
+++ b/modules/pmacenc/pmacenc_doc.rst
@@ -1,0 +1,8 @@
+PMACENC - Pmac encoder
+======================
+The PMACENC block handles the pmac encoder signals
+
+Fields
+------
+
+.. block_fields:: modules/pmacenc/pmacenc.block.ini

--- a/targets/PandABrick/PandABrick.target.ini
+++ b/targets/PandABrick/PandABrick.target.ini
@@ -11,10 +11,13 @@ number: 2
 [TTLOUT]
 number: 2
 
-[INENC]
+[ABSENC]
 number: 8
 
-[OUTENC]
+[INCENC]
+number: 8
+
+[PMACENC]
 number: 8
 
 [PCAP]

--- a/targets/PandABrick/hdl/PandABrick_encoders.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders.vhd
@@ -128,6 +128,9 @@ signal homed_qdec           : std_logic_vector(31 downto 0);
 signal linkup_incr          : std_logic;
 signal linkup_incr_std32    : std_logic_vector(31 downto 0);
 signal linkup_ssi           : std_logic;
+signal ssi_frame            : std_logic;
+signal ssi_frame_sniffer    : std_logic;
+signal ssi_frame_master     : std_logic;
 signal linkup_biss_sniffer  : std_logic;
 signal health_biss_sniffer  : std_logic_vector(31 downto 0);
 signal linkup_biss_master   : std_logic;
@@ -341,7 +344,8 @@ port map (
     ssi_sck_o       => clk_out_encoder_ssi,
     ssi_dat_i       => DATA_IN,
     posn_o          => posn_ssi,
-    posn_valid_o    => open
+    posn_valid_o    => open,
+    ssi_frame_o     => ssi_frame_master
 );
 
 -- SSI Sniffer
@@ -351,11 +355,22 @@ port map (
     reset_i         => reset_i,
     ENCODING        => ABSENC_ENCODING_i,
     BITS            => ABSENC_BITS_i,
-    link_up_o       => linkup_ssi,
     error_o         => open,
     ssi_sck_i       => CLK_IN,
     ssi_dat_i       => DATA_IN,
-    posn_o          => posn_ssi_sniffer
+    posn_o          => posn_ssi_sniffer,
+    ssi_frame_o     => ssi_frame_sniffer
+);
+
+ssi_frame <= ssi_frame_sniffer;
+
+-- Frame checker for SSI
+ssi_err_det_inst: entity work.ssi_error_detect
+port map (
+    clk_i           => clk_i,
+    serial_dat_i    => DATA_IN,
+    ssi_frame_i     => ssi_frame,
+    link_up_o       => linkup_ssi
 );
 
 -- Loopbacks

--- a/targets/PandABrick/hdl/PandABrick_encoders.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders.vhd
@@ -23,10 +23,10 @@ port (
     posn_i              : in  std_logic_vector(31 downto 0);
     enable_i            : in  std_logic;
     -- Encoder I/O Pads
-    INENC_A_o           : out std_logic;
-    INENC_B_o           : out std_logic;
-    INENC_Z_o           : out std_logic;
-    INENC_DATA_o        : out std_logic;
+    INCENC_A_o          : out std_logic;
+    INCENC_B_o          : out std_logic;
+    INCENC_Z_o          : out std_logic;
+    ABSENC_DATA_o       : out std_logic;
     --
     clk_out_ext_i       : in  std_logic;
     clk_int_o           : out std_logic;
@@ -51,47 +51,61 @@ port (
 
     -- Block parameters
     GENERATOR_ERROR_i   : in  std_logic;
-    OUTENC_PROTOCOL_i   : in  std_logic_vector(2 downto 0);
-    OUTENC_ENCODING_i   : in  std_logic_vector(1 downto 0);
-    OUTENC_BITS_i       : in  std_logic_vector(7 downto 0);
+    PMACENC_PROTOCOL_i  : in  std_logic_vector(2 downto 0);
+    PMACENC_ENCODING_i  : in  std_logic_vector(1 downto 0);
+    PMACENC_BITS_i      : in  std_logic_vector(7 downto 0);
     QPERIOD_i           : in  std_logic_vector(31 downto 0);
     QPERIOD_WSTB_i      : in  std_logic;
-    OUTENC_HEALTH_o     : out std_logic_vector(31 downto 0);
+    PMACENC_HEALTH_o    : out std_logic_vector(31 downto 0);
     QSTATE_o            : out std_logic_vector(31 downto 0);
 
-    DCARD_MODE_i        : in  std_logic_vector(31 downto 0);
-    INENC_PROTOCOL_i    : in  std_logic_vector(2 downto 0);
-    INENC_ENCODING_i    : in  std_logic_vector(1 downto 0);
-    CLK_SRC_i           : in  std_logic;
-    CLK_PERIOD_i        : in  std_logic_vector(31 downto 0);
-    FRAME_PERIOD_i      : in  std_logic_vector(31 downto 0);
-    INENC_BITS_i        : in  std_logic_vector(7 downto 0);
+    INCENC_PROTOCOL_i   : in  std_logic_vector(2 downto 0);
+    INCENC_ENCODING_i   : in  std_logic_vector(1 downto 0);
+    INCENC_BITS_i       : in  std_logic_vector(7 downto 0);
     LSB_DISCARD_i       : in  std_logic_vector(4 downto 0);
     MSB_DISCARD_i       : in  std_logic_vector(4 downto 0);
     SETP_i              : in  std_logic_vector(31 downto 0);
     SETP_WSTB_i         : in  std_logic;
     RST_ON_Z_i          : in  std_logic_vector(31 downto 0);
     STATUS_o            : out std_logic_vector(31 downto 0);
-    INENC_HEALTH_o      : out std_logic_vector(31 downto 0);
+    INCENC_HEALTH_o     : out std_logic_vector(31 downto 0);
     HOMED_o             : out std_logic_vector(31 downto 0);
+
+    DCARD_MODE_i        : in  std_logic_vector(31 downto 0);
+    ABSENC_PROTOCOL_i   : in  std_logic_vector(2 downto 0);
+    ABSENC_ENCODING_i   : in  std_logic_vector(1 downto 0);
+    CLK_SRC_i           : in  std_logic;
+    CLK_PERIOD_i        : in  std_logic_vector(31 downto 0);
+    FRAME_PERIOD_i      : in  std_logic_vector(31 downto 0);
+    ABSENC_BITS_i       : in  std_logic_vector(7 downto 0);
+    ABSENC_LSB_DISCARD_i   : in  std_logic_vector(4 downto 0);
+    ABSENC_MSB_DISCARD_i   : in  std_logic_vector(4 downto 0);
+    ABSENC_STATUS_o        : out std_logic_vector(31 downto 0);
+    ABSENC_HEALTH_o     : out std_logic_vector(31 downto 0);
+    ABSENC_HOMED_o      : out std_logic_vector(31 downto 0);
+
     -- Block Outputs
-    posn_o              : out std_logic_vector(31 downto 0)
+    abs_posn_o          : out std_logic_vector(31 downto 0);
+    inc_posn_o          : out std_logic_vector(31 downto 0)
 );
 end entity;
 
 
 architecture rtl of pandabrick_encoders is
 
-constant c_ABZ_PASSTHROUGH  : std_logic_vector(2 downto 0) := std_logic_vector(to_unsigned(4,3));
-constant c_DATA_PASSTHROUGH : std_logic_vector(2 downto 0) := std_logic_vector(to_unsigned(5,3));
-constant c_BISS             : std_logic_vector(2 downto 0) := std_logic_vector(to_unsigned(2,3));
-constant c_enDat            : std_logic_vector(2 downto 0) := std_logic_vector(to_unsigned(3,3));
+-- constant c_ABZ_PASSTHROUGH  : std_logic_vector(2 downto 0) := std_logic_vector(to_unsigned(4,3));
+-- constant c_DATA_PASSTHROUGH : std_logic_vector(2 downto 0) := std_logic_vector(to_unsigned(5,3));
+constant c_BISS             : std_logic_vector(2 downto 0) := std_logic_vector(to_unsigned(5,3));
+-- constant c_enDat            : std_logic_vector(2 downto 0) := std_logic_vector(to_unsigned(3,3));
 
 signal quad_a               : std_logic;
 signal quad_b               : std_logic;
 signal sdat                 : std_logic;
 signal bdat                 : std_logic;
+signal Passthrough          : std_logic;
+signal UVWT                 : std_logic;
 signal health_biss_slave    : std_logic_vector(31 downto 0);
+signal absenc_enable        : std_logic;
 
 signal clk_out_encoder_ssi  : std_logic;
 signal clk_out_encoder_biss : std_logic;
@@ -101,8 +115,10 @@ signal posn_biss            : std_logic_vector(31 downto 0);
 signal posn_ssi_sniffer     : std_logic_vector(31 downto 0);
 signal posn_biss_sniffer    : std_logic_vector(31 downto 0);
 signal posn                 : std_logic_vector(31 downto 0);
+signal posn_inc             : std_logic_vector(31 downto 0);
 signal posn_prev            : std_logic_vector(31 downto 0);
 signal bits_not_used        : unsigned(4 downto 0);
+signal inc_bits_not_used    : unsigned(4 downto 0);
 
 signal homed_qdec           : std_logic_vector(31 downto 0);
 signal linkup_incr          : std_logic;
@@ -139,64 +155,24 @@ signal CLK_IN               : std_logic;
 
 begin
 
------------------------------OUTENC---------------------------------------------
---------------------------------------------------------------------------------
--- When using the monitor control card, only the B signal is used as this is 
--- used to generate the Clock inputted to the Inenc.
-
--- Assign outputs
-A_OUT <= a_ext_i when (OUTENC_PROTOCOL_i = c_ABZ_PASSTHROUGH) else quad_a;
-B_OUT <= b_ext_i when (OUTENC_PROTOCOL_i = c_ABZ_PASSTHROUGH) else quad_b;
-Z_OUT <= z_ext_i when (OUTENC_PROTOCOL_i = c_ABZ_PASSTHROUGH) else '0';
-DATA_OUT <= data_ext_i when (OUTENC_PROTOCOL_i = c_DATA_PASSTHROUGH) else 
-            bdat when (OUTENC_PROTOCOL_i = c_BISS) else sdat;
-
---
--- INCREMENTAL OUT
---
-qenc_inst : entity work.qenc
-port map (
-    clk_i           => clk_i,
-    reset_i         => reset_i,
-    QPERIOD         => QPERIOD_i,
-    QPERIOD_WSTB    => QPERIOD_WSTB_i,
-    QSTATE          => QSTATE_o,
-    enable_i        => enable_i,
-    posn_i          => posn_i,
-    a_o             => quad_a,
-    b_o             => quad_b
-);
-
---
--- SSI SLAVE
---
-ssi_slave_inst : entity work.ssi_slave
-port map (
-    clk_i           => clk_i,
-    reset_i         => reset_i,
-    ENCODING        => OUTENC_ENCODING_i,
-    BITS            => OUTENC_BITS_i,
-    posn_i          => posn_i,
-    ssi_sck_i       => CLK_IN,
-    ssi_dat_o       => sdat
-);
-
---
--- BISS SLAVE
---
-biss_slave_inst : entity work.biss_slave
-port map (
-    clk_i             => clk_i,
-    reset_i           => reset_i,
-    ENCODING          => OUTENC_ENCODING_i,
-    BITS              => OUTENC_BITS_i,
-    enable_i          => enable_i,
-    GENERATOR_ERROR   => GENERATOR_ERROR_i,
-    health_o          => health_biss_slave,
-    posn_i            => posn_i,
-    biss_sck_i        => CLK_IN,
-    biss_dat_o        => bdat
-);
+-----------------------------INCENC---------------------------------------------
+ps_select: process(clk_i)
+begin
+    if rising_edge(clk_i) then
+        -- BITS not begin used
+        inc_bits_not_used <= 31 - (unsigned(INCENC_BITS_i(4 downto 0))-1);
+        inc_lp_test: for i in 31 downto 0 loop
+           -- Discard bits not being used and MSB and LSB and extend the sign.
+           -- Note that we need the loop to manipulate the vector. Slicing with \
+           -- variable indices is not synthesisable.
+           if (i > 31 - inc_bits_not_used - unsigned(MSB_DISCARD_i) - unsigned(LSB_DISCARD_i)) then
+                inc_posn_o(i) <= '0';
+           else
+               inc_posn_o(i) <= posn_inc(i + to_integer(unsigned(LSB_DISCARD_i)));
+           end if;
+        end loop inc_lp_test;
+    end if;
+end process ps_select;
 
 --------------------------------------------------------------------------
 -- Position Data and STATUS readback multiplexer
@@ -206,62 +182,30 @@ port map (
 process(clk_i)
 begin
     if rising_edge(clk_i) then
-        case (OUTENC_PROTOCOL_i) is
-            when "000"  =>              -- INC
-                OUTENC_HEALTH_o <= (others=>'0');
+        case (INCENC_PROTOCOL_i) is
+            when "000"  =>              -- Quadrature
+                posn_inc <= posn_incr;
+                STATUS_o(0) <= linkup_incr;
+                INCENC_HEALTH_o(0) <= not(linkup_incr);
+                INCENC_HEALTH_o(31 downto 1)<= (others=>'0');
+                HOMED_o <= homed_qdec;
 
-            when "001"  =>              -- SSI & Loopback
-                OUTENC_HEALTH_o <= (others=>'0');
-
-            when "010"  =>              -- BISS & Loopback
-                OUTENC_HEALTH_o <= health_biss_slave;
-                
-            when c_enDat =>             -- enDat 
-                OUTENC_HEALTH_o <= std_logic_vector(to_unsigned(2,32)); --ENDAT not implemented
-                
-            when others =>
-                OUTENC_HEALTH_o <= (others=>'0');
-                
+            when "001"  =>              -- Step/Direction
+                posn_inc <= posn_incr;
+                STATUS_o(0) <= linkup_incr;
+                INCENC_HEALTH_o(0) <= not(linkup_incr);
+                INCENC_HEALTH_o(31 downto 1)<= (others=>'0');
+                HOMED_o <= homed_qdec;
+            
+            when others => 
+                posn_inc <= posn_incr;
+                STATUS_o(0) <= linkup_incr;
+                INCENC_HEALTH_o(0) <= not(linkup_incr);
+                INCENC_HEALTH_o(31 downto 1)<= (others=>'0');
+                HOMED_o <= homed_qdec;
         end case;
     end if;
 end process;
-
----------------------------------INENC------------------------------------
---------------------------------------------------------------------------
--- Assign outputs
---------------------------------------------------------------------------
-
-ps_select: process(clk_i)
-begin
-    if rising_edge(clk_i) then
-        -- BITS not begin used
-        bits_not_used <= 31 - (unsigned(INENC_BITS_i(4 downto 0))-1);
-        lp_test: for i in 31 downto 0 loop
-           -- Discard bits not being used and MSB and LSB and extend the sign.
-           -- Note that we need the loop to manipulate the vector. Slicing with \
-           -- variable indices is not synthesisable.
-           if (i > 31 - bits_not_used - unsigned(MSB_DISCARD_i) - unsigned(LSB_DISCARD_i)) then
-               if ((INENC_ENCODING_i=c_UNSIGNED_BINARY_ENCODING) or (INENC_ENCODING_i=c_UNSIGNED_GRAY_ENCODING)) then
-                   posn_o(i) <= '0';
-               else
-                   -- sign extension
-                   posn_o(i) <= posn(31 - to_integer(bits_not_used + unsigned(MSB_DISCARD_i)));
-               end if;
-           -- Add the LSB_DISCARD on to posn index count and start there
-           else
-               posn_o(i) <= posn(i + to_integer(unsigned(LSB_DISCARD_i)));
-           end if;
-        end loop lp_test;
-    end if;
-end process ps_select;
-
--- Loopbacks
-CLK_OUT <=    clk_out_ext_i when (CLK_SRC_i = '1') else
-              clk_out_encoder_biss when (CLK_SRC_i = '0' and INENC_PROTOCOL_i = "010") else
-              clk_out_encoder_ssi;
-
-
-
 --------------------------------------------------------------------------
 -- Incremental Encoder Instantiation :
 --------------------------------------------------------------------------
@@ -283,6 +227,94 @@ port map (
 linkup_incr <= not DCARD_MODE_i(0);
 linkup_incr_std32 <= x"0000000"&"000"&linkup_incr;
 
+-- --
+-- -- INCREMENTAL OUT
+-- --
+-- qenc_inst : entity work.qenc
+-- port map (
+--     clk_i           => clk_i,
+--     reset_i         => reset_i,
+--     QPERIOD         => QPERIOD_i,
+--     QPERIOD_WSTB    => QPERIOD_WSTB_i,
+--     QSTATE          => QSTATE_o,
+--     enable_i        => enable_i,
+--     posn_i          => posn_i,
+--     a_o             => quad_a,
+--     b_o             => quad_b
+-- );
+
+-----------------------------ABSENC---------------------------------------------
+
+abs_ps_select: process(clk_i)
+begin
+    if rising_edge(clk_i) then
+        -- BITS not begin used
+        bits_not_used <= 31 - (unsigned(ABSENC_BITS_i(4 downto 0))-1);
+        lp_test: for i in 31 downto 0 loop
+           -- Discard bits not being used and MSB and LSB and extend the sign.
+           -- Note that we need the loop to manipulate the vector. Slicing with \
+           -- variable indices is not synthesisable.
+           if (i > 31 - bits_not_used - unsigned(ABSENC_MSB_DISCARD_i) - unsigned(ABSENC_LSB_DISCARD_i)) then
+               if ((ABSENC_ENCODING_i=c_UNSIGNED_BINARY_ENCODING) or (ABSENC_ENCODING_i=c_UNSIGNED_GRAY_ENCODING)) then
+                   abs_posn_o(i) <= '0';
+               else
+                   -- sign extension
+                   abs_posn_o(i) <= posn(31 - to_integer(bits_not_used + unsigned(MSB_DISCARD_i)));
+               end if;
+           -- Add the LSB_DISCARD on to posn index count and start there
+           else
+               abs_posn_o(i) <= posn(i + to_integer(unsigned(ABSENC_LSB_DISCARD_i)));
+           end if;
+        end loop lp_test;
+    end if;
+end process abs_ps_select;
+
+--------------------------------------------------------------------------
+-- Position Data and STATUS readback multiplexer
+--
+--  Link status information is valid only for loopback configuration
+--------------------------------------------------------------------------
+process(clk_i)
+begin
+    if rising_edge(clk_i) then
+        case (INCENC_PROTOCOL_i) is
+            when "000"  =>              -- SSI
+                if (DCARD_MODE_i(3 downto 1) = DCARD_MONITOR) then
+                    posn <= posn_ssi_sniffer;
+                    ABSENC_STATUS_o(0) <= linkup_ssi;
+                    if (linkup_ssi = '0') then
+                        ABSENC_HEALTH_o <= TO_SVECTOR(2,32);
+                    else
+                        ABSENC_HEALTH_o <= (others => '0');
+                    end if;
+                else  -- DCARD_CONTROL
+                    posn <= posn_ssi;
+                    ABSENC_STATUS_o <= (others => '0');
+                    ABSENC_HEALTH_o <= (others=>'0');
+                end if;
+                ABSENC_HOMED_o <= TO_SVECTOR(1,32);
+
+            when "010"  =>              -- BISS & Loopback
+                if (DCARD_MODE_i(3 downto 1) = DCARD_MONITOR) then
+                    posn <= posn_biss_sniffer;
+                    ABSENC_STATUS_o(0) <= linkup_biss_sniffer;
+                    ABSENC_HEALTH_o <= health_biss_sniffer;
+                else  -- DCARD_CONTROL
+                    posn <= posn_biss;
+                    ABSENC_STATUS_o(0) <= linkup_biss_master;
+                    ABSENC_HEALTH_o<=health_biss_master;
+                end if;
+                ABSENC_HOMED_o <= TO_SVECTOR(1,32);
+
+            when others =>
+                ABSENC_HEALTH_o <= TO_SVECTOR(5,32);
+                posn <= (others => '0');
+                ABSENC_STATUS_o <= (others => '0');
+                ABSENC_HOMED_o <= TO_SVECTOR(1,32);
+        end case;
+    end if;
+end process;
+
 --------------------------------------------------------------------------
 -- SSI Instantiations
 --------------------------------------------------------------------------
@@ -292,8 +324,8 @@ ssi_master_inst : entity work.ssi_master
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
-    ENCODING        => INENC_ENCODING_i,
-    BITS            => INENC_BITS_i,
+    ENCODING        => ABSENC_ENCODING_i,
+    BITS            => ABSENC_BITS_i,
     CLK_PERIOD      => CLK_PERIOD_i,
     FRAME_PERIOD    => FRAME_PERIOD_i,
     ssi_sck_o       => clk_out_encoder_ssi,
@@ -307,14 +339,19 @@ ssi_sniffer_inst : entity work.ssi_sniffer
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
-    ENCODING        => INENC_ENCODING_i,
-    BITS            => INENC_BITS_i,
+    ENCODING        => ABSENC_ENCODING_i,
+    BITS            => ABSENC_BITS_i,
     link_up_o       => linkup_ssi,
     error_o         => open,
     ssi_sck_i       => CLK_IN,
     ssi_dat_i       => DATA_IN,
     posn_o          => posn_ssi_sniffer
 );
+
+-- Loopbacks
+CLK_OUT <=    clk_out_ext_i when (CLK_SRC_i = '1') else
+    clk_out_encoder_biss when (CLK_SRC_i = '0' and ABSENC_PROTOCOL_i = "101") else
+    clk_out_encoder_ssi;
 
 --------------------------------------------------------------------------
 -- BiSS Instantiations
@@ -324,8 +361,8 @@ biss_master_inst : entity work.biss_master
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
-    ENCODING        => INENC_ENCODING_i,
-    BITS            => INENC_BITS_i,
+    ENCODING        => ABSENC_ENCODING_i,
+    BITS            => ABSENC_BITS_i,
     link_up_o       => linkup_biss_master,
     health_o        => health_biss_master,
     CLK_PERIOD      => CLK_PERIOD_i,
@@ -341,14 +378,57 @@ biss_sniffer_inst : entity work.biss_sniffer
 port map (
     clk_i           => clk_i,
     reset_i         => reset_i,
-    ENCODING        => INENC_ENCODING_i,
-    BITS            => INENC_BITS_i,
+    ENCODING        => ABSENC_ENCODING_i,
+    BITS            => ABSENC_BITS_i,
     link_up_o       => linkup_biss_sniffer,
     health_o        => health_biss_sniffer,
     error_o         => open,
     ssi_sck_i       => CLK_IN,
     ssi_dat_i       => DATA_IN,
     posn_o          => posn_biss_sniffer
+);
+
+
+-----------------------------PMACENC---------------------------------------------
+-- When using the monitor control card, only the B signal is used as this is 
+-- used to generate the Clock inputted to the Inenc.
+
+-- Assign outputs
+A_OUT <= a_ext_i when (Passthrough = '1') else quad_a;
+B_OUT <= b_ext_i when (Passthrough = '1') else quad_b;
+Z_OUT <= z_ext_i when (Passthrough = '1') else '0';
+DATA_OUT <= data_ext_i when (Passthrough = '1') else 
+            bdat when (PMACENC_PROTOCOL_i = c_BISS) else sdat;
+
+--
+-- SSI SLAVE
+--
+ssi_slave_inst : entity work.ssi_slave
+port map (
+    clk_i           => clk_i,
+    reset_i         => reset_i,
+    ENCODING        => PMACENC_ENCODING_i,
+    BITS            => PMACENC_BITS_i,
+    posn_i          => posn_i,
+    ssi_sck_i       => CLK_IN,
+    ssi_dat_o       => sdat
+);
+
+--
+-- BISS SLAVE
+--
+biss_slave_inst : entity work.biss_slave
+port map (
+    clk_i             => clk_i,
+    reset_i           => reset_i,
+    ENCODING          => PMACENC_ENCODING_i,
+    BITS              => PMACENC_BITS_i,
+    enable_i          => enable_i,
+    GENERATOR_ERROR   => GENERATOR_ERROR_i,
+    health_o          => health_biss_slave,
+    posn_i            => posn_i,
+    biss_sck_i        => CLK_IN,
+    biss_dat_o        => bdat
 );
 
 --------------------------------------------------------------------------
@@ -359,47 +439,48 @@ port map (
 process(clk_i)
 begin
     if rising_edge(clk_i) then
-        case (INENC_PROTOCOL_i) is
-            when "000"  =>              -- INC
-                posn <= posn_incr;
-                STATUS_o(0) <= linkup_incr;
-                INENC_HEALTH_o(0) <= not(linkup_incr);
-                INENC_HEALTH_o(31 downto 1)<= (others=>'0');
-                HOMED_o <= homed_qdec;
+        case (PMACENC_PROTOCOL_i) is
+            when "000"  =>              -- Passthrough - UVWT
+                PMACENC_HEALTH_o <= (others=>'0');
+                ABSENC_ENABLE <= '0';
+                UVWT <= '1';
+                Passthrough <= '1';
+            when "001"  =>              -- Passthrough - Absolute
+                PMACENC_HEALTH_o <= (others=>'0');
+                ABSENC_ENABLE <= '1';
+                UVWT <= '0';
+                Passthrough <= '1';
 
-            when "001"  =>              -- SSI & Loopback
-                if (DCARD_MODE_i(3 downto 1) = DCARD_MONITOR) then
-                    posn <= posn_ssi_sniffer;
-                    STATUS_o(0) <= linkup_ssi;
-                    if (linkup_ssi = '0') then
-                        INENC_HEALTH_o <= TO_SVECTOR(2,32);
-                    else
-                        INENC_HEALTH_o <= (others => '0');
-                    end if;
-                else  -- DCARD_CONTROL
-                    posn <= posn_ssi;
-                    STATUS_o <= (others => '0');
-                    INENC_HEALTH_o <= (others=>'0');
-                end if;
-                HOMED_o <= TO_SVECTOR(1,32);
+            when "010"  =>              -- Read - Step/Direction
+                PMACENC_HEALTH_o <= (others=>'0');
+                ABSENC_ENABLE <= '1';
+                UVWT <= '0';
+                Passthrough <= '0';
 
-            when "010"  =>              -- BISS & Loopback
-                if (DCARD_MODE_i(3 downto 1) = DCARD_MONITOR) then
-                    posn <= posn_biss_sniffer;
-                    STATUS_o(0) <= linkup_biss_sniffer;
-                    INENC_HEALTH_o <= health_biss_sniffer;
-                else  -- DCARD_CONTROL
-                    posn <= posn_biss;
-                    STATUS_o(0) <= linkup_biss_master;
-                    INENC_HEALTH_o<=health_biss_master;
-                end if;
-                HOMED_o <= TO_SVECTOR(1,32);
+            when "011"  =>              -- Generate - SSI
+                PMACENC_HEALTH_o <= (others=>'0');
+                ABSENC_ENABLE <= '1';
+                UVWT <= '0';
+                Passthrough <= '0';
 
+            when "100"  =>              -- Generate - enDat
+                PMACENC_HEALTH_o <= std_logic_vector(to_unsigned(2,32)); --ENDAT not implemented
+                ABSENC_ENABLE <= '1';
+                UVWT <= '0';
+                Passthrough <= '0';
+
+            when "101"  =>              -- Generate Biss
+                PMACENC_HEALTH_o <= health_biss_slave;
+                ABSENC_ENABLE <= '1';
+                UVWT <= '0';
+                Passthrough <= '0';
+                                
             when others =>
-                INENC_HEALTH_o <= TO_SVECTOR(5,32);
-                posn <= (others => '0');
-                STATUS_o <= (others => '0');
-                HOMED_o <= TO_SVECTOR(1,32);
+                PMACENC_HEALTH_o <= (others=>'0');
+                ABSENC_ENABLE <= '1';
+                UVWT <= '0';
+                Passthrough <= '0';
+
         end case;
     end if;
 end process;
@@ -463,10 +544,11 @@ As0_opad <= A_OUT;
 Bs0_opad <= B_OUT;
 Zs0_opad <= Z_OUT;
 
-INENC_A_o <= A_IN;
-INENC_B_o <= B_IN;
-INENC_Z_o <= Z_IN;
-INENC_DATA_o <= DATA_IN;
+INCENC_A_o <= A_IN;
+INCENC_B_o <= B_IN;
+INCENC_Z_o <= Z_IN;
+
+ABSENC_DATA_o <= DATA_IN;
 
 clk_int_o <= CLK_IN;
 

--- a/targets/PandABrick/hdl/PandABrick_encoders.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders.vhd
@@ -84,6 +84,8 @@ port (
     ABSENC_HEALTH_o     : out std_logic_vector(31 downto 0);
     ABSENC_HOMED_o      : out std_logic_vector(31 downto 0);
 
+    UVWT_o              : out std_logic;
+
     -- Block Outputs
     abs_posn_o          : out std_logic_vector(31 downto 0);
     inc_posn_o          : out std_logic_vector(31 downto 0)

--- a/targets/PandABrick/hdl/PandABrick_encoders.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders.vhd
@@ -71,7 +71,6 @@ port (
     INCENC_HEALTH_o     : out std_logic_vector(31 downto 0);
     HOMED_o             : out std_logic_vector(31 downto 0);
 
-    DCARD_MODE_i        : in  std_logic_vector(31 downto 0);
     ABSENC_PROTOCOL_i   : in  std_logic_vector(2 downto 0);
     ABSENC_ENCODING_i   : in  std_logic_vector(1 downto 0);
     CLK_SRC_i           : in  std_logic;
@@ -229,7 +228,7 @@ port map (
     out_o           => posn_incr
 );
 
-linkup_incr <= not DCARD_MODE_i(0);
+linkup_incr <= '1';
 linkup_incr_std32 <= x"0000000"&"000"&linkup_incr;
 
 --
@@ -306,15 +305,15 @@ begin
                 ABSENC_HOMED_o <= TO_SVECTOR(1,32);
 
             when "001"  =>              -- BISS & Loopback
-                if (DCARD_MODE_i(3 downto 1) = DCARD_MONITOR) then
-                    posn <= posn_biss_sniffer;
-                    ABSENC_STATUS_o(0) <= linkup_biss_sniffer;
-                    ABSENC_HEALTH_o <= health_biss_sniffer;
-                else  -- DCARD_CONTROL
-                    posn <= posn_biss;
-                    ABSENC_STATUS_o(0) <= linkup_biss_master;
-                    ABSENC_HEALTH_o<=health_biss_master;
-                end if;
+                -- if (DCARD_MODE_i(3 downto 1) = DCARD_MONITOR) then
+                posn <= posn_biss_sniffer;
+                ABSENC_STATUS_o(0) <= linkup_biss_sniffer;
+                ABSENC_HEALTH_o <= health_biss_sniffer;
+                -- else  -- DCARD_CONTROL
+                --     posn <= posn_biss;
+                --     ABSENC_STATUS_o(0) <= linkup_biss_master;
+                --     ABSENC_HEALTH_o<=health_biss_master;
+                -- end if;
                 ABSENC_HOMED_o <= TO_SVECTOR(1,32);
 
             when others =>

--- a/targets/PandABrick/hdl/PandABrick_encoders.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders.vhd
@@ -23,9 +23,9 @@ port (
     posn_i              : in  std_logic_vector(31 downto 0);
     enable_i            : in  std_logic;
     -- Encoder I/O Pads
-    INCENC_A_o          : out std_logic;
-    INCENC_B_o          : out std_logic;
-    INCENC_Z_o          : out std_logic;
+    -- INCENC_A_o          : out std_logic;
+    -- INCENC_B_o          : out std_logic;
+    -- INCENC_Z_o          : out std_logic;
     ABSENC_DATA_o       : out std_logic;
     --
     clk_out_ext_i       : in  std_logic;
@@ -555,9 +555,9 @@ As0_opad <= A_OUT;
 Bs0_opad <= B_OUT;
 Zs0_opad <= Z_OUT;
 
-INCENC_A_o <= A_IN;
-INCENC_B_o <= B_IN;
-INCENC_Z_o <= Z_IN;
+-- INCENC_A_o <= A_IN;
+-- INCENC_B_o <= B_IN;
+-- INCENC_Z_o <= Z_IN;
 
 ABSENC_DATA_o <= DATA_IN;
 

--- a/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
@@ -132,8 +132,8 @@ signal ABSENC_BITS_WSTB         : std_logic;
 signal SETP                     : std_logic_vector(31 downto 0);
 signal SETP_WSTB                : std_logic;
 signal RST_ON_Z                 : std_logic_vector(31 downto 0);
-signal STATUS                   : std_logic_vector(31 downto 0);
-signal absenc_STATUS            : std_logic_vector(31 downto 0);
+signal STATUS                   : std_logic;
+signal absenc_STATUS            : std_logic;
 signal read_ack                 : std_logic;
 signal LSB_DISCARD              : std_logic_vector(31 downto 0);
 signal MSB_DISCARD              : std_logic_vector(31 downto 0);
@@ -162,9 +162,9 @@ PMACENC_CONN_OUT_o <= enable;
 
 -- Input encoder connection status comes from either
 --  * Dcard pin [12] for incremental, or
---  * link_up status for absolute in loopback mode
-INCENC_CONN_OUT_o <= STATUS(0);
-ABSENC_CONN_OUT_o <= ABSENC_STATUS(0);
+--  * link_up status for absolute
+INCENC_CONN_OUT_o <= STATUS;
+ABSENC_CONN_OUT_o <= ABSENC_STATUS;
 -- Certain parameter changes must initiate a block reset.
 reset <= reset_i or PMACENC_PROTOCOL_WSTB or PMACENC_BITS_WSTB or INCENC_PROTOCOL_WSTB
          or PMACENC_ENCODING_WSTB or ABSENC_ENCODING_WSTB or ABSENC_PROTOCOL_WSTB

--- a/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
@@ -58,6 +58,8 @@ port (
     INCENC_CONN_OUT_o        : out std_logic;
     ABSENC_CONN_OUT_o        : out std_logic;
 
+    UVWT_o                   : out std_logic;
+
 
     clk_int_o               : out std_logic;
 
@@ -362,6 +364,8 @@ port map(
     ABSENC_STATUS_o      => ABSENC_STATUS,
     ABSENC_HEALTH_o     => ABSENC_HEALTH,
     ABSENC_HOMED_o      => ABSENC_HOMED,
+
+    UVWT_o              => UVWT_o,
     --
     -- Block Outputs
     abs_posn_o          => abs_posn_o,

--- a/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
@@ -83,7 +83,6 @@ port (
     
 
     -- Position Field interface
-    DCARD_MODE_i            : in  std_logic_vector(31 downto 0);
     bit_bus_i               : in  bit_bus_t;
     pos_bus_i               : in  pos_bus_t;
     posn_o                  : out std_logic_vector(31 downto 0);
@@ -106,7 +105,6 @@ signal PMACENC_BITS_WSTB        : std_logic;
 signal QPERIOD                  : std_logic_vector(31 downto 0);
 signal QPERIOD_WSTB             : std_logic;
 signal QSTATE                   : std_logic_vector(31 downto 0);
-signal DCARD_TYPE               : std_logic_vector(31 downto 0);
 signal PMACENC_HEALTH           : std_logic_vector(31 downto 0);
 signal a_ext, b_ext, z_ext, data_ext    : std_logic;
 signal posn                     : std_logic_vector(31 downto 0);
@@ -172,7 +170,7 @@ reset <= reset_i or PMACENC_PROTOCOL_WSTB or PMACENC_BITS_WSTB or INCENC_PROTOCO
          or PMACENC_ENCODING_WSTB or ABSENC_ENCODING_WSTB or ABSENC_PROTOCOL_WSTB
          or CLK_PERIOD_WSTB or FRAME_PERIOD_WSTB or INCENC_BITS_WSTB;
 
-DCARD_TYPE <= x"0000000" & '0' & DCARD_MODE_i(3 downto 1);
+-- DCARD_TYPE <= x"0000000" & '0' & DCARD_MODE_i(3 downto 1);
 
 --------------------------------------------------------------------------
 -- Control System Interface
@@ -203,7 +201,7 @@ port map (
     PROTOCOL_WSTB       => PMACENC_PROTOCOL_WSTB,
     ENCODING            => PMACENC_ENCODING,
     ENCODING_WSTB       => PMACENC_ENCODING_WSTB,
-    DCARD_TYPE          => DCARD_TYPE,
+    -- DCARD_TYPE          => DCARD_TYPE,
     BITS                => PMACENC_BITS,
     BITS_WSTB           => PMACENC_BITS_WSTB,
     HEALTH              => PMACENC_HEALTH
@@ -280,8 +278,8 @@ port map (
     MSB_DISCARD_WSTB    => open,
     HEALTH              => ABSENC_HEALTH,
     HOMED               => ABSENC_HOMED,
-    ENABLED             => ABSENC_ENABLED,       -- TO BE CONNECTED THROUGH TO ENCODERS.VHD
-    DCARD_TYPE          => DCARD_TYPE
+    ENABLED             => ABSENC_ENABLED       -- TO BE CONNECTED THROUGH TO ENCODERS.VHD
+    -- DCARD_TYPE          => DCARD_TYPE
 );
 
 read_addr <= to_integer(unsigned(read_address_i));
@@ -352,7 +350,7 @@ port map(
     INCENC_HEALTH_o     => INCENC_HEALTH,
     HOMED_o             => HOMED,
 
-    DCARD_MODE_i        => DCARD_MODE_i,
+    -- DCARD_MODE_i        => DCARD_MODE_i,
     ABSENC_PROTOCOL_i   => ABSENC_PROTOCOL(2 downto 0),
     ABSENC_ENCODING_i   => ABSENC_ENCODING(1 downto 0),
     CLK_SRC_i           => CLK_SRC(0),

--- a/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
@@ -15,37 +15,49 @@ port (
     clk_i                   : in  std_logic;
     reset_i                 : in  std_logic;
     -- Memory Bus Interface
-    OUTENC_read_strobe_i    : in  std_logic;
-    OUTENC_read_data_o      : out std_logic_vector(31 downto 0);
-    OUTENC_read_ack_o       : out std_logic;
+    PMACENC_read_strobe_i    : in  std_logic;
+    PMACENC_read_data_o      : out std_logic_vector(31 downto 0);
+    PMACENC_read_ack_o       : out std_logic;
 
-    OUTENC_write_strobe_i   : in  std_logic;
-    OUTENC_write_ack_o      : out std_logic;
+    PMACENC_write_strobe_i   : in  std_logic;
+    PMACENC_write_ack_o      : out std_logic;
 
-    INENC_read_strobe_i     : in  std_logic;
-    INENC_read_data_o       : out std_logic_vector(31 downto 0);
-    INENC_read_ack_o        : out std_logic;
+    INCENC_read_strobe_i     : in  std_logic;
+    INCENC_read_data_o       : out std_logic_vector(31 downto 0);
+    INCENC_read_ack_o        : out std_logic;
 
-    INENC_write_strobe_i    : in  std_logic;
-    INENC_write_ack_o       : out std_logic;
+    INCENC_write_strobe_i    : in  std_logic;
+    INCENC_write_ack_o       : out std_logic;
+
+    ABSENC_read_strobe_i     : in  std_logic;
+    ABSENC_read_data_o       : out std_logic_vector(31 downto 0);
+    ABSENC_read_ack_o        : out std_logic;
+
+    ABSENC_write_strobe_i    : in  std_logic;
+    ABSENC_write_ack_o       : out std_logic;
 
     read_address_i          : in  std_logic_vector(BLK_AW-1 downto 0);
 
     write_address_i         : in  std_logic_vector(BLK_AW-1 downto 0);
     write_data_i            : in  std_logic_vector(31 downto 0);
     -- Encoder I/O Pads
-    INENC_A_o               : out std_logic;
-    INENC_B_o               : out std_logic;
-    INENC_Z_o               : out std_logic;
-    INENC_DATA_o            : out std_logic;
+    INCENC_A_o               : out std_logic;
+    INCENC_B_o               : out std_logic;
+    INCENC_Z_o               : out std_logic;
+    
+    ABSENC_DATA_o            : out std_logic;
 
-    OUTENC_PROTOCOL_o       : out std_logic_vector(31 downto 0);
-    OUTENC_PROTOCOL_WSTB_o  : out std_logic;
-    INENC_PROTOCOL_o        : out std_logic_vector(31 downto 0);
-    INENC_PROTOCOL_WSTB_o   : out std_logic;
+    PMACENC_PROTOCOL_o       : out std_logic_vector(31 downto 0);
+    PMACENC_PROTOCOL_WSTB_o  : out std_logic;
+    INCENC_PROTOCOL_o        : out std_logic_vector(31 downto 0);
+    INCENC_PROTOCOL_WSTB_o   : out std_logic;
+    ABSENC_PROTOCOL_o        : out std_logic_vector(31 downto 0);
+    ABSENC_PROTOCOL_WSTB_o   : out std_logic;
 
-    OUTENC_CONN_OUT_o       : out std_logic;
-    INENC_CONN_OUT_o        : out std_logic;
+    PMACENC_CONN_OUT_o       : out std_logic;
+    INCENC_CONN_OUT_o        : out std_logic;
+    ABSENC_CONN_OUT_o        : out std_logic;
+
 
     clk_int_o               : out std_logic;
 
@@ -72,7 +84,8 @@ port (
     DCARD_MODE_i            : in  std_logic_vector(31 downto 0);
     bit_bus_i               : in  bit_bus_t;
     pos_bus_i               : in  pos_bus_t;
-    posn_o                  : out std_logic_vector(31 downto 0)
+    posn_o                  : out std_logic_vector(31 downto 0);
+    abs_posn_o              : out std_logic_vector(31 downto 0)
 );
 end entity;
 
@@ -82,43 +95,55 @@ signal reset            : std_logic;
 
 -- Block Configuration Registers
 signal GENERATOR_ERROR          : std_logic_vector(31 downto 0);
-signal OUTENC_PROTOCOL          : std_logic_vector(31 downto 0);
-signal OUTENC_PROTOCOL_WSTB     : std_logic;
-signal OUTENC_ENCODING          : std_logic_vector(31 downto 0);
-signal OUTENC_ENCODING_WSTB     : std_logic;
-signal OUTENC_BITS              : std_logic_vector(31 downto 0);
-signal OUTENC_BITS_WSTB         : std_logic;
+signal PMACENC_PROTOCOL         : std_logic_vector(31 downto 0);
+signal PMACENC_PROTOCOL_WSTB    : std_logic;
+signal PMACENC_ENCODING         : std_logic_vector(31 downto 0);
+signal PMACENC_ENCODING_WSTB    : std_logic;
+signal PMACENC_BITS             : std_logic_vector(31 downto 0);
+signal PMACENC_BITS_WSTB        : std_logic;
 signal QPERIOD                  : std_logic_vector(31 downto 0);
 signal QPERIOD_WSTB             : std_logic;
 signal QSTATE                   : std_logic_vector(31 downto 0);
 signal DCARD_TYPE               : std_logic_vector(31 downto 0);
-signal OUTENC_HEALTH            : std_logic_vector(31 downto 0);
+signal PMACENC_HEALTH           : std_logic_vector(31 downto 0);
 signal a_ext, b_ext, z_ext, data_ext    : std_logic;
 signal posn                     : std_logic_vector(31 downto 0);
 signal enable                   : std_logic;
+signal absenc_enable            : std_logic;
 
 signal clk_ext                  : std_logic;
 -- Block Configuration Registers
-signal INENC_PROTOCOL           : std_logic_vector(31 downto 0);
-signal INENC_PROTOCOL_WSTB      : std_logic;
-signal INENC_ENCODING           : std_logic_vector(31 downto 0);
-signal INENC_ENCODING_WSTB      : std_logic;
+signal INCENC_PROTOCOL          : std_logic_vector(31 downto 0);
+signal INCENC_PROTOCOL_WSTB     : std_logic;
+signal INCENC_ENCODING          : std_logic_vector(31 downto 0);
+signal INCENC_ENCODING_WSTB     : std_logic;
+signal ABSENC_PROTOCOL          : std_logic_vector(31 downto 0);
+signal ABSENC_PROTOCOL_WSTB     : std_logic;
+signal ABSENC_ENCODING          : std_logic_vector(31 downto 0);
+signal ABSENC_ENCODING_WSTB     : std_logic;
 signal CLK_SRC                  : std_logic_vector(31 downto 0);
 signal CLK_PERIOD               : std_logic_vector(31 downto 0);
 signal CLK_PERIOD_WSTB          : std_logic;
 signal FRAME_PERIOD             : std_logic_vector(31 downto 0);
 signal FRAME_PERIOD_WSTB        : std_logic;
-signal INENC_BITS               : std_logic_vector(31 downto 0);
-signal INENC_BITS_WSTB          : std_logic;
+signal INCENC_BITS              : std_logic_vector(31 downto 0);
+signal INCENC_BITS_WSTB         : std_logic;
+signal ABSENC_BITS              : std_logic_vector(31 downto 0);
+signal ABSENC_BITS_WSTB         : std_logic;
 signal SETP                     : std_logic_vector(31 downto 0);
 signal SETP_WSTB                : std_logic;
 signal RST_ON_Z                 : std_logic_vector(31 downto 0);
 signal STATUS                   : std_logic_vector(31 downto 0);
+signal absenc_STATUS            : std_logic_vector(31 downto 0);
 signal read_ack                 : std_logic;
 signal LSB_DISCARD              : std_logic_vector(31 downto 0);
 signal MSB_DISCARD              : std_logic_vector(31 downto 0);
-signal INENC_HEALTH             : std_logic_vector(31 downto 0);
+signal ABSENC_LSB_DISCARD       : std_logic_vector(31 downto 0);
+signal ABSENC_MSB_DISCARD       : std_logic_vector(31 downto 0);
+signal INCENC_HEALTH            : std_logic_vector(31 downto 0);
+signal ABSENC_HEALTH            : std_logic_vector(31 downto 0);
 signal HOMED                    : std_logic_vector(31 downto 0);
+signal ABSENC_HOMED             : std_logic_vector(31 downto 0);
 
 signal read_addr                : natural range 0 to (2**read_address_i'length - 1);
 
@@ -126,96 +151,85 @@ begin
 
 -- Assign outputs
 
-INENC_PROTOCOL_o <= INENC_PROTOCOL;
-INENC_PROTOCOL_WSTB_o <= INENC_PROTOCOL_WSTB;
-OUTENC_PROTOCOL_o <= OUTENC_PROTOCOL;
-OUTENC_PROTOCOL_WSTB_o <= OUTENC_PROTOCOL_WSTB;
+INCENC_PROTOCOL_o <= INCENC_PROTOCOL;
+INCENC_PROTOCOL_WSTB_o <= INCENC_PROTOCOL_WSTB;
+ABSENC_PROTOCOL_o <= ABSENC_PROTOCOL;
+ABSENC_PROTOCOL_WSTB_o <= ABSENC_PROTOCOL_WSTB;
+PMACENC_PROTOCOL_o <= PMACENC_PROTOCOL;
+PMACENC_PROTOCOL_WSTB_o <= PMACENC_PROTOCOL_WSTB;
 
-OUTENC_CONN_OUT_o <= enable;
+PMACENC_CONN_OUT_o <= enable;
 
 -- Input encoder connection status comes from either
 --  * Dcard pin [12] for incremental, or
 --  * link_up status for absolute in loopback mode
-INENC_CONN_OUT_o <= STATUS(0);
-
+INCENC_CONN_OUT_o <= STATUS(0);
+ABSENC_CONN_OUT_o <= ABSENC_STATUS(0);
 -- Certain parameter changes must initiate a block reset.
-reset <= reset_i or OUTENC_PROTOCOL_WSTB or OUTENC_BITS_WSTB or INENC_PROTOCOL_WSTB
-         or OUTENC_ENCODING_WSTB or INENC_ENCODING_WSTB
-         or CLK_PERIOD_WSTB or FRAME_PERIOD_WSTB or INENC_BITS_WSTB;
+reset <= reset_i or PMACENC_PROTOCOL_WSTB or PMACENC_BITS_WSTB or INCENC_PROTOCOL_WSTB
+         or PMACENC_ENCODING_WSTB or ABSENC_ENCODING_WSTB or ABSENC_PROTOCOL_WSTB
+         or CLK_PERIOD_WSTB or FRAME_PERIOD_WSTB or INCENC_BITS_WSTB;
 
 DCARD_TYPE <= x"0000000" & '0' & DCARD_MODE_i(3 downto 1);
 
 --------------------------------------------------------------------------
 -- Control System Interface
 --------------------------------------------------------------------------
-outenc_ctrl : entity work.outenc_ctrl
+pmacenc_ctrl : entity work.pmacenc_ctrl
 port map (
     clk_i               => clk_i,
     reset_i             => reset_i,
     bit_bus_i           => bit_bus_i,
     pos_bus_i           => pos_bus_i,
-    a_from_bus          => a_ext,
-    b_from_bus          => b_ext,
-    z_from_bus          => z_ext,
     data_from_bus       => data_ext,
     enable_from_bus     => enable,
     val_from_bus        => posn,
 
-    read_strobe_i       => OUTENC_read_strobe_i,
+    read_strobe_i       => PMACENC_read_strobe_i,
     read_address_i      => read_address_i,
-    read_data_o         => OUTENC_read_data_o,
-    read_ack_o          => OUTENC_read_ack_o,
+    read_data_o         => PMACENC_read_data_o,
+    read_ack_o          => PMACENC_read_ack_o,
 
-    write_strobe_i      => OUTENC_write_strobe_i,
+    write_strobe_i      => PMACENC_write_strobe_i,
     write_address_i     => write_address_i,
     write_data_i        => write_data_i,
-    write_ack_o         => OUTENC_write_ack_o,
+    write_ack_o         => PMACENC_write_ack_o,
 
     -- Block Parameters
     GENERATOR_ERROR     => GENERATOR_ERROR,
-    PROTOCOL            => OUTENC_PROTOCOL,
-    PROTOCOL_WSTB       => OUTENC_PROTOCOL_WSTB,
-    ENCODING            => OUTENC_ENCODING,
-    ENCODING_WSTB       => OUTENC_ENCODING_WSTB,
+    PROTOCOL            => PMACENC_PROTOCOL,
+    PROTOCOL_WSTB       => PMACENC_PROTOCOL_WSTB,
+    ENCODING            => PMACENC_ENCODING,
+    ENCODING_WSTB       => PMACENC_ENCODING_WSTB,
     DCARD_TYPE          => DCARD_TYPE,
-    BITS                => OUTENC_BITS,
-    BITS_WSTB           => OUTENC_BITS_WSTB,
+    BITS                => PMACENC_BITS,
+    BITS_WSTB           => PMACENC_BITS_WSTB,
+    HEALTH              => PMACENC_HEALTH,
     QPERIOD             => QPERIOD,
-    QPERIOD_WSTB        => QPERIOD_WSTB,
-    HEALTH              => OUTENC_HEALTH,
     QSTATE              => QSTATE
 );
 
-inenc_ctrl : entity work.inenc_ctrl
+incenc_ctrl : entity work.incenc_ctrl
 port map (
     clk_i               => clk_i,
     reset_i             => reset_i,
     bit_bus_i           => bit_bus_i,
     pos_bus_i           => pos_bus_i,
-    clk_from_bus        => clk_ext,
 
-    read_strobe_i       => INENC_read_strobe_i,
+    read_strobe_i       => INCENC_read_strobe_i,
     read_address_i      => read_address_i,
-    read_data_o         => INENC_read_data_o,
-    read_ack_o          => INENC_read_ack_o,
+    read_data_o         => INCENC_read_data_o,
+    read_ack_o          => INCENC_read_ack_o,
 
-    write_strobe_i      => INENC_write_strobe_i,
+    write_strobe_i      => INCENC_write_strobe_i,
     write_address_i     => write_address_i,
     write_data_i        => write_data_i,
-    write_ack_o         => INENC_write_ack_o,
+    write_ack_o         => INCENC_write_ack_o,
 
-    PROTOCOL            => INENC_PROTOCOL,
-    PROTOCOL_WSTB       => INENC_PROTOCOL_WSTB,
-    ENCODING            => INENC_ENCODING,
-    ENCODING_WSTB       => INENC_ENCODING_WSTB,
-    CLK_SRC             => CLK_SRC,
-    CLK_SRC_WSTB        => open,
-    CLK_PERIOD          => CLK_PERIOD,
-    CLK_PERIOD_WSTB     => CLK_PERIOD_WSTB,
-    FRAME_PERIOD        => FRAME_PERIOD,
-    FRAME_PERIOD_WSTB   => FRAME_PERIOD_WSTB,
-    BITS                => INENC_BITS,
-    BITS_WSTB           => INENC_BITS_WSTB,
+    PROTOCOL            => INCENC_PROTOCOL,
+    PROTOCOL_WSTB       => INCENC_PROTOCOL_WSTB,
+    BITS                => INCENC_BITS,
+    BITS_WSTB           => INCENC_BITS_WSTB,
     LSB_DISCARD         => LSB_DISCARD,
     LSB_DISCARD_WSTB    => open,
     MSB_DISCARD         => MSB_DISCARD,
@@ -224,8 +238,47 @@ port map (
     SETP_WSTB           => SETP_WSTB,
     RST_ON_Z            => RST_ON_Z,
     RST_ON_Z_WSTB       => open,
-    HEALTH              => INENC_HEALTH,
-    HOMED               => HOMED,
+    HEALTH              => INCENC_HEALTH,
+    HOMED               => HOMED
+);
+
+absenc_ctrl : entity work.absenc_ctrl
+port map (
+    clk_i               => clk_i,
+    reset_i             => reset_i,
+    bit_bus_i           => bit_bus_i,
+    pos_bus_i           => pos_bus_i,
+    clk_from_bus        => clk_ext,
+    enable_from_bus     => absenc_enable,       -- TO BE CONNECTED THROUGH TO ENCODERS.VHD
+
+    read_strobe_i       => ABSENC_read_strobe_i,
+    read_address_i      => read_address_i,
+    read_data_o         => ABSENC_read_data_o,
+    read_ack_o          => ABSENC_read_ack_o,
+
+    write_strobe_i      => ABSENC_write_strobe_i,
+    write_address_i     => write_address_i,
+    write_data_i        => write_data_i,
+    write_ack_o         => ABSENC_write_ack_o,
+
+    PROTOCOL            => ABSENC_PROTOCOL,
+    PROTOCOL_WSTB       => ABSENC_PROTOCOL_WSTB,
+    ENCODING            => ABSENC_ENCODING,
+    ENCODING_WSTB       => ABSENC_ENCODING_WSTB,
+    CLK_SRC             => CLK_SRC,
+    CLK_SRC_WSTB        => open,
+    CLK_PERIOD          => CLK_PERIOD,
+    CLK_PERIOD_WSTB     => CLK_PERIOD_WSTB,
+    FRAME_PERIOD        => FRAME_PERIOD,
+    FRAME_PERIOD_WSTB   => FRAME_PERIOD_WSTB,
+    BITS                => ABSENC_BITS,
+    BITS_WSTB           => ABSENC_BITS_WSTB,
+    LSB_DISCARD         => ABSENC_LSB_DISCARD,
+    LSB_DISCARD_WSTB    => open,
+    MSB_DISCARD         => ABSENC_MSB_DISCARD,
+    MSB_DISCARD_WSTB    => open,
+    HEALTH              => ABSENC_HEALTH,
+    HOMED               => ABSENC_HOMED,
     DCARD_TYPE          => DCARD_TYPE
 );
 
@@ -248,10 +301,10 @@ port map(
     posn_i              => posn,
     enable_i            => enable,
     -- Encoder I/O Pads
-    INENC_A_o           => INENC_A_o,
-    INENC_B_o           => INENC_B_o,
-    INENC_Z_o           => INENC_Z_o,
-    INENC_DATA_o        => INENC_DATA_o,
+    INCENC_A_o          => INCENC_A_o,
+    INCENC_B_o          => INCENC_B_o,
+    INCENC_Z_o          => INCENC_Z_o,
+    ABSENC_DATA_o       => ABSENC_DATA_o,
     --
     clk_out_ext_i       => clk_ext,
     clk_int_o           => clk_int_o,
@@ -277,32 +330,42 @@ port map(
     
     -- Block parameters
     GENERATOR_ERROR_i   => GENERATOR_ERROR(0),
-    OUTENC_PROTOCOL_i   => OUTENC_PROTOCOL(2 downto 0),
-    OUTENC_ENCODING_i   => OUTENC_ENCODING(1 downto 0),
-    OUTENC_BITS_i       => OUTENC_BITS(7 downto 0),
+    PMACENC_PROTOCOL_i  => PMACENC_PROTOCOL(2 downto 0),
+    PMACENC_ENCODING_i  => PMACENC_ENCODING(1 downto 0),
+    PMACENC_BITS_i      => PMACENC_BITS(7 downto 0),
     QPERIOD_i           => QPERIOD,
     QPERIOD_WSTB_i      => QPERIOD_WSTB,
-    OUTENC_HEALTH_o     => OUTENC_HEALTH,
+    PMACENC_HEALTH_o    => PMACENC_HEALTH,
     QSTATE_o            => QSTATE,
 
-    DCARD_MODE_i        => DCARD_MODE_i,
-    INENC_PROTOCOL_i    => INENC_PROTOCOL(2 downto 0),
-    INENC_ENCODING_i    => INENC_ENCODING(1 downto 0),
-    CLK_SRC_i           => CLK_SRC(0),
-    CLK_PERIOD_i        => CLK_PERIOD,
-    FRAME_PERIOD_i      => FRAME_PERIOD,
-    INENC_BITS_i        => INENC_BITS(7 downto 0),
+    INCENC_PROTOCOL_i   => INCENC_PROTOCOL(2 downto 0),
+    INCENC_ENCODING_i   => INCENC_ENCODING(1 downto 0),
+    INCENC_BITS_i       => INCENC_BITS(7 downto 0),
     LSB_DISCARD_i       => LSB_DISCARD(4 downto 0),
     MSB_DISCARD_i       => MSB_DISCARD(4 downto 0),
     SETP_i              => SETP,
     SETP_WSTB_i         => SETP_WSTB,
     RST_ON_Z_i          => RST_ON_Z,
     STATUS_o            => STATUS,
-    INENC_HEALTH_o      => INENC_HEALTH,
+    INCENC_HEALTH_o     => INCENC_HEALTH,
     HOMED_o             => HOMED,
+
+    DCARD_MODE_i        => DCARD_MODE_i,
+    ABSENC_PROTOCOL_i   => ABSENC_PROTOCOL(2 downto 0),
+    ABSENC_ENCODING_i   => ABSENC_ENCODING(1 downto 0),
+    CLK_SRC_i           => CLK_SRC(0),
+    CLK_PERIOD_i        => CLK_PERIOD,
+    FRAME_PERIOD_i      => FRAME_PERIOD,
+    ABSENC_BITS_i       => ABSENC_BITS(7 downto 0),
+    ABSENC_LSB_DISCARD_i => ABSENC_LSB_DISCARD(4 downto 0),
+    ABSENC_MSB_DISCARD_i => ABSENC_MSB_DISCARD(4 downto 0),
+    ABSENC_STATUS_o      => ABSENC_STATUS,
+    ABSENC_HEALTH_o     => ABSENC_HEALTH,
+    ABSENC_HOMED_o      => ABSENC_HOMED,
     --
     -- Block Outputs
-    posn_o              => posn_o
+    abs_posn_o          => abs_posn_o,
+    inc_posn_o          => posn_o
 );
 
 end rtl;

--- a/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
@@ -41,9 +41,9 @@ port (
     write_address_i         : in  std_logic_vector(BLK_AW-1 downto 0);
     write_data_i            : in  std_logic_vector(31 downto 0);
     -- Encoder I/O Pads
-    INCENC_A_o               : out std_logic;
-    INCENC_B_o               : out std_logic;
-    INCENC_Z_o               : out std_logic;
+    -- INCENC_A_o               : out std_logic;
+    -- INCENC_B_o               : out std_logic;
+    -- INCENC_Z_o               : out std_logic;
     
     ABSENC_DATA_o            : out std_logic;
 
@@ -303,9 +303,9 @@ port map(
     posn_i              => posn,
     enable_i            => enable,
     -- Encoder I/O Pads
-    INCENC_A_o          => INCENC_A_o,
-    INCENC_B_o          => INCENC_B_o,
-    INCENC_Z_o          => INCENC_Z_o,
+    -- INCENC_A_o          => INCENC_A_o,
+    -- INCENC_B_o          => INCENC_B_o,
+    -- INCENC_Z_o          => INCENC_Z_o,
     ABSENC_DATA_o       => ABSENC_DATA_o,
     --
     clk_out_ext_i       => clk_ext,

--- a/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders_block.vhd
@@ -111,7 +111,6 @@ signal PMACENC_HEALTH           : std_logic_vector(31 downto 0);
 signal a_ext, b_ext, z_ext, data_ext    : std_logic;
 signal posn                     : std_logic_vector(31 downto 0);
 signal enable                   : std_logic;
-signal absenc_enable            : std_logic;
 
 signal clk_ext                  : std_logic;
 -- Block Configuration Registers
@@ -145,6 +144,7 @@ signal ABSENC_MSB_DISCARD       : std_logic_vector(31 downto 0);
 signal INCENC_HEALTH            : std_logic_vector(31 downto 0);
 signal ABSENC_HEALTH            : std_logic_vector(31 downto 0);
 signal HOMED                    : std_logic_vector(31 downto 0);
+signal ABSENC_ENABLED           : std_logic_vector(31 downto 0);
 signal ABSENC_HOMED             : std_logic_vector(31 downto 0);
 
 signal read_addr                : natural range 0 to (2**read_address_i'length - 1);
@@ -206,9 +206,7 @@ port map (
     DCARD_TYPE          => DCARD_TYPE,
     BITS                => PMACENC_BITS,
     BITS_WSTB           => PMACENC_BITS_WSTB,
-    HEALTH              => PMACENC_HEALTH,
-    QPERIOD             => QPERIOD,
-    QSTATE              => QSTATE
+    HEALTH              => PMACENC_HEALTH
 );
 
 incenc_ctrl : entity work.incenc_ctrl
@@ -241,7 +239,9 @@ port map (
     RST_ON_Z            => RST_ON_Z,
     RST_ON_Z_WSTB       => open,
     HEALTH              => INCENC_HEALTH,
-    HOMED               => HOMED
+    HOMED               => HOMED,
+    QPERIOD             => QPERIOD,
+    QSTATE              => QSTATE
 );
 
 absenc_ctrl : entity work.absenc_ctrl
@@ -251,7 +251,6 @@ port map (
     bit_bus_i           => bit_bus_i,
     pos_bus_i           => pos_bus_i,
     clk_from_bus        => clk_ext,
-    enable_from_bus     => absenc_enable,       -- TO BE CONNECTED THROUGH TO ENCODERS.VHD
 
     read_strobe_i       => ABSENC_read_strobe_i,
     read_address_i      => read_address_i,
@@ -281,6 +280,7 @@ port map (
     MSB_DISCARD_WSTB    => open,
     HEALTH              => ABSENC_HEALTH,
     HOMED               => ABSENC_HOMED,
+    ENABLED             => ABSENC_ENABLED,       -- TO BE CONNECTED THROUGH TO ENCODERS.VHD
     DCARD_TYPE          => DCARD_TYPE
 );
 
@@ -363,6 +363,7 @@ port map(
     ABSENC_MSB_DISCARD_i => ABSENC_MSB_DISCARD(4 downto 0),
     ABSENC_STATUS_o      => ABSENC_STATUS,
     ABSENC_HEALTH_o     => ABSENC_HEALTH,
+    ABSENC_ENABLED_o    => ABSENC_ENABLED,
     ABSENC_HOMED_o      => ABSENC_HOMED,
 
     UVWT_o              => UVWT_o,

--- a/targets/PandABrick/hdl/PandABrick_encoders_top.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders_top.vhd
@@ -17,27 +17,35 @@ port (
     clk_i                   : in  std_logic;
     reset_i                 : in  std_logic;
     -- Memory Bus Interface
-    OUTENC_read_strobe_i    : in  std_logic;
-    OUTENC_read_data_o      : out std_logic_vector(31 downto 0);
-    OUTENC_read_ack_o       : out std_logic;
+    PMACENC_read_strobe_i   : in  std_logic;
+    PMACENC_read_data_o     : out std_logic_vector(31 downto 0);
+    PMACENC_read_ack_o      : out std_logic;
 
-    OUTENC_write_strobe_i   : in  std_logic;
-    OUTENC_write_ack_o      : out std_logic;
+    PMACENC_write_strobe_i  : in  std_logic;
+    PMACENC_write_ack_o     : out std_logic;
 
-    INENC_read_strobe_i     : in  std_logic;
-    INENC_read_data_o       : out std_logic_vector(31 downto 0);
-    INENC_read_ack_o        : out std_logic;
+    INCENC_read_strobe_i    : in  std_logic;
+    INCENC_read_data_o      : out std_logic_vector(31 downto 0);
+    INCENC_read_ack_o       : out std_logic;
 
-    INENC_write_strobe_i    : in  std_logic;
-    INENC_write_ack_o       : out std_logic;
+    INCENC_write_strobe_i   : in  std_logic;
+    INCENC_write_ack_o      : out std_logic;
+
+    ABSENC_read_strobe_i    : in  std_logic;
+    ABSENC_read_data_o      : out std_logic_vector(31 downto 0);
+    ABSENC_read_ack_o       : out std_logic;
+
+    ABSENC_write_strobe_i   : in  std_logic;
+    ABSENC_write_ack_o      : out std_logic;
 
     read_address_i          : in  std_logic_vector(PAGE_AW-1 downto 0);
 
     write_address_i         : in  std_logic_vector(PAGE_AW-1 downto 0);
     write_data_i            : in  std_logic_vector(31 downto 0);
     
-    OUTENC_CONN_OUT_o       : out std_logic_vector(ENC_NUM-1 downto 0);
-    INENC_CONN_OUT_o        : out std_logic_vector(ENC_NUM-1 downto 0);
+    PMACENC_CONN_OUT_o      : out std_logic_vector(ENC_NUM-1 downto 0);
+    INCENC_CONN_OUT_o       : out std_logic_vector(ENC_NUM-1 downto 0);
+    ABSENC_CONN_OUT_o       : out std_logic_vector(ENC_NUM-1 downto 0);
     
     -- Encoder I/O Pads
     pins_ENC_A_in           : in  std_logic_vector(ENC_NUM-1 downto 0);
@@ -61,54 +69,73 @@ port (
 
     -- Signals passed to internal bus
     clk_int_o               : out std_logic_vector(ENC_NUM-1 downto 0);
-    inenc_a_o               : out std_logic_vector(ENC_NUM-1 downto 0);
-    inenc_b_o               : out std_logic_vector(ENC_NUM-1 downto 0);
-    inenc_z_o               : out std_logic_vector(ENC_NUM-1 downto 0);
-    inenc_data_o            : out std_logic_vector(ENC_NUM-1 downto 0);
+    incenc_a_o              : out std_logic_vector(ENC_NUM-1 downto 0);
+    incenc_b_o              : out std_logic_vector(ENC_NUM-1 downto 0);
+    incenc_z_o              : out std_logic_vector(ENC_NUM-1 downto 0);
+    absenc_data_o           : out std_logic_vector(ENC_NUM-1 downto 0);
     -- Block Input and Outputs
     bit_bus_i               : in  bit_bus_t;
     pos_bus_i               : in  pos_bus_t;
     DCARD_MODE_i            : in  std32_array(ENC_NUM-1 downto 0);
     posn_o                  : out std32_array(ENC_NUM-1 downto 0);
+    abs_posn_o                  : out std32_array(ENC_NUM-1 downto 0);
 
-    OUTENC_PROTOCOL_o       : out std32_array(ENC_NUM-1 downto 0);
-    OUTENC_PROTOCOL_WSTB_o  : out std_logic_vector(ENC_NUM-1 downto 0);
-    INENC_PROTOCOL_o        : out std32_array(ENC_NUM-1 downto 0);
-    INENC_PROTOCOL_WSTB_o   : out std_logic_vector(ENC_NUM-1 downto 0)
+
+    PMACENC_PROTOCOL_o      : out std32_array(ENC_NUM-1 downto 0);
+    PMACENC_PROTOCOL_WSTB_o : out std_logic_vector(ENC_NUM-1 downto 0);
+    INCENC_PROTOCOL_o       : out std32_array(ENC_NUM-1 downto 0);
+    INCENC_PROTOCOL_WSTB_o  : out std_logic_vector(ENC_NUM-1 downto 0);
+    ABSENC_PROTOCOL_o       : out std32_array(ENC_NUM-1 downto 0);
+    ABSENC_PROTOCOL_WSTB_o  : out std_logic_vector(ENC_NUM-1 downto 0)
 );
 end pandabrick_encoders_top;
 
 architecture rtl of pandabrick_encoders_top is
 
-signal OUTENC_read_strobe       : std_logic_vector(ENC_NUM-1 downto 0);
-signal OUTENC_read_data         : std32_array(ENC_NUM-1 downto 0);
-signal OUTENC_write_strobe      : std_logic_vector(ENC_NUM-1 downto 0);
-signal OUTENC_read_ack          : std_logic_vector(ENC_NUM-1 downto 0);
+signal PMACENC_read_strobe      : std_logic_vector(ENC_NUM-1 downto 0);
+signal PMACENC_read_data        : std32_array(ENC_NUM-1 downto 0);
+signal PMACENC_write_strobe     : std_logic_vector(ENC_NUM-1 downto 0);
+signal PMACENC_read_ack         : std_logic_vector(ENC_NUM-1 downto 0);
 
-signal INENC_read_strobe        : std_logic_vector(ENC_NUM-1 downto 0);
-signal INENC_read_data          : std32_array(ENC_NUM-1 downto 0);
-signal INENC_write_strobe       : std_logic_vector(ENC_NUM-1 downto 0);
+signal INCENC_read_strobe       : std_logic_vector(ENC_NUM-1 downto 0);
+signal INCENC_read_data         : std32_array(ENC_NUM-1 downto 0);
+signal INCENC_write_strobe      : std_logic_vector(ENC_NUM-1 downto 0);
 signal posn                     : std32_array(ENC_NUM-1 downto 0);
-signal INENC_read_ack           : std_logic_vector(ENC_NUM-1 downto 0);
+signal INCENC_read_ack          : std_logic_vector(ENC_NUM-1 downto 0);
+
+signal ABSENC_read_strobe       : std_logic_vector(ENC_NUM-1 downto 0);
+signal ABSENC_read_data         : std32_array(ENC_NUM-1 downto 0);
+signal ABSENC_write_strobe      : std_logic_vector(ENC_NUM-1 downto 0);
+signal abs_posn                 : std32_array(ENC_NUM-1 downto 0);
+signal ABSENC_read_ack          : std_logic_vector(ENC_NUM-1 downto 0);
 
 begin
 
 -- Acknowledgement to AXI Lite interface
-OUTENC_write_ack_o <= '1';
-OUTENC_read_ack_o <= or_reduce(OUTENC_read_ack);
+PMACENC_write_ack_o <= '1';
+PMACENC_read_ack_o <= or_reduce(PMACENC_read_ack);
 
 -- Multiplex read data out from multiple instantiations
-OUTENC_read_data_o <= OUTENC_read_data(to_integer(unsigned(read_address_i(PAGE_AW-1 downto BLK_AW))));
+PMACENC_read_data_o <= PMACENC_read_data(to_integer(unsigned(read_address_i(PAGE_AW-1 downto BLK_AW))));
 
 -- Acknowledgement to AXI Lite interface
-INENC_write_ack_o <= '1';
-INENC_read_ack_o <= or_reduce(INENC_read_ack);
+INCENC_write_ack_o <= '1';
+INCENC_read_ack_o <= or_reduce(INCENC_read_ack);
 
 -- Multiplex read data out from multiple instantiations
-INENC_read_data_o <= INENC_read_data(to_integer(unsigned(read_address_i(PAGE_AW-1 downto BLK_AW))));
+INCENC_read_data_o <= INCENC_read_data(to_integer(unsigned(read_address_i(PAGE_AW-1 downto BLK_AW))));
+
+-- Acknowledgement to AXI Lite interface
+ABSENC_write_ack_o <= '1';
+ABSENC_read_ack_o <= or_reduce(ABSENC_read_ack);
+
+-- Multiplex read data out from multiple instantiations
+ABSENC_read_data_o <= ABSENC_read_data(to_integer(unsigned(read_address_i(PAGE_AW-1 downto BLK_AW))));
+
 
 -- Outputs
 posn_o <= posn;
+abs_posn_o <= abs_posn;
 
 --
 -- Instantiate ENCOUT Blocks :
@@ -117,11 +144,14 @@ posn_o <= posn;
 ENC_GEN : FOR I IN 0 TO ENC_NUM-1 GENERATE
 
 -- Sub-module address decoding
-OUTENC_read_strobe(I) <= compute_block_strobe(read_address_i, I) and OUTENC_read_strobe_i;
-OUTENC_write_strobe(I) <= compute_block_strobe(write_address_i, I) and OUTENC_write_strobe_i;
+PMACENC_read_strobe(I) <= compute_block_strobe(read_address_i, I) and PMACENC_read_strobe_i;
+PMACENC_write_strobe(I) <= compute_block_strobe(write_address_i, I) and PMACENC_write_strobe_i;
 
-INENC_read_strobe(I) <= compute_block_strobe(read_address_i, I) and INENC_read_strobe_i;
-INENC_write_strobe(I) <= compute_block_strobe(write_address_i, I) and INENC_write_strobe_i;
+INCENC_read_strobe(I) <= compute_block_strobe(read_address_i, I) and INCENC_read_strobe_i;
+INCENC_write_strobe(I) <= compute_block_strobe(write_address_i, I) and INCENC_write_strobe_i;
+
+ABSENC_read_strobe(I) <= compute_block_strobe(read_address_i, I) and ABSENC_read_strobe_i;
+ABSENC_write_strobe(I) <= compute_block_strobe(write_address_i, I) and ABSENC_write_strobe_i;
 
 encoders_block_inst : entity work.pandabrick_encoders_block
 port map (
@@ -129,38 +159,48 @@ port map (
     clk_i                   => clk_i,
     reset_i                 => reset_i,
     -- Memory Bus Interface
-    OUTENC_read_strobe_i    => OUTENC_read_strobe(I),
-    OUTENC_read_data_o      => OUTENC_read_data(I),
-    OUTENC_read_ack_o       => OUTENC_read_ack(I),
+    PMACENC_read_strobe_i   => PMACENC_read_strobe(I),
+    PMACENC_read_data_o     => PMACENC_read_data(I),
+    PMACENC_read_ack_o      => PMACENC_read_ack(I),
 
-    OUTENC_write_strobe_i   => OUTENC_write_strobe(I),
-    OUTENC_write_ack_o      => open,
+    PMACENC_write_strobe_i  => PMACENC_write_strobe(I),
+    PMACENC_write_ack_o     => open,
 
-    INENC_read_strobe_i     => INENC_read_strobe(I),
-    INENC_read_data_o       => INENC_read_data(I),
-    INENC_read_ack_o        => INENC_read_ack(I),
+    INCENC_read_strobe_i    => INCENC_read_strobe(I),
+    INCENC_read_data_o      => INCENC_read_data(I),
+    INCENC_read_ack_o       => INCENC_read_ack(I),
 
-    INENC_write_strobe_i    => INENC_write_strobe(I),
-    INENC_write_ack_o       => open,
+    INCENC_write_strobe_i   => INCENC_write_strobe(I),
+    INCENC_write_ack_o      => open,
+
+    ABSENC_read_strobe_i    => ABSENC_read_strobe(I),
+    ABSENC_read_data_o      => ABSENC_read_data(I),
+    ABSENC_read_ack_o       => ABSENC_read_ack(I),
+
+    ABSENC_write_strobe_i   => ABSENC_write_strobe(I),
+    ABSENC_write_ack_o      => open,
 
     read_address_i          => read_address_i(BLK_AW-1 downto 0),
 
     write_address_i         => write_address_i(BLK_AW-1 downto 0),
     write_data_i            => write_data_i,
     -- Encoder I/O Pads
-    OUTENC_CONN_OUT_o       => OUTENC_CONN_OUT_o(I),
-    INENC_CONN_OUT_o        => INENC_CONN_OUT_o(I),
+    PMACENC_CONN_OUT_o      => PMACENC_CONN_OUT_o(I),
+    INCENC_CONN_OUT_o       => INCENC_CONN_OUT_o(I),
+    ABSENC_CONN_OUT_o       => ABSENC_CONN_OUT_o(I),
 
     clk_int_o               => clk_int_o(I),
-    inenc_a_o               => inenc_a_o(I),
-    inenc_b_o               => inenc_b_o(I),
-    inenc_z_o               => inenc_z_o(I),
-    inenc_data_o            => inenc_data_o(I),
+    incenc_a_o              => incenc_a_o(I),
+    incenc_b_o              => incenc_b_o(I),
+    incenc_z_o              => incenc_z_o(I),
+    absenc_data_o           => absenc_data_o(I),
 
-    OUTENC_PROTOCOL_o       => OUTENC_PROTOCOL_o(I),
-    OUTENC_PROTOCOL_WSTB_o  => OUTENC_PROTOCOL_WSTB_o(I),
-    INENC_PROTOCOL_o        => INENC_PROTOCOL_o(I),
-    INENC_PROTOCOL_WSTB_o   => INENC_PROTOCOL_WSTB_o(I),
+    PMACENC_PROTOCOL_o      => PMACENC_PROTOCOL_o(I),
+    PMACENC_PROTOCOL_WSTB_o => PMACENC_PROTOCOL_WSTB_o(I),
+    INCENC_PROTOCOL_o       => INCENC_PROTOCOL_o(I),
+    INCENC_PROTOCOL_WSTB_o  => INCENC_PROTOCOL_WSTB_o(I),
+    ABSENC_PROTOCOL_o       => ABSENC_PROTOCOL_o(I),
+    ABSENC_PROTOCOL_WSTB_o  => ABSENC_PROTOCOL_WSTB_o(I),
 
     pin_ENC_A_in            => pins_ENC_A_in(I),
     pin_ENC_B_in            => pins_ENC_B_in(I),
@@ -185,7 +225,8 @@ port map (
     DCARD_MODE_i            => DCARD_MODE_i(I),
     bit_bus_i               => bit_bus_i,
     pos_bus_i               => pos_bus_i,
-    posn_o                  => posn(I)
+    posn_o                  => posn(I),
+    abs_posn_o              => abs_posn(I)
     );
 
 

--- a/targets/PandABrick/hdl/PandABrick_encoders_top.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders_top.vhd
@@ -76,7 +76,7 @@ port (
     -- Block Input and Outputs
     bit_bus_i               : in  bit_bus_t;
     pos_bus_i               : in  pos_bus_t;
-    DCARD_MODE_i            : in  std32_array(ENC_NUM-1 downto 0);
+    -- DCARD_MODE_i            : in  std32_array(ENC_NUM-1 downto 0);
     posn_o                  : out std32_array(ENC_NUM-1 downto 0);
     abs_posn_o                  : out std32_array(ENC_NUM-1 downto 0);
 
@@ -225,7 +225,7 @@ port map (
    
 
     -- Position Field interface
-    DCARD_MODE_i            => DCARD_MODE_i(I),
+    -- DCARD_MODE_i            => DCARD_MODE_i(I),
     bit_bus_i               => bit_bus_i,
     pos_bus_i               => pos_bus_i,
     posn_o                  => posn(I),

--- a/targets/PandABrick/hdl/PandABrick_encoders_top.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders_top.vhd
@@ -80,6 +80,7 @@ port (
     posn_o                  : out std32_array(ENC_NUM-1 downto 0);
     abs_posn_o                  : out std32_array(ENC_NUM-1 downto 0);
 
+    UVWT_o                  : out std_logic_vector(ENC_NUM-1 downto 0);
 
     PMACENC_PROTOCOL_o      : out std32_array(ENC_NUM-1 downto 0);
     PMACENC_PROTOCOL_WSTB_o : out std_logic_vector(ENC_NUM-1 downto 0);
@@ -201,6 +202,8 @@ port map (
     INCENC_PROTOCOL_WSTB_o  => INCENC_PROTOCOL_WSTB_o(I),
     ABSENC_PROTOCOL_o       => ABSENC_PROTOCOL_o(I),
     ABSENC_PROTOCOL_WSTB_o  => ABSENC_PROTOCOL_WSTB_o(I),
+
+    UVWT_o                  => UVWT_o(I),
 
     pin_ENC_A_in            => pins_ENC_A_in(I),
     pin_ENC_B_in            => pins_ENC_B_in(I),

--- a/targets/PandABrick/hdl/PandABrick_encoders_top.vhd
+++ b/targets/PandABrick/hdl/PandABrick_encoders_top.vhd
@@ -69,9 +69,9 @@ port (
 
     -- Signals passed to internal bus
     clk_int_o               : out std_logic_vector(ENC_NUM-1 downto 0);
-    incenc_a_o              : out std_logic_vector(ENC_NUM-1 downto 0);
-    incenc_b_o              : out std_logic_vector(ENC_NUM-1 downto 0);
-    incenc_z_o              : out std_logic_vector(ENC_NUM-1 downto 0);
+    -- incenc_a_o              : out std_logic_vector(ENC_NUM-1 downto 0);
+    -- incenc_b_o              : out std_logic_vector(ENC_NUM-1 downto 0);
+    -- incenc_z_o              : out std_logic_vector(ENC_NUM-1 downto 0);
     absenc_data_o           : out std_logic_vector(ENC_NUM-1 downto 0);
     -- Block Input and Outputs
     bit_bus_i               : in  bit_bus_t;
@@ -191,9 +191,9 @@ port map (
     ABSENC_CONN_OUT_o       => ABSENC_CONN_OUT_o(I),
 
     clk_int_o               => clk_int_o(I),
-    incenc_a_o              => incenc_a_o(I),
-    incenc_b_o              => incenc_b_o(I),
-    incenc_z_o              => incenc_z_o(I),
+    -- incenc_a_o              => incenc_a_o(I),
+    -- incenc_b_o              => incenc_b_o(I),
+    -- incenc_z_o              => incenc_z_o(I),
     absenc_data_o           => absenc_data_o(I),
 
     PMACENC_PROTOCOL_o      => PMACENC_PROTOCOL_o(I),

--- a/targets/PandABrick/hdl/PandABrick_top.vhd
+++ b/targets/PandABrick/hdl/PandABrick_top.vhd
@@ -483,7 +483,7 @@ signal rdma_valid           : std_logic_vector(5 downto 0);
 
 -- Hard-wiring DCARD_MODE to x"00000002" (CONTROL MODE)
 -- This needs to be set by an appropiate block register and tied to corresponding relay setting
-signal DCARD_MODE : std32_array(ENC_NUM-1 downto 0) := (others => (1 => '1', others => '0'));
+-- signal DCARD_MODE : std32_array(ENC_NUM-1 downto 0) := (others => (1 => '1', others => '0'));
 
 -- SFP Block
 signal MGT_MAC_ADDR_ARR     : std32_array(2*NUM_SFP-1 downto 0);
@@ -1282,7 +1282,7 @@ port map (
     -- Block Input and Outputs
     bit_bus_i               => bit_bus,
     pos_bus_i               => pos_bus,
-    DCARD_MODE_i            => DCARD_MODE,
+    -- DCARD_MODE_i            => DCARD_MODE,
     posn_o                  => incenc_val,
     abs_posn_o              => absenc_val,
 

--- a/targets/PandABrick/hdl/PandABrick_top.vhd
+++ b/targets/PandABrick/hdl/PandABrick_top.vhd
@@ -1301,7 +1301,7 @@ port map (
 -- BIT_BUS_SIZE and POS_BUS_SIZE declared in addr_defines.vhd
 
 bit_bus(BIT_BUS_SIZE-1 downto 0 ) <= pcap_active & pmacenc_clk & incenc_conn &
-                                    absenc_data & absenc_conn & ttlin_val;
+                                     absenc_conn & absenc_data & ttlin_val;
 
 pos_bus(POS_BUS_SIZE-1 downto 0) <= incenc_val & absenc_val;
 

--- a/targets/PandABrick/hdl/PandABrick_top.vhd
+++ b/targets/PandABrick/hdl/PandABrick_top.vhd
@@ -1286,6 +1286,8 @@ port map (
     posn_o                  => incenc_val,
     abs_posn_o              => absenc_val,
 
+    UVWT_o                  => uvwt,
+
     PMACENC_PROTOCOL_o       => PMACENC_PROTOCOL,
     PMACENC_PROTOCOL_WSTB_o  => PMACENC_PROTOCOL_WSTB,
     INCENC_PROTOCOL_o        => INCENC_PROTOCOL,
@@ -1332,10 +1334,10 @@ port map (
 -- Data to be passed to PIC...
 
 pass_thru_gen: for chan in 0 to ENC_NUM-1 generate
-    serial_pass(chan) <= '1' when (PMACENC_PROTOCOL(chan)(2 downto 0) = "000") else '0';
+    serial_pass(chan) <= '1' when (PMACENC_PROTOCOL(chan)(2 downto 1) = "00") else '0';
 end generate;
 
-uvwt         <= "00000000";
+-- uvwt         <= "00000000";
 pic_data_out <= ( uvwt & serial_pass );
 
 

--- a/targets/PandABrick/hdl/PandABrick_top.vhd
+++ b/targets/PandABrick/hdl/PandABrick_top.vhd
@@ -406,9 +406,9 @@ signal pins_T               : std_logic_vector(ENC_NUM-1 downto 0);
 -- Incremental Encoder
 signal incenc_val           : std32_array(ENC_NUM-1 downto 0);
 signal incenc_conn          : std_logic_vector(ENC_NUM-1 downto 0);
-signal incenc_a             : std_logic_vector(ENC_NUM-1 downto 0);
-signal incenc_b             : std_logic_vector(ENC_NUM-1 downto 0);
-signal incenc_z             : std_logic_vector(ENC_NUM-1 downto 0);
+-- signal incenc_a             : std_logic_vector(ENC_NUM-1 downto 0);
+-- signal incenc_b             : std_logic_vector(ENC_NUM-1 downto 0);
+-- signal incenc_z             : std_logic_vector(ENC_NUM-1 downto 0);
 signal INCENC_PROTOCOL      : std32_array(ENC_NUM-1 downto 0);
 signal INCENC_PROTOCOL_WSTB : std_logic_vector(ENC_NUM-1 downto 0);
 
@@ -1275,9 +1275,9 @@ port map (
 
     -- Signals passed to internal bus
     clk_int_o               => pmacenc_clk,
-    incenc_a_o              => incenc_a,
-    incenc_b_o              => incenc_b,
-    incenc_z_o              => incenc_z,
+    -- incenc_a_o              => incenc_a,
+    -- incenc_b_o              => incenc_b,
+    -- incenc_z_o              => incenc_z,
     absenc_data_o           => absenc_data,
     -- Block Input and Outputs
     bit_bus_i               => bit_bus,
@@ -1301,8 +1301,7 @@ port map (
 -- BIT_BUS_SIZE and POS_BUS_SIZE declared in addr_defines.vhd
 
 bit_bus(BIT_BUS_SIZE-1 downto 0 ) <= pcap_active & pmacenc_clk & incenc_conn &
-                                    incenc_z & incenc_b & incenc_a & absenc_data &
-                                    absenc_conn & ttlin_val;
+                                    absenc_data & absenc_conn & ttlin_val;
 
 pos_bus(POS_BUS_SIZE-1 downto 0) <= incenc_val & absenc_val;
 

--- a/targets/PandABrick/hdl/PandABrick_top.vhd
+++ b/targets/PandABrick/hdl/PandABrick_top.vhd
@@ -403,21 +403,27 @@ signal pins_V               : std_logic_vector(ENC_NUM-1 downto 0);
 signal pins_W               : std_logic_vector(ENC_NUM-1 downto 0);
 signal pins_T               : std_logic_vector(ENC_NUM-1 downto 0);
 
--- Input Encoder
-signal inenc_val            : std32_array(ENC_NUM-1 downto 0);
-signal inenc_conn           : std_logic_vector(ENC_NUM-1 downto 0);
-signal inenc_a              : std_logic_vector(ENC_NUM-1 downto 0);
-signal inenc_b              : std_logic_vector(ENC_NUM-1 downto 0);
-signal inenc_z              : std_logic_vector(ENC_NUM-1 downto 0);
-signal inenc_data           : std_logic_vector(ENC_NUM-1 downto 0);
-signal INENC_PROTOCOL       : std32_array(ENC_NUM-1 downto 0);
-signal INENC_PROTOCOL_WSTB  : std_logic_vector(ENC_NUM-1 downto 0);
+-- Incremental Encoder
+signal incenc_val           : std32_array(ENC_NUM-1 downto 0);
+signal incenc_conn          : std_logic_vector(ENC_NUM-1 downto 0);
+signal incenc_a             : std_logic_vector(ENC_NUM-1 downto 0);
+signal incenc_b             : std_logic_vector(ENC_NUM-1 downto 0);
+signal incenc_z             : std_logic_vector(ENC_NUM-1 downto 0);
+signal INCENC_PROTOCOL      : std32_array(ENC_NUM-1 downto 0);
+signal INCENC_PROTOCOL_WSTB : std_logic_vector(ENC_NUM-1 downto 0);
+
+-- Absolute Encoder
+signal absenc_val           : std32_array(ENC_NUM-1 downto 0);
+signal absenc_conn          : std_logic_vector(ENC_NUM-1 downto 0);
+signal absenc_data          : std_logic_vector(ENC_NUM-1 downto 0);
+signal ABSENC_PROTOCOL      : std32_array(ENC_NUM-1 downto 0);
+signal ABSENC_PROTOCOL_WSTB : std_logic_vector(ENC_NUM-1 downto 0);
 
 -- Output Encoder
-signal outenc_clk           : std_logic_vector(ENC_NUM-1 downto 0);
-signal outenc_conn          : std_logic_vector(ENC_NUM-1 downto 0);
-signal OUTENC_PROTOCOL      : std32_array(ENC_NUM-1 downto 0);
-signal OUTENC_PROTOCOL_WSTB : std_logic_vector(ENC_NUM-1 downto 0);
+signal pmacenc_clk          : std_logic_vector(ENC_NUM-1 downto 0);
+signal pmacenc_conn         : std_logic_vector(ENC_NUM-1 downto 0);
+signal PMACENC_PROTOCOL     : std32_array(ENC_NUM-1 downto 0);
+signal PMACENC_PROTOCOL_WSTB : std_logic_vector(ENC_NUM-1 downto 0);
 
 signal pic_data_in          : std_logic_vector(15 downto 0);
 signal pic_data_out         : std_logic_vector(15 downto 0);
@@ -1222,25 +1228,31 @@ port map (
     reset_i                 => FCLK_RESET0,
     
     -- Memory Bus Interface
-    OUTENC_read_strobe_i    => read_strobe(OUTENC_CS),
-    OUTENC_read_data_o      => read_data(OUTENC_CS),
-    OUTENC_read_ack_o       => read_ack(OUTENC_CS),
+    PMACENC_read_strobe_i    => read_strobe(PMACENC_CS),
+    PMACENC_read_data_o      => read_data(PMACENC_CS),
+    PMACENC_read_ack_o       => read_ack(PMACENC_CS),
 
-    OUTENC_write_strobe_i   => write_strobe(OUTENC_CS),
-    OUTENC_write_ack_o      => write_ack(OUTENC_CS),
+    PMACENC_write_strobe_i   => write_strobe(PMACENC_CS),
+    PMACENC_write_ack_o      => write_ack(PMACENC_CS),
 
-    INENC_read_strobe_i     => read_strobe(INENC_CS),
-    INENC_read_data_o       => read_data(INENC_CS),
-    INENC_read_ack_o        => read_ack(INENC_CS),
-    INENC_write_strobe_i    => write_strobe(INENC_CS),
-    INENC_write_ack_o       => write_ack(INENC_CS),
+    INCENC_read_strobe_i     => read_strobe(INCENC_CS),
+    INCENC_read_data_o       => read_data(INCENC_CS),
+    INCENC_read_ack_o        => read_ack(INCENC_CS),
+    INCENC_write_strobe_i    => write_strobe(INCENC_CS),
+    INCENC_write_ack_o       => write_ack(INCENC_CS),
+    ABSENC_read_strobe_i    => read_strobe(ABSENC_CS),
+    ABSENC_read_data_o      => read_data(ABSENC_CS),
+    ABSENC_read_ack_o       => read_ack(ABSENC_CS),
+    ABSENC_write_strobe_i   => write_strobe(ABSENC_CS),
+    ABSENC_write_ack_o      => write_ack(ABSENC_CS),
     read_address_i          => read_address,
     write_address_i         => write_address,
     write_data_i            => write_data,
     
     -- Encoder I/O Pads
-    OUTENC_CONN_OUT_o       => outenc_conn,
-    INENC_CONN_OUT_o        => inenc_conn,
+    PMACENC_CONN_OUT_o       => pmacenc_conn,
+    INCENC_CONN_OUT_o        => incenc_conn,
+    ABSENC_CONN_OUT_o       => absenc_conn,
 
     pins_ENC_A_in           => pins_ENC_A_in,
     pins_ENC_B_in           => pins_ENC_B_in,
@@ -1262,32 +1274,35 @@ port map (
     
 
     -- Signals passed to internal bus
-    clk_int_o               => outenc_clk,
-    inenc_a_o               => inenc_a,
-    inenc_b_o               => inenc_b,
-    inenc_z_o               => inenc_z,
-    inenc_data_o            => inenc_data,
+    clk_int_o               => pmacenc_clk,
+    incenc_a_o              => incenc_a,
+    incenc_b_o              => incenc_b,
+    incenc_z_o              => incenc_z,
+    absenc_data_o           => absenc_data,
     -- Block Input and Outputs
     bit_bus_i               => bit_bus,
     pos_bus_i               => pos_bus,
     DCARD_MODE_i            => DCARD_MODE,
-    posn_o                  => inenc_val,
+    posn_o                  => incenc_val,
+    abs_posn_o              => absenc_val,
 
-    OUTENC_PROTOCOL_o       => OUTENC_PROTOCOL,
-    OUTENC_PROTOCOL_WSTB_o  => OUTENC_PROTOCOL_WSTB,
-    INENC_PROTOCOL_o        => INENC_PROTOCOL,
-    INENC_PROTOCOL_WSTB_o   => INENC_PROTOCOL_WSTB
+    PMACENC_PROTOCOL_o       => PMACENC_PROTOCOL,
+    PMACENC_PROTOCOL_WSTB_o  => PMACENC_PROTOCOL_WSTB,
+    INCENC_PROTOCOL_o        => INCENC_PROTOCOL,
+    INCENC_PROTOCOL_WSTB_o   => INCENC_PROTOCOL_WSTB,
+    ABSENC_PROTOCOL_o       => ABSENC_PROTOCOL,
+    ABSENC_PROTOCOL_WSTB_o  => ABSENC_PROTOCOL_WSTB
 );
 
 -- Bus assembly ----
 
 -- BIT_BUS_SIZE and POS_BUS_SIZE declared in addr_defines.vhd
 
-bit_bus(BIT_BUS_SIZE-1 downto 0 ) <= pcap_active & outenc_clk & inenc_conn &
-                                   inenc_data & inenc_z & inenc_b & inenc_a &
-                                   ttlin_val;
+bit_bus(BIT_BUS_SIZE-1 downto 0 ) <= pcap_active & pmacenc_clk & incenc_conn &
+                                    incenc_z & incenc_b & incenc_a & absenc_data &
+                                    absenc_conn & ttlin_val;
 
-pos_bus(POS_BUS_SIZE-1 downto 0) <= inenc_val;
+pos_bus(POS_BUS_SIZE-1 downto 0) <= incenc_val & absenc_val;
 
 ---------------------------------------------------------------------------
 -- Test the Register Interface (provides dummy data)
@@ -1317,7 +1332,7 @@ port map (
 -- Data to be passed to PIC...
 
 pass_thru_gen: for chan in 0 to ENC_NUM-1 generate
-    serial_pass(chan) <= '1' when (OUTENC_PROTOCOL(chan)(2 downto 0) = "000") else '0';
+    serial_pass(chan) <= '1' when (PMACENC_PROTOCOL(chan)(2 downto 0) = "000") else '0';
 end generate;
 
 uvwt         <= "00000000";


### PR DESCRIPTION
Changes to split PandABrick encoders into ABSENC, INCENC and PMACENC. Step Direction on PMACENC still needs to be implemented and an issue has been made for this #204.

Resolves #184 