### PR TITLE
Removed old workaround for make boot

### DIFF
--- a/.github/workflows/_make_boot.yml
+++ b/.github/workflows/_make_boot.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Make boot
         id: make_boot
         run: |
-          echo "boot_files=false" >> $GITHUB_OUTPUT
           cd repos/PandABlocks-fpga
           ln -s CONFIG.example CONFIG
           make boot APP_NAME=${{ matrix.app }}
@@ -43,7 +42,6 @@ jobs:
 
       # Upload artifacts if boot files present
       - name: Upload boot
-        if: ${{ steps.make_boot.outputs.boot_files == 'true'}}
         uses: actions/upload-artifact@v4
         with:
           name: boot-${{ matrix.app }}


### PR DESCRIPTION
A remnant of the original workaround to get make boot working in CI, wasn't removed in #187. Which meant the upload was dependant on a signal that would never go true.