### PR TITLE
Remove useless unisim imports that make simulation harder/slower

### DIFF
--- a/common/hdl/bitmux.vhd
+++ b/common/hdl/bitmux.vhd
@@ -15,9 +15,6 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 library work;
 use work.top_defines.all;
 

--- a/common/hdl/delay_filter.vhd
+++ b/common/hdl/delay_filter.vhd
@@ -17,9 +17,6 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.std_logic_unsigned.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 entity delay_filter is
 port (
     -- Clock and reset signals

--- a/common/hdl/posmux.vhd
+++ b/common/hdl/posmux.vhd
@@ -15,9 +15,6 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 library work;
 use work.top_defines.all;
 

--- a/common/hdl/reg_top.vhd
+++ b/common/hdl/reg_top.vhd
@@ -17,9 +17,6 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 library work;
 use work.support.all;
 use work.addr_defines.all;

--- a/common/hdl/serial_engine.vhd
+++ b/common/hdl/serial_engine.vhd
@@ -19,9 +19,6 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 entity serial_engine is
 generic (
     SYS_PERIOD      : natural := 8;     -- Sys clock [ns]

--- a/modules/posenc/hdl/posenc.vhd
+++ b/modules/posenc/hdl/posenc.vhd
@@ -2,9 +2,6 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library unisim;
-use unisim.vcomponents.all;
-
 entity posenc is
 port (
     -- Clock and Reset


### PR DESCRIPTION
This change removes  a bunch of unisim import that aren't needed.