### PR TITLE
Add a vhdl PID for the PandA

### DIFF
--- a/apps/PandABox-test.app.ini
+++ b/apps/PandABox-test.app.ini
@@ -1,0 +1,30 @@
+[.]
+description:
+    Test
+target: PandABox
+options: !pcap_std_dev
+
+[SFP3_SYNC]
+module: sfp_panda_sync
+site: sfp 3
+
+[COUNTER]
+number: 4
+
+[POSENC]
+number: 1
+
+[QDEC]
+number: 1
+
+[PID]
+number: 1
+
+[CLOCK]
+number: 1
+
+[PGEN]
+number: 1
+
+[PCOMP]
+number: 1

--- a/apps/PandABox-test.app.ini
+++ b/apps/PandABox-test.app.ini
@@ -4,30 +4,17 @@ description:
 target: PandABox
 options: !pcap_std_dev
 
-[SFP3_SYNC]
-module: sfp_panda_sync
-site: sfp 3
+[CASCADED_PID]
+number: 3
 
 [COUNTER]
-number: 4
-
-[PID]
 number: 4
 
 [CLOCK]
 number: 2
 
 [PGEN]
-number: 4
+number: 3
 
-[PCOMP]
+[PID]
 number: 1
-
-[BITS]
-number: 2
-
-[PULSE]
-number: 2
-
-[LUT]
-number: 2

--- a/apps/PandABox-test.app.ini
+++ b/apps/PandABox-test.app.ini
@@ -4,7 +4,7 @@ description:
 target: PandABox
 options: !pcap_std_dev
 
-[CASCADED_PID]
+[CALC]
 number: 3
 
 [COUNTER]
@@ -17,4 +17,4 @@ number: 2
 number: 3
 
 [PID]
-number: 1
+number: 3

--- a/apps/PandABox-test.app.ini
+++ b/apps/PandABox-test.app.ini
@@ -11,20 +11,23 @@ site: sfp 3
 [COUNTER]
 number: 4
 
-[POSENC]
-number: 1
-
-[QDEC]
-number: 1
-
 [PID]
-number: 1
+number: 4
 
 [CLOCK]
-number: 1
+number: 2
 
 [PGEN]
-number: 1
+number: 4
 
 [PCOMP]
 number: 1
+
+[BITS]
+number: 2
+
+[PULSE]
+number: 2
+
+[LUT]
+number: 2

--- a/modules/cascaded_pid/cascaded_pid.block.ini
+++ b/modules/cascaded_pid/cascaded_pid.block.ini
@@ -1,30 +1,50 @@
 [.]
-description: A generic PID for control.
-entity: pid
+description: A Cascaded PID to control position and velocity.
+entity: cascaded_pid
 
 [INIT]
 type: bit_mux
 description: reset switch
 
-[TRIG]
+[TRIG_SLO]
 type: bit_mux
 description: position calculation clock rate
 
-[KP_I]
+[TRIG_FST]
+type: bit_mux
+description: velocity calculation clock rate
+
+[KP_POS_I]
 type: param int
 description: position proportional constant
 
-[KI_I]
+[KI_POS_I]
 type: param int
 description: position integral constant
 
-[KD_I]
+[KD_POS_I]
 type: param int
 description: position derivative constant
 
-[FF_I]
+[FF_POS_I]
 type: param int
 description: position feed-forward constant
+
+[KP_VEL_I]
+type: param int
+description: velocity proportional constant
+
+[KI_VEL_I]
+type: param int
+description: velocity integral constant
+
+[KD_VEL_I]
+type: param int
+description: velocity derivative constant
+
+[FF_VEL_I]
+type: param int
+description: velocity feed-forward constant
 
 [DIR_TOGGLE_I]
 type: param int
@@ -38,6 +58,6 @@ description: process variable input to the position PID
 type: pos_mux
 description: setpoint value for the position PID
 
-[POSITION_OUT]
+[REAL_OUTPUT]
 type: pos_out
 description: final value output by the PID

--- a/modules/cascaded_pid/hdl/cascaded_pid.vhd
+++ b/modules/cascaded_pid/hdl/cascaded_pid.vhd
@@ -1,0 +1,70 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library work;
+use work.position_control;
+use work.velocity_control;
+
+entity cascaded_pid is
+    port (
+        clk_i : in std_logic;
+        init_i : in std_logic;
+        trig_slo_i : in std_logic;
+        trig_fst_i : in std_logic;
+        kp_pos_i : in std_logic_vector(31 downto 0) := (others => '0');
+        ki_pos_i : in std_logic_vector(31 downto 0) := (others => '0');
+        kd_pos_i : in std_logic_vector(31 downto 0) := (others => '0');
+        ff_pos_i : in std_logic_vector(31 downto 0) := (others => '0');
+        kp_vel_i : in std_logic_vector(31 downto 0) := (others => '0');
+        ki_vel_i : in std_logic_vector(31 downto 0) := (others => '0');
+        kd_vel_i : in std_logic_vector(31 downto 0) := (others => '0');
+        ff_vel_i : in std_logic_vector(31 downto 0) := (others => '0');
+        dir_toggle_i : in std_logic_vector(31 downto 0) := (others => '0');
+        
+        -- clk_rate_i : in std_logic_vector(31 downto 0) := (others => '0');
+        -- sample_rate_i : in std_logic_vector(31 downto 0) := (others => '0');
+        -- velocity_target_i : in std_logic_vector(31 downto 0) := (others => '0');
+
+        real_input_i : in std_logic_vector(31 downto 0) := (others => '0');
+        setpoint_i : in std_logic_vector(31 downto 0) := (others => '0');
+        real_output_o : out std_logic_vector(31 downto 0)
+    );
+end cascaded_pid;
+
+
+architecture rtl of cascaded_pid is
+    signal position_out : signed(31 downto 0) := (others => '0');
+
+begin
+    network : entity work.position_control port map (
+        clk => clk_i,
+        reset => init_i,
+        trig => trig_slo_i,
+        kp_pos => kp_pos_i,
+        ki_pos => ki_pos_i,
+        kd_pos => kd_pos_i,
+        ff_pos => ff_pos_i,
+        dir_toggle => dir_toggle_i,
+        setpoint => setpoint_i,
+        real_input => real_input_i,
+        position_out => position_out
+    );
+
+    model_output : entity work.velocity_control port map (
+        clk => clk_i,
+        reset => init_i,
+        trig => trig_fst_i,
+        kp_vel => kp_vel_i,
+        ki_vel => ki_vel_i,
+        kd_vel => kd_vel_i,
+        ff_vel => ff_vel_i,
+        current_position => real_input_i,
+        dir_toggle => dir_toggle_i,
+        -- sample_rate => sample_rate_i,
+        -- clock_rate => clk_rate_i,
+        velocity_setpoint => position_out,
+        velocity_out => real_output_o
+    );
+
+end rtl;

--- a/modules/cascaded_pid/hdl/position_control.vhd
+++ b/modules/cascaded_pid/hdl/position_control.vhd
@@ -1,5 +1,5 @@
 --------------------------------------------------------------------------------
---  File:       pid.vhd
+--  File:       position_control.vhd
 --  Desc:       Implementation of an outer PID loop which controls position.
 --------------------------------------------------------------------------------
 
@@ -8,28 +8,28 @@ use ieee.std_logic_1164.all;
 use ieee.std_logic_signed.all;
 use ieee.numeric_std.all;
 
-entity pid is 
+entity position_control is 
 port (
-    clk_i : in std_logic;
-    init_i : in std_logic;
-    trig_i : in std_logic;
+    clk : in std_logic;
+    reset : in std_logic;
+    trig : in std_logic; -- 10 us clock
 
-    kp_i : in std_logic_vector(31 downto 0);
-    ki_i : in std_logic_vector(31 downto 0);
-    kd_i : in std_logic_vector(31 downto 0);
-    ff_i : in std_logic_vector(31 downto 0);
-    dir_toggle_i : in std_logic_vector(31 downto 0);
+    kp_pos : in std_logic_vector(31 downto 0);
+    ki_pos : in std_logic_vector(31 downto 0);
+    kd_pos : in std_logic_vector(31 downto 0);
+    ff_pos : in std_logic_vector(31 downto 0);
+    dir_toggle : in std_logic_vector(31 downto 0);
 
-    real_input_i : in std_logic_vector(31 downto 0); -- Measured value
-    setpoint_i : in std_logic_vector(31 downto 0); -- Desired value
-    position_out_o : out std_logic_vector(31 downto 0) := (others => '0') -- Output value
+    real_input : in std_logic_vector(31 downto 0); -- Measured value
+    setpoint : in std_logic_vector(31 downto 0); -- Desired value
+    position_out : out signed(31 downto 0) := (others => '0') -- Output value
 );
-end entity pid;
+end entity position_control;
 
-architecture rtl of pid is
+architecture rtl of position_control is
     signal in_error : signed(24 downto 0) := (others => '0');
     signal prev_error : signed(24 downto 0) := (others => '0');
-    signal round_out : signed(position_out_o'range) := (others => '0');
+    signal round_out : signed(position_out'range) := (others => '0');
 
     signal in_tmp_error : signed(31 downto 0) := (others => '0');
     signal i_tmp : signed(44 downto 0) := (others => '0');
@@ -40,30 +40,30 @@ architecture rtl of pid is
     signal d_val : signed(42 downto 0) := (others => '0');
     signal ff_val : signed(42 downto 0) := (others => '0');
 
-    signal dir_toggle_i_prev : std_logic_vector(31 downto 0);
+    signal dir_toggle_prev : std_logic_vector(31 downto 0);
     signal trigger : std_logic;
     signal trig_prev : std_logic;
     
-    constant max_lim : signed(position_out_o'range) := (position_out_o'left => '0', others => '1');
-    constant min_lim : signed(position_out_o'range) := (position_out_o'left => '1', others => '0');
-    constant max_integral_lim : signed(position_out_o'range) := (position_out_o'left => '0', others => '1');
-    constant min_integral_lim : signed(position_out_o'range) := (position_out_o'left => '1', others => '0');
+    constant max_lim : signed(position_out'range) := (position_out'left => '0', others => '1');
+    constant min_lim : signed(position_out'range) := (position_out'left => '1', others => '0');
+    constant max_integral_lim : signed(position_out'range) := (position_out'left => '0', others => '1');
+    constant min_integral_lim : signed(position_out'range) := (position_out'left => '1', others => '0');
 
 begin
     
-    process(clk_i)
+    process(clk)
     begin
-        if rising_edge(clk_i) then
+        if rising_edge(clk) then
             -- trigger
-            trig_prev <= trig_i;
-            dir_toggle_i_prev <= dir_toggle_i;
-            trigger <= trig_i and not trig_prev;
+            trig_prev <= trig;
+            dir_toggle_prev <= dir_toggle;
+            trigger <= trig and not trig_prev;
 
-            if init_i = '1' then
+            if reset = '1' then
                 in_error <= (others => '0');
                 prev_error <= (others => '0');
                 round_out <= (others => '0');
-                position_out_o <= (others => '0');
+                position_out <= (others => '0');
                 in_tmp_error <= (others => '0');
                 i_tmp <= (others => '0');
                 sum_tmp <= (others => '0');
@@ -74,7 +74,7 @@ begin
 
             elsif trigger = '1' then
                     -- Calculate error and clamp diff
-                    in_tmp_error <= signed(setpoint_i) - signed(real_input_i);
+                    in_tmp_error <= signed(setpoint) - signed(real_input);
                     if in_tmp_error > max_lim then
                         in_error <= (in_error'left => '0', others => '1');
                     elsif in_tmp_error < min_lim then
@@ -87,10 +87,10 @@ begin
                     prev_error <= in_error;
 
                     -- Proportional
-                    p_val <= (resize(signed(kp_i), 18) * in_error);
+                    p_val <= (resize(signed(kp_pos), 18) * in_error);
 
                     -- Integral
-                    i_tmp <= i_tmp + (resize(signed(ki_i), 18) * in_error);
+                    i_tmp <= i_tmp + (resize(signed(ki_pos), 18) * in_error);
                     if i_tmp > max_integral_lim then
                         i_val <= (i_val'left => '0', others => '1');
                     elsif i_tmp < min_integral_lim then
@@ -100,10 +100,10 @@ begin
                     end if;
 
                     -- Derivative
-                    d_val <= resize(signed(kd_i), 18) * (in_error - prev_error);
+                    d_val <= resize(signed(kd_pos), 18) * (in_error - prev_error);
 
                     -- Feedforwards
-                    ff_val <= (resize(signed(ff_i), 18) * resize(signed(setpoint_i), 25));
+                    ff_val <= (resize(signed(ff_pos), 18) * resize(signed(setpoint), 25));
 
                     -- Sum terms
                     sum_tmp <= p_val + i_val + d_val + ff_val;
@@ -116,14 +116,14 @@ begin
                     end if;
 
                     -- Toggle direction if requested
-                    if unsigned(dir_toggle_i) /= 0 and dir_toggle_i /= dir_toggle_i_prev then
+                    if unsigned(dir_toggle) /= 0 and dir_toggle /= dir_toggle_prev then
                         if not round_out = to_signed(0, round_out'length) then
                             round_out <= not round_out; -- apparently not 0 is -1
                         end if;
                     end if;
 
                     -- Return value
-                    position_out_o <= std_logic_vector(round_out);
+                    position_out <= round_out;
 
             end if; -- Reset
         end if; -- Clock

--- a/modules/cascaded_pid/hdl/velocity_control.vhd
+++ b/modules/cascaded_pid/hdl/velocity_control.vhd
@@ -1,0 +1,150 @@
+--------------------------------------------------------------------------------
+--  File:       velocity_control.vhd
+--  Desc:       Implementation of an inner PID loop which controls velocity.
+--------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_signed.all;
+use ieee.numeric_std.all;
+
+entity velocity_control is 
+port (
+    clk : in std_logic;
+    reset : in std_logic;
+    trig : in std_logic; -- 1 us clock
+
+    kp_vel : in std_logic_vector(31 downto 0);
+    ki_vel : in std_logic_vector(31 downto 0);
+    kd_vel : in std_logic_vector(31 downto 0);
+    ff_vel : in std_logic_vector(31 downto 0);
+    dir_toggle : in std_logic_vector(31 downto 0);
+
+    -- sample_rate : in std_logic_vector(31 downto 0);
+    -- clock_rate : in std_logic_vector(31 downto 0);
+
+    current_position : in std_logic_vector(31 downto 0); -- Used for current velocity calculation
+    velocity_setpoint : in signed(31 downto 0) := (others => '0'); -- Desired value, passed in from outer PID
+    velocity_out : out std_logic_vector(31 downto 0)  -- Output value
+);
+end entity velocity_control;
+
+architecture rtl of velocity_control is
+    signal combined_val : signed(42 downto 0) := (others => '0');
+    signal position_diff : signed(31 downto 0) := (others => '0');
+    signal in_error : signed(24 downto 0) := (others => '0');
+    signal prev_error : signed(24 downto 0) := (others => '0');
+    signal round_out : signed(velocity_out'range) := (others => '0');
+
+    signal in_tmp_error : signed(31 downto 0) := (others => '0');
+    signal i_tmp : signed(44 downto 0) := (others => '0');
+    signal sum_tmp : signed(42 downto 0) := (others => '0');
+
+    signal p_val : signed(42 downto 0) := (others => '0');
+    signal i_val : signed(42 downto 0) := (others => '0');
+    signal d_val : signed(42 downto 0) := (others => '0');
+    signal ff_val : signed(42 downto 0) := (others => '0');
+    
+    -- constant scale_factor : real := clock_rate / sample_rate; -- 1/dt, can't precompute due to PandA input constaints
+    -- constant scaled_int : integer := integer(scale_factor * 256.0); -- Q.8
+
+    signal current_velocity : signed(31 downto 0) := (others => '0');
+    signal previous_position : signed(31 downto 0) := (others => '0');
+
+    signal dir_toggle_prev : std_logic_vector(31 downto 0);
+    signal trigger : std_logic;
+    signal trig_prev : std_logic;
+
+    constant max_lim : signed(velocity_out'range) := (velocity_out'left => '0', others => '1');
+    constant min_lim : signed(velocity_out'range) := (velocity_out'left => '1', others => '0');
+    constant max_integral_lim : signed(velocity_out'range) := (velocity_out'left => '0', others => '1');
+    constant min_integral_lim : signed(velocity_out'range) := (velocity_out'left => '1', others => '0');
+
+begin
+    process(clk)
+    begin
+        if rising_edge(clk) then
+            -- trigger
+            trig_prev <= trig;
+            dir_toggle_prev <= dir_toggle;
+            trigger <= trig and not trig_prev;
+
+            if reset = '1' then
+                combined_val <= (others => '0');
+                in_error <= (others => '0');
+                prev_error <= (others => '0');
+
+                in_tmp_error <= (others => '0');
+                i_tmp <= (others => '0');
+                sum_tmp <= (others => '0');
+
+                p_val <= (others => '0');
+                i_val <= (others => '0');
+                d_val <= (others => '0');
+                ff_val <= (others => '0');
+                velocity_out <= (others => '0');
+
+            elsif trigger = '1' then
+                -- Determine the current value of the velocity
+                position_diff <= signed(current_position) - previous_position; -- Let 1/dt = 1
+                current_velocity <= position_diff; -- Assume 1/dt is 1
+
+                -- Calculate error and clamp diff
+                in_tmp_error <= velocity_setpoint - signed(current_velocity);
+                if in_tmp_error > max_lim then
+                    in_error <= (in_error'left => '0', others => '1');
+                elsif in_tmp_error < min_lim then
+                    in_error <= (in_error'left => '1', others => '0');
+                else
+                    in_error <= resize((in_tmp_error), in_error'length);
+                end if;
+
+                -- Proportional
+                p_val <= (resize(signed(kp_vel), 18) * in_error);
+
+                -- Integral
+                i_tmp <= i_tmp + (resize(signed(ki_vel), 18) * in_error);
+                if to_integer(signed(i_tmp)) > to_integer(signed(max_integral_lim)) then
+                    i_val <= (i_val'left => '0', others => '1');
+                elsif to_integer(signed(i_tmp)) < to_integer(signed(min_integral_lim)) then
+                    i_val <= (i_val'left => '1', others => '0');
+                else
+                    i_val <= resize(i_tmp, i_val'length);
+                end if;
+
+                -- Derivative
+                d_val <= resize(signed(kd_vel), 18) * (in_error - prev_error);
+
+                -- Feedforwards
+                ff_val <= (resize(signed(ff_vel), 18) * resize(velocity_setpoint, 25));
+
+                -- Update past error
+                prev_error <= in_error;
+                previous_position <= signed(current_position);
+
+                -- Sum terms
+                sum_tmp <= p_val + i_val + d_val + ff_val;
+                if to_integer(signed(sum_tmp)) > to_integer(resize(signed(max_lim), sum_tmp'length)) then
+                    round_out <= (round_out'left => '0', others => '1');
+                elsif to_integer(signed(sum_tmp)) < to_integer(resize(signed(min_lim), sum_tmp'length)) then
+                    round_out <= (round_out'left => '1', others => '0');
+                else
+                    round_out <= resize(sum_tmp, round_out'length);
+                end if;
+
+                -- Toggle direction if requested
+                if unsigned(dir_toggle) /= 0 and dir_toggle_prev /= dir_toggle then
+                    if not round_out = to_signed(0, round_out'length) then
+                        round_out <= not round_out; -- apparently not 0 is -1
+                    end if;
+                end if;
+
+                -- Return value
+                velocity_out <= std_logic_vector(round_out);
+
+            end if; -- Reset
+        end if; -- Clock
+
+    end process;
+
+end rtl;

--- a/modules/pid/hdl/cascaded_consts.vhd
+++ b/modules/pid/hdl/cascaded_consts.vhd
@@ -1,0 +1,80 @@
+library ieee;
+use ieee.std_logic_1164.all;
+-- use ieee.std_logic_signed.all;
+use ieee.numeric_std.all;
+
+package cascaded_consts is
+    -- Global
+    constant ERR_CLIPPED_LIM : natural := 131070;
+
+    -- Position
+    -- constant K_INT : natural := 10 + 1; -- Includes signed
+    -- constant K_FRAC : natural := 7;
+    -- constant K_INT : natural := 3 + 1; -- Includes signed
+    -- constant K_FRAC : natural := 14;
+    constant K_INT : natural := 10 + 1; -- Includes signed
+    constant K_FRAC : natural := 21;
+    constant P_ERR_INT : natural := 24 + 1; -- Includes signed
+    constant ID_ERR_INT : natural := 17 + 1; -- Includes signed
+    constant FF_SETPOINT_SIZE : natural := 24 + 1; -- Includes signed
+    constant CLIPPED_ERR_INT : natural := 17 + 1; -- Includes signed
+    constant I_ACCUM_BUFFER : natural := 8;
+    -- constant D_INVDT_INT : natural := 15 + 1; -- Includes signed
+    -- constant D_INVDT_FRAC : natural := 16;
+    constant D_DT_SIZE : natural := 24 + 1; -- Includes signed
+
+    constant DT_INT : natural := 0 + 1; -- Includes signed
+    constant DT_FRAC : natural := 21; -- 5e-6 @ 10% error
+
+    constant P_MUL_SIZE : natural := P_ERR_INT + K_INT + K_FRAC;
+    constant P_SCALED_SIZE : natural := P_MUL_SIZE + DT_FRAC - K_FRAC;
+
+    constant I_MUL_FRAC_SIZE : natural := K_INT + DT_INT + K_FRAC + DT_FRAC;
+    constant I_MUL_ERR_SIZE : natural := I_MUL_FRAC_SIZE + ID_ERR_INT;
+    constant I_SCALED_FRAC_SIZE : natural := K_INT + DT_INT + ID_ERR_INT + DT_FRAC; --11+1+18.21
+    constant I_SCALED_SIZE : natural := I_ACCUM_BUFFER + I_SCALED_FRAC_SIZE; --30+8.21
+
+    constant D_MUL_SIZE : natural := K_INT + D_DT_SIZE + K_FRAC;
+    -- constant D_MUL_SIZE : natural := K_INT + D_INVDT_INT + K_FRAC + D_INVDT_FRAC;
+    constant D_MUL_ERR_SIZE : natural := D_MUL_SIZE + P_ERR_INT;
+    -- constant D_MUL_ERR_SIZE : natural := D_MUL_SIZE + P_ERR_INT;
+    constant D_SCALED_SIZE : natural := D_MUL_ERR_SIZE + DT_FRAC - K_FRAC;
+    -- constant D_SCALED_SIZE : natural := D_MUL_ERR_SIZE - D_INVDT_FRAC;
+
+    constant FF_MUL_SIZE : natural := FF_SETPOINT_SIZE + K_INT + K_FRAC;
+    constant FF_SCALED_SIZE : natural := FF_MUL_SIZE + DT_FRAC - K_FRAC;
+
+    constant SUM_OVERFLOW_SIZE : natural := 4;
+    constant SUM_SCALED_SIZE : natural := D_SCALED_SIZE + SUM_OVERFLOW_SIZE + 7;
+
+    -- Velocity
+
+end package cascaded_consts;
+
+-- K_INT + D_DT_SIZE + K_FRAC + ID_ERR_INT + DT_FRAC - K_FRAC
+-- 4 + 25 + 14 + 18 + 21 - 14 = 68
+
+-- 11 + 25 + 7 + 18 + 21 - 7 = 75
+
+
+
+
+-- [KP_I]
+-- type: param scalar
+-- scale: 0.00006103515625
+-- description: position proportional constant.
+
+-- [KI_I]
+-- type: param scalar
+-- scale: 0.00006103515625
+-- description: position integral constant.
+
+-- [KD_I]
+-- type: param scalar
+-- scale: 0.00006103515625
+-- description: position derivative constant.
+
+-- [KFF_I]
+-- type: param scalar
+-- scale: 0.00006103515625
+-- description: position feedforward constant.

--- a/modules/pid/hdl/pid.vhd
+++ b/modules/pid/hdl/pid.vhd
@@ -1,0 +1,108 @@
+--------------------------------------------------------------------------------
+--  File:       PID.vhd
+--  Desc:       HDL implementation of a PID
+--------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.std_logic_signed.all;
+use ieee.numeric_std.all;
+
+entity PID is 
+port (
+    clk_i             : in  std_logic; -- Forced by PandA
+    init_i            : in  std_logic;
+    slo_clk_i         : in  std_logic;
+
+    -- Pass in constants externally
+    Kp_i              : in  std_logic_vector(31 downto 0);
+    Ki_i              : in  std_logic_vector(31 downto 0);
+    Kd_i              : in  std_logic_vector(31 downto 0);
+    FF_i              : in  std_logic_vector(31 downto 0);
+     
+    setpoint_i        : in  std_logic_vector(31 downto 0); -- Desired value
+    in_signal_i       : in  std_logic_vector(31 downto 0); -- Measured value
+    out_signal_o      : out std_logic_vector(31 downto 0)  -- Output value
+);
+end entity PID;
+
+architecture Basic_PID of PID is
+    signal in_error   : signed(31 downto 0) := (others => '0');
+    signal prev_error : signed(31 downto 0) := (others => '0'); -- Start from zero
+    signal integral   : signed(63 downto 0) := (others => '0'); -- Start from zero
+    signal derivative : signed(31 downto 0) := (others => '0');
+    signal P_out      : signed(63 downto 0) := (others => '0');
+    signal I_out      : signed(63 downto 0) := (others => '0');
+    signal D_out      : signed(63 downto 0) := (others => '0');
+    signal round_out  : signed(63 downto 0) := (others => '0');
+
+    -- For type conversion
+    signal Kp         : signed(31 downto 0) := (others => '0');
+    signal Ki         : signed(31 downto 0) := (others => '0');
+    signal Kd         : signed(31 downto 0) := (others => '0');
+    signal FF         : signed(31 downto 0) := (others => '0'); -- Feed Forward
+    signal setpoint   : signed(31 downto 0) := (others => '0');
+    signal in_signal  : signed(31 downto 0) := (others => '0');
+    signal out_signal : signed(31 downto 0) := (others => '0');
+
+begin
+
+    -- Conversions forced by FPGA weirdness
+    Kp            <= signed(Kp_i);
+    Ki            <= signed(Ki_i);
+    Kd            <= signed(Kd_i);
+    FF            <= signed(FF_i);
+    setpoint      <= signed(setpoint_i);
+    in_signal     <= signed(in_signal_i);
+
+    process(slo_clk_i)
+        variable max_lim : signed(out_signal'range);
+        variable min_lim : signed(out_signal'range);
+
+    begin
+        max_lim := (out_signal'left => '0', others => '1');
+        min_lim := (out_signal'left => '1', others => '0');
+
+        if rising_edge(slo_clk_i) then
+            if init_i = '1' then
+                round_out  <= (others => '0');
+                P_out      <= (others => '0');
+                I_out      <= (others => '0');
+                D_out      <= (others => '0');
+                FF         <= (others => '0');
+            else
+                -- Proportional
+                P_out      <= (Kp * in_error);
+
+                -- Integral
+                I_out      <= I_out + (Ki * in_error);
+
+                -- Derivative
+                D_out      <= D_out + (Kd * (in_error - prev_error));
+
+                -- Update
+                prev_error <= in_error;
+
+                -- Protect against overflow
+                if P_out + I_out + D_out + FF > max_lim then
+                    report "OVERFLOW HIGH";
+                    round_out  <= (round_out'left => '0', others => '1');
+                elsif P_out + I_out + D_out + FF < min_lim then
+                    round_out  <= (round_out'left => '1', others => '0');
+                    report "OVERFLOW LOW";
+                else
+                    round_out  <= P_out + I_out + D_out + FF;
+                end if;
+
+            end if; -- Reset + Logic
+        end if; -- Clock
+    end process;
+
+    -- Error calc
+    in_error     <= setpoint - in_signal;
+
+    -- Output conversions
+    out_signal   <= resize(round_out, 32);
+    out_signal_o <= std_logic_vector(out_signal);
+
+end architecture Basic_PID;

--- a/modules/pid/hdl/pid.vhd
+++ b/modules/pid/hdl/pid.vhd
@@ -10,85 +10,107 @@ use ieee.numeric_std.all;
 
 entity PID is 
 port (
-    clk_i             : in  std_logic; -- Forced by PandA
-    init_i            : in  std_logic;
-    slo_clk_i         : in  std_logic;
+    clk_i                : in  std_logic; -- Forced by PandA
+    init_i               : in  std_logic;
+    trig_i               : in  std_logic;
 
     -- Pass in constants externally
-    Kp_i              : in  std_logic_vector(31 downto 0);
-    Ki_i              : in  std_logic_vector(31 downto 0);
-    Kd_i              : in  std_logic_vector(31 downto 0);
-    FF_i              : in  std_logic_vector(31 downto 0);
-     
-    setpoint_i        : in  std_logic_vector(31 downto 0); -- Desired value
-    in_signal_i       : in  std_logic_vector(31 downto 0); -- Measured value
-    out_signal_o      : out std_logic_vector(31 downto 0)  -- Output value
+    Kp_i                 : in  std_logic_vector(31 downto 0);
+    Ki_i                 : in  std_logic_vector(31 downto 0);
+    Kd_i                 : in  std_logic_vector(31 downto 0);
+    FF_i                 : in  std_logic_vector(31 downto 0);
+
+    setpoint_i           : in  std_logic_vector(31 downto 0); -- Desired value
+    in_signal_i          : in  std_logic_vector(31 downto 0); -- Measured value
+    out_signal_o         : out std_logic_vector(31 downto 0)  -- Output value
 );
 end entity PID;
 
 architecture Basic_PID of PID is
-    signal in_error   : signed(31 downto 0) := (others => '0');
-    signal prev_error : signed(31 downto 0) := (others => '0'); -- Start from zero
-    signal integral   : signed(63 downto 0) := (others => '0'); -- Start from zero
-    signal derivative : signed(31 downto 0) := (others => '0');
-    signal P_out      : signed(63 downto 0) := (others => '0');
-    signal I_out      : signed(63 downto 0) := (others => '0');
-    signal D_out      : signed(63 downto 0) := (others => '0');
-    signal FF_out     : signed(63 downto 0) := (others => '0');
-    signal round_out  : signed(63 downto 0) := (others => '0');
+    signal setpoint      : signed(25 downto 0) := (others => '0');
+    signal in_error      : signed(25 downto 0) := (others => '0');
+    signal prev_error    : signed(25 downto 0) := (others => '0');
 
-    -- For type conversion
-    signal Kp         : signed(31 downto 0) := (others => '0');
-    signal Ki         : signed(31 downto 0) := (others => '0');
-    signal Kd         : signed(31 downto 0) := (others => '0');
-    signal FF         : signed(31 downto 0) := (others => '0'); -- Feed Forward
-    signal setpoint   : signed(31 downto 0) := (others => '0');
-    signal in_signal  : signed(31 downto 0) := (others => '0');
-    signal out_signal : signed(31 downto 0) := (others => '0');
+    signal P_out         : signed(44 downto 0) := (others => '0');
+    signal I_out         : signed(44 downto 0) := (others => '0');
+    signal D_out         : signed(44 downto 0) := (others => '0');
+    signal FF_out        : signed(44 downto 0) := (others => '0');
+
+    signal Kp            : signed(18 downto 0) := (others => '0');
+    signal Ki            : signed(18 downto 0) := (others => '0');
+    signal Kd            : signed(18 downto 0) := (others => '0');
+    signal FF            : signed(18 downto 0) := (others => '0');
+
+    signal in_signal     : signed(25 downto 0) := (others => '0');
+    signal round_out     : signed(44 downto 0) := (others => '0');
+    signal out_signal    : signed(31 downto 0) := (others => '0');
+
+    signal trigger       : std_logic;
+    signal trigger_prev  : std_logic;
+
+    signal I_out_current : signed(44 downto 0) := (others => '0');
 
 begin
 
-    -- Conversions forced by FPGA weirdness
-    Kp            <= signed(Kp_i);
-    Ki            <= signed(Ki_i);
-    Kd            <= signed(Kd_i);
-    FF            <= signed(FF_i);
-    setpoint      <= signed(setpoint_i);
-    in_signal     <= signed(in_signal_i);
+    process(clk_i)
+        constant max_lim_final : signed(out_signal'range) := (out_signal'left => '0', others => '1');
+        constant min_lim_final : signed(out_signal'range) := (out_signal'left => '1', others => '0');
 
-    process(slo_clk_i)
-        constant max_lim : signed(out_signal'range) := (out_signal'left => '0', others => '1');
-        constant min_lim : signed(out_signal'range) := (out_signal'left => '1', others => '0');
+        constant max_lim_err  : signed(out_signal'range) := (out_signal'left => '0', others => '1');
+        constant min_lim_err  : signed(out_signal'range) := (out_signal'left => '1', others => '0');
 
     begin
-        if rising_edge(slo_clk_i) then
+        if rising_edge(clk_i) then
+            -- PandA type conversions
+            Kp             <= resize(signed(Kp_i), 19);
+            Ki             <= resize(signed(Ki_i), 19);
+            Kd             <= resize(signed(Kd_i), 19);
+            FF             <= resize(signed(FF_i), 19);
+            setpoint       <= resize(signed(setpoint_i), 26);
+            in_signal      <= resize(signed(in_signal_i), 26);
+
+            trigger_prev   <= trig_i;
+
+            I_out <= I_out_current;
+
+            -- Error calc w/ overflow protection
+            if setpoint - in_signal > max_lim_err then
+                report "OVERFLOW HIGH";
+                in_error  <= (in_error'left => '0', others => '1');
+            elsif setpoint - in_signal < min_lim_err then
+                in_error  <= (in_error'left => '1', others => '0');
+                report "OVERFLOW LOW";
+            else
+                in_error     <= resize(setpoint - in_signal, 26);
+            end if;
+
             if init_i = '1' then
                 round_out  <= (others => '0');
                 P_out      <= (others => '0');
                 I_out      <= (others => '0');
                 D_out      <= (others => '0');
                 FF         <= (others => '0');
-            else
+            elsif trigger = '1' then
                 -- Proportional
-                P_out      <= (Kp * in_error);
+                P_out    <= (Kp * in_error);
 
                 -- Integral
-                I_out      <= I_out + (Ki * in_error);
+                I_out_current <= (Ki * in_error);
 
                 -- Derivative
-                D_out      <= Kd * (in_error - prev_error);
+                D_out    <= Kd * (in_error - prev_error);
 
                 -- Feedforwards
-                FF_out     <= FF * setpoint;
+                FF_out     <= (FF * setpoint);
 
                 -- Update
                 prev_error <= in_error;
 
                 -- Protect against overflow
-                if P_out + I_out + D_out + FF_out > max_lim then
+                if P_out + I_out + D_out + FF_out > max_lim_final then
                     report "OVERFLOW HIGH";
                     round_out  <= (round_out'left => '0', others => '1');
-                elsif P_out + I_out + D_out + FF_out < min_lim then
+                elsif P_out + I_out + D_out + FF_out < min_lim_final then
                     round_out  <= (round_out'left => '1', others => '0');
                     report "OVERFLOW LOW";
                 else
@@ -99,8 +121,10 @@ begin
         end if; -- Clock
     end process;
 
-    -- Error calc
-    in_error     <= setpoint - in_signal;
+    -- trigger if clock is high and previous was not high
+    -- only triggers for one clock period on rising edge
+    trigger      <= trig_i and not trigger_prev;
+    
 
     -- Output conversions
     out_signal   <= resize(round_out, 32);

--- a/modules/pid/hdl/pid.vhd
+++ b/modules/pid/hdl/pid.vhd
@@ -19,6 +19,7 @@ port (
     Ki_i                 : in  std_logic_vector(31 downto 0);
     Kd_i                 : in  std_logic_vector(31 downto 0);
     FF_i                 : in  std_logic_vector(31 downto 0);
+    err_sign_i           : in  std_logic_vector(31 downto 0);
 
     setpoint_i           : in  std_logic_vector(31 downto 0); -- Desired value
     in_signal_i          : in  std_logic_vector(31 downto 0); -- Measured value
@@ -40,10 +41,12 @@ architecture Basic_PID of PID is
     signal Ki            : signed(18 downto 0) := (others => '0');
     signal Kd            : signed(18 downto 0) := (others => '0');
     signal FF            : signed(18 downto 0) := (others => '0');
+    signal err_sign      : signed(1 downto 0) := (others => '0');
 
     signal in_signal     : signed(25 downto 0) := (others => '0');
     signal round_out     : signed(44 downto 0) := (others => '0');
     signal out_signal    : signed(31 downto 0) := (others => '0');
+    signal out_sign      : signed(46 downto 0) := (others => '0');
 
     signal trigger       : std_logic;
     signal trigger_prev  : std_logic;
@@ -66,6 +69,7 @@ begin
             Ki             <= resize(signed(Ki_i), 19);
             Kd             <= resize(signed(Kd_i), 19);
             FF             <= resize(signed(FF_i), 19);
+            err_sign       <= resize(signed(err_sign_i), 2);
             setpoint       <= resize(signed(setpoint_i), 26);
             in_signal      <= resize(signed(in_signal_i), 26);
 
@@ -127,7 +131,8 @@ begin
     
 
     -- Output conversions
-    out_signal   <= resize(round_out, 32);
+    out_sign     <= round_out * err_sign;
+    out_signal   <= resize(out_sign, 32);
     out_signal_o <= std_logic_vector(out_signal);
 
 end architecture Basic_PID;

--- a/modules/pid/hdl/pid.vhd
+++ b/modules/pid/hdl/pid.vhd
@@ -12,120 +12,241 @@ entity pid is
 port (
     clk_i : in std_logic;
     init_i : in std_logic;
-    trig_i : in std_logic;
 
-    kp_i : in std_logic_vector(31 downto 0);
+    pid_period_i : in std_logic_vector(31 downto 0);
+
+    kp_i : in std_logic_vector(31 downto 0) := (others => '0');
     ki_i : in std_logic_vector(31 downto 0);
     kd_i : in std_logic_vector(31 downto 0);
-    ff_i : in std_logic_vector(31 downto 0);
+    kff_i : in std_logic_vector(31 downto 0);
     dir_toggle_i : in std_logic_vector(31 downto 0);
+
+    dt_i : in std_logic_vector(31 downto 0);
+    dt_inverse_i : in std_logic_vector(31 downto 0);
+
+    max_integral_i : in std_logic_vector(31 downto 0);
+    max_output_i : in std_logic_vector(31 downto 0);
 
     real_input_i : in std_logic_vector(31 downto 0); -- Measured value
     setpoint_i : in std_logic_vector(31 downto 0); -- Desired value
-    position_out_o : out std_logic_vector(31 downto 0) := (others => '0') -- Output value
+    real_output_o : out std_logic_vector(31 downto 0) := (others => '0') -- Output value
 );
 end entity pid;
 
 architecture rtl of pid is
-    signal in_error : signed(24 downto 0) := (others => '0');
-    signal prev_error : signed(24 downto 0) := (others => '0');
-    signal round_out : signed(position_out_o'range) := (others => '0');
+    -- 200 kHz target
+    -- 25 x 18 multipliers
+    constant ERR_CLIPPED_LIM : natural := 131070;
 
-    signal in_tmp_error : signed(31 downto 0) := (others => '0');
-    signal i_tmp : signed(44 downto 0) := (others => '0');
-    signal sum_tmp : signed(42 downto 0) := (others => '0');
+    constant K_INT : natural := 10 + 1; -- Includes signed
+    constant K_FRAC : natural := 7;
+    constant P_ERR_INT : natural := 24 + 1; -- Includes signed
+    constant ID_ERR_INT : natural := 17 + 1; -- Includes signed
+    constant FF_SETPOINT_SIZE : natural := 24 + 1; -- Includes signed
+    constant CLIPPED_ERR_INT : natural := 17 + 1; -- Includes signed
+    constant I_ACCUM_BUFFER : natural := 8;
+    constant D_DT_SIZE : natural := 24 + 1; -- Includes signed
 
-    signal p_val : signed(42 downto 0) := (others => '0');
-    signal i_val : signed(42 downto 0) := (others => '0');
-    signal d_val : signed(42 downto 0) := (others => '0');
-    signal ff_val : signed(42 downto 0) := (others => '0');
+    constant DT_INT : natural := 0 + 1; -- Includes signed
+    constant DT_FRAC : natural := 21; -- 5e-6 @ 10% error
 
-    signal dir_toggle_i_prev : std_logic_vector(31 downto 0);
+    -- constant DT_VAL : std_logic_vector(DT_INT + DT_FRAC - 1 downto 0) := "0000000000000000001011"; --Q1.21 5e-6
+
+    constant P_MUL_SIZE : natural := P_ERR_INT + K_INT + K_FRAC;
+    constant P_SCALED_SIZE : natural := P_MUL_SIZE + DT_FRAC - K_FRAC;
+
+    constant I_MUL_FRAC_SIZE : natural := K_INT + DT_INT + K_FRAC + DT_FRAC;
+    constant I_MUL_ERR_SIZE : natural := I_MUL_FRAC_SIZE + ID_ERR_INT;
+    constant I_SCALED_FRAC_SIZE : natural := K_INT + DT_INT + ID_ERR_INT + DT_FRAC; --11+1+18.21
+    constant I_SCALED_SIZE : natural := I_ACCUM_BUFFER + I_SCALED_FRAC_SIZE; --30+8.21
+
+    constant D_MUL_SIZE : natural := K_INT + D_DT_SIZE + K_FRAC;
+    constant D_MUL_ERR_SIZE : natural := D_MUL_SIZE + ID_ERR_INT;
+    constant D_SCALED_SIZE : natural := D_MUL_ERR_SIZE + DT_FRAC - K_FRAC;
+
+    constant FF_MUL_SIZE : natural := FF_SETPOINT_SIZE + K_INT + K_FRAC;
+    constant FF_SCALED_SIZE : natural := FF_MUL_SIZE + DT_FRAC - K_FRAC;
+
+    constant SUM_OVERFLOW_SIZE : natural := 4;
+    constant SUM_SCALED_SIZE : natural := D_SCALED_SIZE + SUM_OVERFLOW_SIZE;
+
+    signal prev_error : signed(31 downto 0) := (others => '0');
+    signal round_out : signed(real_output_o'range) := (others => '0');
+    signal err_clipped : signed(ID_ERR_INT - 1 downto 0) := (others => '0');
+
+    signal err_full : signed(31 downto 0) := (others => '0');
+    signal p_mul : signed(P_MUL_SIZE - 1 downto 0) := (others => '0');
+    signal p_scaled : signed(P_SCALED_SIZE - 1 downto 0) := (others => '0');
+
+    signal i_mul_frac_parts : signed(I_MUL_FRAC_SIZE - 1 downto 0) := (others => '0');
+    signal i_mul_err : signed(I_MUL_ERR_SIZE - 1 downto 0) := (others => '0');
+    signal i_round : signed(i_mul_err'length - 1 downto 0) := (others => '0');
+    signal i_scaled_frac : signed(I_SCALED_FRAC_SIZE - 1 downto 0) := (others => '0');
+    signal i_scaled : signed(I_SCALED_SIZE - 1 downto 0) := (others => '0');
+
+    signal max_integral_shifted : signed(i_scaled'length - 1 downto 0) := (others => '0');
+
+    signal d_mul : signed(D_MUL_SIZE -1 downto 0) := (others => '0');
+    signal d_mul_err : signed(D_MUL_ERR_SIZE -1 downto 0) := (others => '0');
+    signal d_scaled : signed(D_SCALED_SIZE - 1 downto 0) := (others => '0');
+
+    signal ff_mul : signed(FF_MUL_SIZE - 1 downto 0) := (others => '0');
+    signal ff_scaled : signed(FF_SCALED_SIZE - 1 downto 0) := (others => '0');
+
+    signal sum_scaled : signed(SUM_SCALED_SIZE - 1 downto 0) := (others => '0');
+    signal sum_rounded : signed(sum_scaled'length - 1 downto 0) := (others => '0');
+    signal sum_integer : signed(sum_scaled'length - DT_FRAC - 1 downto 0) := (others => '0');
+
+    signal pipeline_counter : unsigned(3 downto 0) := (others => '0');
+    signal enable_pipeline  : std_logic := '0';
+
+    signal clk_count : unsigned(31 downto 0) := (others => '0'); -- 625 is ~200kHz
     signal trigger : std_logic;
-    signal trig_prev : std_logic;
-    
-    constant max_lim : signed(position_out_o'range) := (position_out_o'left => '0', others => '1');
-    constant min_lim : signed(position_out_o'range) := (position_out_o'left => '1', others => '0');
-    constant max_integral_lim : signed(position_out_o'range) := (position_out_o'left => '0', others => '1');
-    constant min_integral_lim : signed(position_out_o'range) := (position_out_o'left => '1', others => '0');
 
 begin
-    
+
     process(clk_i)
     begin
         if rising_edge(clk_i) then
-            -- trigger
-            trig_prev <= trig_i;
-            dir_toggle_i_prev <= dir_toggle_i;
-            trigger <= trig_i and not trig_prev;
+            if init_i = '1' then
+                trigger <= '0';
+                clk_count <= (others => '0');
+            else
+                if clk_count = unsigned(pid_period_i) - 1 then
+                    trigger <= '1';
+                    clk_count <= (others => '0');
+                else
+                    trigger <= '0';
+                    clk_count <= clk_count + 1;
+                end if; -- Update count
+            end if; -- Process reset
+        end if; -- Clock
+    end process;
+
+    process(clk_i)
+    begin
+        if rising_edge(clk_i) then
+
+            -- Scale integral limit to Q38.21
+            max_integral_shifted <= shift_left(resize(signed(max_integral_i), max_integral_shifted'length), DT_FRAC); -- Q38.21
+            
+            -- Reduce error for Integral and Derivative terms
+            if err_full > ERR_CLIPPED_LIM then
+                err_clipped <= (err_clipped'left => '0', others => '1');
+            elsif err_full < -ERR_CLIPPED_LIM then
+                err_clipped <= (err_clipped'left => '1', others => '0');
+            else
+                err_clipped <= resize(err_full, err_clipped'length);
+            end if;
 
             if init_i = '1' then
-                in_error <= (others => '0');
+                err_full <= (others => '0');
                 prev_error <= (others => '0');
+                
+                sum_scaled <= (others => '0');
+                sum_rounded <= (others => '0');
+                sum_integer <= (others => '0');
+
+                ff_mul <= (others => '0');
+                ff_scaled <= (others => '0');
+
+                p_mul <= (others => '0');
+                p_scaled <= (others => '0');
+
+                i_mul_frac_parts <= (others => '0');
+                i_mul_err <= (others => '0');
+                i_round <= (others => '0');
+                i_scaled_frac <= (others => '0');
+                i_scaled <= (others => '0');
+
                 round_out <= (others => '0');
-                position_out_o <= (others => '0');
-                in_tmp_error <= (others => '0');
-                i_tmp <= (others => '0');
-                sum_tmp <= (others => '0');
-                p_val <= (others => '0');
-                i_val <= (others => '0');
-                d_val <= (others => '0');
-                ff_val <= (others => '0');
+                real_output_o <= (others => '0');
+                err_full <= (others => '0');
 
-            elsif trigger = '1' then
-                    -- Calculate error and clamp diff
-                    in_tmp_error <= signed(setpoint_i) - signed(real_input_i);
-                    if in_tmp_error > max_lim then
-                        in_error <= (in_error'left => '0', others => '1');
-                    elsif in_tmp_error < min_lim then
-                        in_error <= (in_error'left => '1', others => '0');
-                    else
-                        in_error <= resize(in_tmp_error, in_error'length);
-                    end if;
+                pipeline_counter <= "0000";
+                enable_pipeline <= '0';
 
-                    -- Store previous error
-                    prev_error <= in_error;
+            elsif enable_pipeline = '1' then
+                case pipeline_counter is
+                    when "0000" =>
+                        p_mul <= resize(signed(kp_i), K_INT + K_FRAC) * resize(signed(err_full), P_ERR_INT); --Q25+11.7 = Q36.7 = 43 bits
+                        i_mul_frac_parts <= resize(signed(ki_i), K_INT + K_FRAC) * resize(signed(dt_i), DT_INT + DT_FRAC); --Q11+1.21+7 = Q12.28
+                        d_mul <= resize(signed(kd_i), K_INT + K_FRAC) * resize(signed(dt_inverse_i), D_DT_SIZE); --Q11+25.7 = Q36.7
+                        pipeline_counter <= "0001";
 
-                    -- Proportional
-                    p_val <= (resize(signed(kp_i), 18) * in_error);
+                    when "0001" =>
+                        ff_mul <= resize(signed(kff_i), K_INT + K_FRAC) * resize(signed(setpoint_i), FF_SETPOINT_SIZE); --Q25+11.7 = Q36.7 = 43 bits
+                        i_mul_err <= resize(signed(err_clipped), ID_ERR_INT) * i_mul_frac_parts; --Q18+11+1.28 = Q30.28
+                        d_mul_err <= resize(signed(err_clipped), ID_ERR_INT) * d_mul; -- Q36+18.7 = Q54.7 = 61 bits
+                        pipeline_counter <= "0010";
 
-                    -- Integral
-                    i_tmp <= i_tmp + (resize(signed(ki_i), 18) * in_error);
-                    if i_tmp > max_integral_lim then
-                        i_val <= (i_val'left => '0', others => '1');
-                    elsif i_tmp < min_integral_lim then
-                        i_val <= (i_val'left => '1', others => '0');
-                    else
-                        i_val <= resize(i_tmp, i_val'length);
-                    end if;
+                    when "0010" =>
+                        p_scaled <= p_mul & (DT_FRAC - K_FRAC - 1 downto 0 => '0'); --Q36.21 = 57 bits
+                        ff_scaled <= ff_mul & (DT_FRAC - K_FRAC - 1 downto 0 => '0'); -- Q36.21 = 57 bits
+                        i_round <= i_mul_err + shift_right(i_mul_err, DT_FRAC - 1); --Q18+11+1.28 = Q30.28
+                        d_scaled <= d_mul_err & (DT_FRAC - K_FRAC - 1 downto 0 => '0'); -- Q54.21 = 75 bits
+                        pipeline_counter <= "0011";
 
-                    -- Derivative
-                    d_val <= resize(signed(kd_i), 18) * (in_error - prev_error);
+                    when "0011" =>
+                        i_scaled_frac <= resize(shift_right(i_round, K_FRAC), i_scaled_frac'length); --Q30.21 = 51 bits
+                        pipeline_counter <= "0100";
 
-                    -- Feedforwards
-                    ff_val <= (resize(signed(ff_i), 18) * resize(signed(setpoint_i), 25));
-
-                    -- Sum terms
-                    sum_tmp <= p_val + i_val + d_val + ff_val;
-                    if sum_tmp > max_lim then
-                        round_out <= (round_out'left => '0', others => '1');
-                    elsif sum_tmp < min_lim then
-                        round_out <= (round_out'left => '1', others => '0');
-                    else
-                        round_out <= resize(sum_tmp, round_out'length);
-                    end if;
-
-                    -- Toggle direction if requested
-                    if unsigned(dir_toggle_i) /= 0 and dir_toggle_i /= dir_toggle_i_prev then
-                        if not round_out = to_signed(0, round_out'length) then
-                            round_out <= not round_out; -- apparently not 0 is -1
+                    when "0100" =>
+                        if (i_scaled + i_scaled_frac) > max_integral_shifted then
+                            i_scaled <= max_integral_shifted;
+                        elsif (i_scaled + i_scaled_frac) < -max_integral_shifted then
+                            i_scaled <= -max_integral_shifted;
+                        else
+                            i_scaled <= i_scaled + i_scaled_frac; --Q8+11+1+18.21 = Q38.21 = 59 bits
                         end if;
-                    end if;
+                        pipeline_counter <= "0101";
 
-                    -- Return value
-                    position_out_o <= std_logic_vector(round_out);
+                    when "0101" => -- process sum
+                        sum_scaled <= resize((p_scaled + i_scaled + d_scaled + ff_scaled), sum_scaled'length); --Q11+25+18+4.21 = 79 bits
+                        pipeline_counter <= "0110";
 
-            end if; -- Reset
+                    when "0110" =>
+                        sum_rounded <= sum_scaled + shift_right(sum_scaled, DT_FRAC - 1); --Q58.21 = 79 bits
+                        pipeline_counter <= "0111";
+
+                    when "0111" =>
+                        sum_integer <= resize(shift_right(sum_rounded, DT_FRAC), sum_integer'length); --Q58.0 = 58 bits
+                        pipeline_counter <= "1000";
+
+                    when "1000" =>
+                        -- Control output clamp
+                        if sum_integer > signed(max_output_i) then
+                            round_out <= resize(signed(max_output_i), round_out'length); --Q32.0
+                        elsif sum_integer < signed(-max_output_i) then
+                            round_out <= resize(signed(-max_output_i), round_out'length); --Q32.0
+                        else
+                            -- Toggle Direction
+                            if dir_toggle_i(0) = '1' then
+                                round_out <= resize(-sum_integer, round_out'length); --Q32.0
+                            else
+                                round_out <= resize(sum_integer, round_out'length); --Q32.0
+                            end if;
+                        end if;
+                        pipeline_counter <= "0000";
+                        enable_pipeline <= '0';
+
+                    when others =>
+                        pipeline_counter <= "0000";
+                        enable_pipeline <= '0';
+
+                end case;
+
+            elsif trigger = '1' and (dt_i /= (dt_i'range => '0')) then
+                -- Handle error
+                err_full <= signed(setpoint_i) - signed(real_input_i);
+                prev_error <= err_full;
+
+                -- Return value
+                real_output_o <= std_logic_vector(round_out);
+                enable_pipeline <= '1';
+
+            end if; -- Reset + Trigger
+
         end if; -- Clock
 
     end process;

--- a/modules/pid/hdl/pid.vhd
+++ b/modules/pid/hdl/pid.vhd
@@ -3,10 +3,14 @@
 --  Desc:       Implementation of an outer PID loop which controls position.
 --------------------------------------------------------------------------------
 
+-- We assume the input rate of the data will always be greater than the servo-rate of the PID.
+
+
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_signed.all;
 use ieee.numeric_std.all;
+use work.cascaded_consts.all;
 
 entity pid is 
 port (
@@ -23,9 +27,11 @@ port (
 
     dt_i : in std_logic_vector(31 downto 0);
     dt_inverse_i : in std_logic_vector(31 downto 0);
+    use_vel_der_i : in std_logic_vector(31 downto 0);
 
     max_integral_i : in std_logic_vector(31 downto 0);
     max_output_i : in std_logic_vector(31 downto 0);
+    max_following_err_i : in std_logic_vector(31 downto 0) := (others => '0');
 
     real_input_i : in std_logic_vector(31 downto 0); -- Measured value
     setpoint_i : in std_logic_vector(31 downto 0); -- Desired value
@@ -36,45 +42,22 @@ end entity pid;
 architecture rtl of pid is
     -- 200 kHz target
     -- 25 x 18 multipliers
-    constant ERR_CLIPPED_LIM : natural := 131070;
 
-    constant K_INT : natural := 10 + 1; -- Includes signed
-    constant K_FRAC : natural := 7;
-    constant P_ERR_INT : natural := 24 + 1; -- Includes signed
-    constant ID_ERR_INT : natural := 17 + 1; -- Includes signed
-    constant FF_SETPOINT_SIZE : natural := 24 + 1; -- Includes signed
-    constant CLIPPED_ERR_INT : natural := 17 + 1; -- Includes signed
-    constant I_ACCUM_BUFFER : natural := 8;
-    constant D_DT_SIZE : natural := 24 + 1; -- Includes signed
+    signal kp_prev : std_logic_vector(31 downto 0) := (others => '0');
+    signal ki_prev : std_logic_vector(31 downto 0) := (others => '0');
+    signal kd_prev : std_logic_vector(31 downto 0) := (others => '0');
+    signal kff_prev : std_logic_vector(31 downto 0) := (others => '0');
+    signal dt_prev : std_logic_vector(31 downto 0) := (others => '0');
+    signal dt_inv_prev : std_logic_vector(31 downto 0) := (others => '0');
+    signal input_changed : std_logic;
 
-    constant DT_INT : natural := 0 + 1; -- Includes signed
-    constant DT_FRAC : natural := 21; -- 5e-6 @ 10% error
-
-    -- constant DT_VAL : std_logic_vector(DT_INT + DT_FRAC - 1 downto 0) := "0000000000000000001011"; --Q1.21 5e-6
-
-    constant P_MUL_SIZE : natural := P_ERR_INT + K_INT + K_FRAC;
-    constant P_SCALED_SIZE : natural := P_MUL_SIZE + DT_FRAC - K_FRAC;
-
-    constant I_MUL_FRAC_SIZE : natural := K_INT + DT_INT + K_FRAC + DT_FRAC;
-    constant I_MUL_ERR_SIZE : natural := I_MUL_FRAC_SIZE + ID_ERR_INT;
-    constant I_SCALED_FRAC_SIZE : natural := K_INT + DT_INT + ID_ERR_INT + DT_FRAC; --11+1+18.21
-    constant I_SCALED_SIZE : natural := I_ACCUM_BUFFER + I_SCALED_FRAC_SIZE; --30+8.21
-
-    constant D_MUL_SIZE : natural := K_INT + D_DT_SIZE + K_FRAC;
-    constant D_MUL_ERR_SIZE : natural := D_MUL_SIZE + ID_ERR_INT;
-    constant D_SCALED_SIZE : natural := D_MUL_ERR_SIZE + DT_FRAC - K_FRAC;
-
-    constant FF_MUL_SIZE : natural := FF_SETPOINT_SIZE + K_INT + K_FRAC;
-    constant FF_SCALED_SIZE : natural := FF_MUL_SIZE + DT_FRAC - K_FRAC;
-
-    constant SUM_OVERFLOW_SIZE : natural := 4;
-    constant SUM_SCALED_SIZE : natural := D_SCALED_SIZE + SUM_OVERFLOW_SIZE;
-
-    signal prev_error : signed(31 downto 0) := (others => '0');
     signal round_out : signed(real_output_o'range) := (others => '0');
-    signal err_clipped : signed(ID_ERR_INT - 1 downto 0) := (others => '0');
 
     signal err_full : signed(31 downto 0) := (others => '0');
+    signal err_buffered : signed(31 downto 0) := (others => '0');
+    signal err_prev : signed(31 downto 0) := (others => '0');
+    signal err_diff : signed(31 downto 0) := (others => '0');
+
     signal p_mul : signed(P_MUL_SIZE - 1 downto 0) := (others => '0');
     signal p_scaled : signed(P_SCALED_SIZE - 1 downto 0) := (others => '0');
 
@@ -90,12 +73,14 @@ architecture rtl of pid is
     signal d_mul_err : signed(D_MUL_ERR_SIZE -1 downto 0) := (others => '0');
     signal d_scaled : signed(D_SCALED_SIZE - 1 downto 0) := (others => '0');
 
+    signal prev_position : std_logic_vector(31 downto 0) := (others => '0');
+
     signal ff_mul : signed(FF_MUL_SIZE - 1 downto 0) := (others => '0');
     signal ff_scaled : signed(FF_SCALED_SIZE - 1 downto 0) := (others => '0');
 
     signal sum_scaled : signed(SUM_SCALED_SIZE - 1 downto 0) := (others => '0');
-    signal sum_rounded : signed(sum_scaled'length - 1 downto 0) := (others => '0');
-    signal sum_integer : signed(sum_scaled'length - DT_FRAC - 1 downto 0) := (others => '0');
+    signal sum_rounded : signed(SUM_SCALED_SIZE - 1 downto 0) := (others => '0');
+    signal sum_integer : signed(SUM_SCALED_SIZE - DT_FRAC - 1 downto 0) := (others => '0');
 
     signal pipeline_counter : unsigned(3 downto 0) := (others => '0');
     signal enable_pipeline  : std_logic := '0';
@@ -127,28 +112,48 @@ begin
     begin
         if rising_edge(clk_i) then
 
-            -- Scale integral limit to Q38.21
-            max_integral_shifted <= shift_left(resize(signed(max_integral_i), max_integral_shifted'length), DT_FRAC); -- Q38.21
+            -- -- Check if inputs have changed
+            -- if kp_i /= kp_prev or
+            -- ki_i /= ki_prev or
+            -- kd_i /= kd_prev or
+            -- dt_i /= dt_prev or
+            -- dt_inverse_i /= dt_inv_prev then
+            --     input_changed <= '1';
+            -- else
+            --     input_changed <= '0';
+            -- end if;
+
+            -- -- Update input buffer
+            -- kp_prev <= kp_i;
+            -- ki_prev <= ki_i;
+            -- kd_prev <= kd_i;
+            -- dt_prev <= dt_i;
+            -- dt_inv_prev <= dt_inverse_i;
+
+            -- Scale integral limit to fixed point
+            max_integral_shifted <= shift_left(resize(signed(max_integral_i), max_integral_shifted'length), DT_FRAC);
             
-            -- Reduce error for Integral and Derivative terms
-            if err_full > ERR_CLIPPED_LIM then
-                err_clipped <= (err_clipped'left => '0', others => '1');
-            elsif err_full < -ERR_CLIPPED_LIM then
-                err_clipped <= (err_clipped'left => '1', others => '0');
-            else
-                err_clipped <= resize(err_full, err_clipped'length);
-            end if;
+            -- Calculate the setpoint error
+            err_full <= signed(setpoint_i) - signed(real_input_i);
+
+            -- -- Caclulate velocity
+            -- vel_o <= std_logic_vector(resize(signed(real_input_i) - signed(prev_position), vel_o'length));
+
+            -- Reset/following error protection
+            -- if init_i = '1' or 
+            -- signed(real_input_i) > signed(max_following_err_i) or 
+            -- signed(real_input_i) < signed(-max_following_err_i) or
+            -- input_changed = '1' then
 
             if init_i = '1' then
                 err_full <= (others => '0');
-                prev_error <= (others => '0');
+                err_prev <= (others => '0');
+                err_buffered <= (others => '0');
+                err_diff <= (others => '0');
                 
                 sum_scaled <= (others => '0');
                 sum_rounded <= (others => '0');
                 sum_integer <= (others => '0');
-
-                ff_mul <= (others => '0');
-                ff_scaled <= (others => '0');
 
                 p_mul <= (others => '0');
                 p_scaled <= (others => '0');
@@ -159,74 +164,93 @@ begin
                 i_scaled_frac <= (others => '0');
                 i_scaled <= (others => '0');
 
+                d_mul <= (others => '0');
+                d_mul_err <= (others => '0');
+                d_scaled <= (others => '0');
+
+                prev_position <= (others => '0');
+
+                ff_mul <= (others => '0');
+                ff_scaled <= (others => '0');
+
                 round_out <= (others => '0');
                 real_output_o <= (others => '0');
-                err_full <= (others => '0');
 
                 pipeline_counter <= "0000";
                 enable_pipeline <= '0';
 
+            elsif trigger = '1' then
+                -- Output value and process next
+                real_output_o <= std_logic_vector(round_out);
+                enable_pipeline <= '1';
+
             elsif enable_pipeline = '1' then
                 case pipeline_counter is
                     when "0000" =>
-                        p_mul <= resize(signed(kp_i), K_INT + K_FRAC) * resize(signed(err_full), P_ERR_INT); --Q25+11.7 = Q36.7 = 43 bits
-                        i_mul_frac_parts <= resize(signed(ki_i), K_INT + K_FRAC) * resize(signed(dt_i), DT_INT + DT_FRAC); --Q11+1.21+7 = Q12.28
-                        d_mul <= resize(signed(kd_i), K_INT + K_FRAC) * resize(signed(dt_inverse_i), D_DT_SIZE); --Q11+25.7 = Q36.7
+                        i_mul_frac_parts <= resize(signed(ki_i), K_INT + K_FRAC) * resize(signed(dt_i), DT_INT + DT_FRAC);
+                        d_mul <= resize(signed(kd_i), K_INT + K_FRAC) * resize(signed(dt_inverse_i), D_DT_SIZE);
+
+                        if use_vel_der_i(0) = '1' then
+                            err_diff <= signed(real_input_i) - signed(prev_position);
+                        else
+                            err_diff <= signed(err_prev) - signed(err_full);
+                        end if;
                         pipeline_counter <= "0001";
 
                     when "0001" =>
-                        ff_mul <= resize(signed(kff_i), K_INT + K_FRAC) * resize(signed(setpoint_i), FF_SETPOINT_SIZE); --Q25+11.7 = Q36.7 = 43 bits
-                        i_mul_err <= resize(signed(err_clipped), ID_ERR_INT) * i_mul_frac_parts; --Q18+11+1.28 = Q30.28
-                        d_mul_err <= resize(signed(err_clipped), ID_ERR_INT) * d_mul; -- Q36+18.7 = Q54.7 = 61 bits
+                        p_mul <= resize(signed(kp_i), K_INT + K_FRAC) * resize(signed(err_full), P_ERR_INT);
+                        i_mul_err <= resize(signed(err_full), ID_ERR_INT) * i_mul_frac_parts;
+                        ff_mul <= resize(signed(kff_i), K_INT + K_FRAC) * resize(signed(setpoint_i), FF_SETPOINT_SIZE);
                         pipeline_counter <= "0010";
 
                     when "0010" =>
-                        p_scaled <= p_mul & (DT_FRAC - K_FRAC - 1 downto 0 => '0'); --Q36.21 = 57 bits
-                        ff_scaled <= ff_mul & (DT_FRAC - K_FRAC - 1 downto 0 => '0'); -- Q36.21 = 57 bits
-                        i_round <= i_mul_err + shift_right(i_mul_err, DT_FRAC - 1); --Q18+11+1.28 = Q30.28
-                        d_scaled <= d_mul_err & (DT_FRAC - K_FRAC - 1 downto 0 => '0'); -- Q54.21 = 75 bits
+                        p_scaled <= p_mul & (DT_FRAC - K_FRAC - 1 downto 0 => '0');
+                        i_scaled_frac <= resize(shift_right(i_mul_err + shift_right(i_mul_err, DT_FRAC - 1), K_FRAC), i_scaled_frac'length);
+                        d_mul_err <= resize(signed(err_diff), P_ERR_INT) * d_mul;
+                        ff_scaled <= ff_mul & (DT_FRAC - K_FRAC - 1 downto 0 => '0');
                         pipeline_counter <= "0011";
 
                     when "0011" =>
-                        i_scaled_frac <= resize(shift_right(i_round, K_FRAC), i_scaled_frac'length); --Q30.21 = 51 bits
-                        pipeline_counter <= "0100";
-
-                    when "0100" =>
                         if (i_scaled + i_scaled_frac) > max_integral_shifted then
                             i_scaled <= max_integral_shifted;
                         elsif (i_scaled + i_scaled_frac) < -max_integral_shifted then
                             i_scaled <= -max_integral_shifted;
                         else
-                            i_scaled <= i_scaled + i_scaled_frac; --Q8+11+1+18.21 = Q38.21 = 59 bits
+                            i_scaled <= i_scaled + i_scaled_frac;
                         end if;
+
+                        d_scaled <= d_mul_err & (DT_FRAC - K_FRAC - 1 downto 0 => '0');
+                        pipeline_counter <= "0100";
+
+                    when "0100" =>
+                        sum_scaled <= resize((p_scaled + i_scaled + d_scaled + ff_scaled), sum_scaled'length);
                         pipeline_counter <= "0101";
 
-                    when "0101" => -- process sum
-                        sum_scaled <= resize((p_scaled + i_scaled + d_scaled + ff_scaled), sum_scaled'length); --Q11+25+18+4.21 = 79 bits
+                    when "0101" =>
+                        sum_integer <= resize(shift_right(sum_scaled + shift_right(sum_scaled, DT_FRAC - 1), DT_FRAC), sum_integer'length);
                         pipeline_counter <= "0110";
 
                     when "0110" =>
-                        sum_rounded <= sum_scaled + shift_right(sum_scaled, DT_FRAC - 1); --Q58.21 = 79 bits
-                        pipeline_counter <= "0111";
-
-                    when "0111" =>
-                        sum_integer <= resize(shift_right(sum_rounded, DT_FRAC), sum_integer'length); --Q58.0 = 58 bits
-                        pipeline_counter <= "1000";
-
-                    when "1000" =>
                         -- Control output clamp
-                        if sum_integer > signed(max_output_i) then
-                            round_out <= resize(signed(max_output_i), round_out'length); --Q32.0
-                        elsif sum_integer < signed(-max_output_i) then
-                            round_out <= resize(signed(-max_output_i), round_out'length); --Q32.0
+                        if sum_integer > resize(signed(max_output_i), sum_integer'length) then
+                            round_out <= resize(signed(max_output_i), round_out'length);
+                        elsif sum_integer < resize(signed(-max_output_i), sum_integer'length) then
+                            round_out <= resize(signed(-max_output_i), round_out'length);
                         else
                             -- Toggle Direction
                             if dir_toggle_i(0) = '1' then
-                                round_out <= resize(-sum_integer, round_out'length); --Q32.0
+                                round_out <= resize(-sum_integer, round_out'length);
                             else
-                                round_out <= resize(sum_integer, round_out'length); --Q32.0
+                                round_out <= resize(sum_integer, round_out'length);
                             end if;
                         end if;
+
+                        -- Update previous error
+                        err_prev <= err_full;
+
+                        -- Update previous position for velocity
+                        prev_position <= real_input_i;
+
                         pipeline_counter <= "0000";
                         enable_pipeline <= '0';
 
@@ -235,15 +259,6 @@ begin
                         enable_pipeline <= '0';
 
                 end case;
-
-            elsif trigger = '1' and (dt_i /= (dt_i'range => '0')) then
-                -- Handle error
-                err_full <= signed(setpoint_i) - signed(real_input_i);
-                prev_error <= err_full;
-
-                -- Return value
-                real_output_o <= std_logic_vector(round_out);
-                enable_pipeline <= '1';
 
             end if; -- Reset + Trigger
 

--- a/modules/pid/pid.block.ini
+++ b/modules/pid/pid.block.ini
@@ -1,0 +1,39 @@
+[.]
+description: A PID to miimic the preformance of the Motion Controller on P99.
+entity: pid
+
+[SLO_CLK]
+type: bit_mux
+description: manual clock
+
+[INIT]
+type: bit_mux
+description: reset switch
+
+[KP_I]
+type: param
+description: proportional constant
+
+[KI_I]
+type: param
+description: integral constant
+
+[KD_I]
+type: param
+description: derivative constant
+
+[FF_I]
+type: param
+description: feed-forward constant
+
+[SETPOINT]
+type: pos_mux
+description: setpoint value for the PID
+
+[IN_SIGNAL]
+type: pos_mux
+description: measured value of the system
+
+[OUT_SIGNAL]
+type: pos_out
+description: value produced by the PID

--- a/modules/pid/pid.block.ini
+++ b/modules/pid/pid.block.ini
@@ -1,43 +1,64 @@
 [.]
-description: A generic PID for control.
+description: A Cascaded PID to control position and velocity.
 entity: pid
 
 [INIT]
 type: bit_mux
-description: reset switch
+description: reset switch.
 
-[TRIG]
-type: bit_mux
-description: position calculation clock rate
+[PID_PERIOD_I]
+type: param int
+description: sets PID output rate as a function of the master clock.
 
 [KP_I]
-type: param int
-description: position proportional constant
+type: param scalar
+scale: 0.0078125
+description: position proportional constant.
 
 [KI_I]
-type: param int
-description: position integral constant
+type: param scalar
+scale: 0.0078125
+description: position integral constant.
 
 [KD_I]
-type: param int
-description: position derivative constant
+type: param scalar
+scale: 0.0078125
+description: position derivative constant.
 
-[FF_I]
-type: param int
-description: position feed-forward constant
+[KFF_I]
+type: param scalar
+scale: 0.0078125
+description: position feedforward constant.
 
 [DIR_TOGGLE_I]
+type: param bit
+description: output sign toggle.
+
+[DT_I]
+type: param scalar
+scale: 0.000000476837158203125
+description: sets dt for the integral term.
+
+[DT_INVERSE_I]
 type: param int
-description: output sign toggle
+description: sets 1/dt for the derivative term.
+
+[MAX_INTEGRAL_I]
+type: param int
+description: a cap on integral growth.
+
+[MAX_OUTPUT_I]
+type: param int
+description: a cap on PID output.
 
 [REAL_INPUT]
 type: pos_mux
-description: process variable input to the position PID
+description: process variable input to the position PID.
 
 [SETPOINT]
 type: pos_mux
-description: setpoint value for the position PID
+description: setpoint value for the position PID.
 
-[POSITION_OUT]
+[REAL_OUTPUT]
 type: pos_out
-description: final value output by the PID
+description: final value output by the PID.

--- a/modules/pid/pid.block.ini
+++ b/modules/pid/pid.block.ini
@@ -2,7 +2,7 @@
 description: A PID to miimic the preformance of the Motion Controller on P99.
 entity: pid
 
-[SLO_CLK]
+[TRIG]
 type: bit_mux
 description: manual clock
 

--- a/modules/pid/pid.block.ini
+++ b/modules/pid/pid.block.ini
@@ -12,27 +12,31 @@ description: sets PID output rate as a function of the master clock.
 
 [KP_I]
 type: param scalar
-scale: 0.0078125
+scale: 0.000000476837158203125
 description: position proportional constant.
 
 [KI_I]
 type: param scalar
-scale: 0.0078125
+scale: 0.000000476837158203125
 description: position integral constant.
 
 [KD_I]
 type: param scalar
-scale: 0.0078125
+scale: 0.000000476837158203125
 description: position derivative constant.
 
 [KFF_I]
 type: param scalar
-scale: 0.0078125
+scale: 0.000000476837158203125
 description: position feedforward constant.
 
 [DIR_TOGGLE_I]
 type: param bit
 description: output sign toggle.
+
+[USE_VEL_DER_I]
+type: param bit
+description: use velocity instead of error in derivative calculation.
 
 [DT_I]
 type: param scalar
@@ -50,6 +54,10 @@ description: a cap on integral growth.
 [MAX_OUTPUT_I]
 type: param int
 description: a cap on PID output.
+
+[MAX_FOLLOWING_ERR_I]
+type: param int
+description: a failsafe against erroneous movement of the stage.
 
 [REAL_INPUT]
 type: pos_mux


### PR DESCRIPTION
Created a PID block for use on PandA devices.

The PID accepts four parameters from input signals, allowing for custom tuning to fit the system. These include: a proportioal term, a derivative term, an integral term and a feed-forward term.

The PID takes a setpoint value and a measured value and returns a correction term for motion.

Currently the PID caps values at the signed limits, which are dynamically calculated from the size of the input/output signals. Whilst this provides flexability, if the values are fixed then this could be simplified to conserve board space.