### PR TITLE
axi_lite_slave: fix bvalid could be too early

### DIFF
--- a/common/hdl/axi_lite_slave.vhd
+++ b/common/hdl/axi_lite_slave.vhd
@@ -258,11 +258,7 @@ process (clk_i) begin
                         if vector_and(wstrb_i) then
                             -- Generate write strobe for valid cycle
                             write_strobe_o <= write_strobe;
-                            if write_ack = '1' then
-                                write_state <= WRITE_DONE;
-                            else
-                                write_state <= WRITE_WRITING;
-                            end if;
+                            write_state <= WRITE_WRITING;
                         else
                             -- For invalid write go straight to completion
                             write_state <= WRITE_DONE;


### PR DESCRIPTION
When write_ack is 1 constantly, bvalid is asserted before the transfer is
complete(i.e. not AXI compliant) because of its combinatorial nature, this
change fixes the issue by registering bvalid.

Additionally, axi_lite_slave code style was improved.