### PR TITLE
EnDat encoder module added

### DIFF
--- a/common/hdl/encoders/encoders.vhd
+++ b/common/hdl/encoders/encoders.vhd
@@ -105,6 +105,19 @@ signal health_biss_sniffer  : std_logic_vector(31 downto 0);
 signal linkup_biss_master   : std_logic;
 signal health_biss_master   : std_logic_vector(31 downto 0);
 
+-- EnDat
+signal edat                 : std_logic;
+signal posn_endat           : std_logic_vector(31 downto 0);
+signal posn_endat_sniffer   : std_logic_vector(31 downto 0);
+signal linkup_endat_sniffer : std_logic;
+signal health_endat_sniffer : std_logic_vector(31 downto 0);
+signal linkup_endat_master  : std_logic;
+signal health_endat_master  : std_logic_vector(31 downto 0);
+signal clk_out_encoder_endat : std_logic;
+signal health_endat_slave    : std_logic_vector(31 downto 0);
+
+
+
 signal inenc_dir            : std_logic;
 signal outenc_dir           : std_logic;
 signal inenc_ctrl           : std_logic_vector(2 downto 0);
@@ -135,6 +148,8 @@ signal OUTENC_PROTOCOL      : std_logic_vector(2 downto 0);
 signal OUTENC_PROTOCOL_rb   : std_logic_vector(2 downto 0);
 signal INENC_PROTOCOL_rb    : std_logic_vector(2 downto 0);
 
+
+
 begin
 
 -- Unused Nets.
@@ -155,8 +170,15 @@ OUTENC_PROTOCOL <=
 A_OUT <= a_ext_i when (OUTENC_PROTOCOL = c_ABZ_PASSTHROUGH) else quad_a;
 B_OUT <= b_ext_i when (OUTENC_PROTOCOL = c_ABZ_PASSTHROUGH) else quad_b;
 Z_OUT <= z_ext_i when (OUTENC_PROTOCOL = c_ABZ_PASSTHROUGH) else '0';
-DATA_OUT <= data_ext_i when (OUTENC_PROTOCOL = c_DATA_PASSTHROUGH) else 
-            bdat when (OUTENC_PROTOCOL = c_BISS) else sdat;
+
+--DATA_OUT <= data_ext_i when (OUTENC_PROTOCOL = c_DATA_PASSTHROUGH) else 
+--            bdat when (OUTENC_PROTOCOL = c_BISS) else sdat;
+
+DATA_OUT <= data_ext_i when (OUTENC_PROTOCOL = c_DATA_PASSTHROUGH) else
+            bdat        when (OUTENC_PROTOCOL = c_BISS) else
+            edat        when (OUTENC_PROTOCOL = c_enDat) else
+            sdat;
+
 
 --
 -- INCREMENTAL OUT
@@ -205,6 +227,34 @@ port map (
     biss_dat_o        => bdat
 );
 
+
+-- ENDAT SLAVE
+endat_slave_inst : entity work.endat_slave
+    generic map (
+        MAX_DATA_WIDTH      => 32,
+        SYS_CLOCK_FREQ_MHz  => 125,
+        STOP_TIME_uS        => 2,
+        TIMEOUT_mS          => 10,
+        ENDAT_S_SCLKDLY_CNT => 4
+    )
+    port map (
+        clk_i          => clk_i,
+        reset_i        => reset_i,
+        ENCODING       => "00",
+        BITS           => OUTENC_BITS_i,
+        enable_i       => enable_i,
+        GENERATOR_ERROR=> GENERATOR_ERROR_i,
+        health_o       => health_endat_slave,
+        posn_i         => posn_i,
+        endat_clk_i    => CLK_IN,
+        endat_data_i   => DATA_IN,
+        endat_data_o   => edat,
+        endat_wr_nrd_o => open
+    );
+
+
+
+
 --------------------------------------------------------------------------
 -- Position Data and STATUS readback multiplexer
 --
@@ -229,7 +279,7 @@ begin
                 when "010"  =>              -- BISS & Loopback
                     OUTENC_HEALTH_o <= health_biss_slave;
                 when c_enDat =>             -- enDat 
-                    OUTENC_HEALTH_o <= std_logic_vector(to_unsigned(2,32)); --ENDAT not implemented
+                    OUTENC_HEALTH_o <= health_endat_slave; --std_logic_vector(to_unsigned(2,32)); --ENDAT not implemented
                 when others =>
                     OUTENC_HEALTH_o <= (others=>'0');
             end case;
@@ -267,11 +317,14 @@ begin
 end process ps_select;
 
 -- Loopbacks
+--CLK_OUT <=    clk_out_ext_i when (CLK_SRC_i = '1') else
+--              clk_out_encoder_biss when (CLK_SRC_i = '0' and INENC_PROTOCOL_i = "010") else
+--              clk_out_encoder_ssi;
+
 CLK_OUT <=    clk_out_ext_i when (CLK_SRC_i = '1') else
-              clk_out_encoder_biss when (CLK_SRC_i = '0' and INENC_PROTOCOL_i = "010") else
+              clk_out_encoder_biss  when (CLK_SRC_i = '0' and INENC_PROTOCOL_i = "010") else
+              clk_out_encoder_endat when (CLK_SRC_i = '0' and INENC_PROTOCOL_i = "011") else
               clk_out_encoder_ssi;
-
-
 
 --------------------------------------------------------------------------
 -- Incremental Encoder Instantiation :
@@ -375,6 +428,67 @@ port map (
     posn_o          => posn_biss_sniffer
 );
 
+
+--------------------------------------------------------------------------
+-- EnDat2 Instantiations
+--------------------------------------------------------------------------
+
+endat_master_inst : entity work.endat2_master
+    generic map (
+        g_rx_falling_edge => 1
+    )
+    port map (
+        clk_i          => clk_i,
+        reset_i        => reset_i,
+
+        BITS           => INENC_BITS_i,
+        CLK_PERIOD_i   => CLK_PERIOD_i,
+        FRAME_PERIOD_i => FRAME_PERIOD_i,
+
+        link_up_o      => linkup_endat_master,
+        health_o       => health_endat_master,
+        posn_o         => posn_endat,
+        posn_valid_o   => open,
+
+        cmd_o          => open,
+        cmd_valid_o    => open,
+
+        endat_sck_o    => clk_out_encoder_endat,
+        endat_dat_i    => DATA_IN,
+        endat_dat_o    => open      -- ???
+    );
+
+
+
+endat2_sniffer_inst : entity work.endat2_sniffer
+    generic map (
+        G_ENDAT2_2     => 0
+    )
+    port map (
+        clk_i          => clk_i,
+        reset_i        => reset_i,
+        ENCODING       => INENC_ENCODING_i,
+        BITS           => INENC_BITS_i,
+        link_up_o      => linkup_endat_sniffer,
+        health_o       => health_endat_sniffer,
+        error_o        => open,
+        endat_sck_i    => CLK_IN,
+        endat_dat_i    => DATA_IN,
+        posn_o         => posn_endat_sniffer,
+        -- Debugging ports
+        crc_rx_o       => open,
+        crc_calc_o     => open,
+        error_count_o  => open,
+        posn_valid_o   => open,
+        frame_ok_o     => open,
+        sample_count_o => open
+    );
+
+
+
+
+
+
 --------------------------------------------------------------------------
 -- Position Data and STATUS readback multiplexer
 --
@@ -423,6 +537,21 @@ begin
                     end if;
                     HOMED_o <= TO_SVECTOR(1,32);
 
+                -- EnDat2 test
+                when "011"  =>              -- ENDAT & Loopback
+                    if (DCARD_MODE_i(3 downto 1) = DCARD_MONITOR) then
+                        posn           <= posn_endat_sniffer;
+                        STATUS_o(0)    <= linkup_endat_sniffer;
+                        INENC_HEALTH_o <= health_endat_sniffer;
+                    else
+                        posn           <= posn_endat;
+                        STATUS_o(0)    <= linkup_endat_master;
+                        INENC_HEALTH_o <= health_endat_master;
+                    end if;
+                    HOMED_o <= TO_SVECTOR(1,32);
+                --
+
+
                 when others =>
                     INENC_HEALTH_o <= TO_SVECTOR(5,32);
                     posn <= (others => '0');
@@ -432,6 +561,9 @@ begin
         end if;
     end if;
 end process;
+
+
+
 
 -------------------dcard_interface----------------------------------------------
 --------------------------------------------------------------------------------

--- a/common/hdl/encoders/endat2_master.vhd
+++ b/common/hdl/encoders/endat2_master.vhd
@@ -1,0 +1,546 @@
+
+
+-- Test with endat_slave and endat2_sniffer.
+-- Generate 46 clocks
+--    C_CMD_BITS (10) + C_TURN_BITS (4) + START(1) + F1(1) + POSITION(25) + C_CRC_BITS (5)
+--
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity endat2_master is
+  generic (
+    g_rx_falling_edge : integer := 1  -- 1: sample RX on SCK falling edge (default), 0: rising edge
+  );
+  port (
+    clk_i          : in  std_logic;
+    reset_i        : in  std_logic;
+
+    -- Configuration
+    BITS           : in  std_logic_vector(7 downto 0);   -- position bits (typically 25)
+    CLK_PERIOD_i   : in  std_logic_vector(31 downto 0);  -- SCK half-period control
+    FRAME_PERIOD_i : in  std_logic_vector(31 downto 0);  -- frame rate divider
+
+    -- Status / data
+    link_up_o      : out std_logic;
+    health_o       : out std_logic_vector(31 downto 0);
+    posn_o         : out std_logic_vector(31 downto 0);
+    posn_valid_o   : out std_logic;
+
+    -- Debug: commanded word as actually driven on the bus
+    cmd_o          : out std_logic_vector(9 downto 0);
+    cmd_valid_o    : out std_logic;
+
+    -- Physical EnDat interface
+    endat_sck_o    : out std_logic;
+    endat_dat_i    : in  std_logic;
+    endat_dat_o    : out std_logic
+  );
+end endat2_master;
+
+architecture rtl of endat2_master is
+
+
+  -----------------------------------------------------------------------------
+  -- Constants
+  -----------------------------------------------------------------------------
+  constant C_CMD_BITS  : integer := 10;
+  constant C_TURN_BITS : integer := 4;
+  constant C_CRC_BITS  : integer := 5;
+
+  -- Required EnDat command (placeholder used in your previous version)
+  constant C_MODE_COMMAND : std_logic_vector(9 downto 0) := "0000011100";
+
+  -----------------------------------------------------------------------------
+  -- Frame trigger + clock generator
+  -----------------------------------------------------------------------------
+  signal frame_cnt_r     : unsigned(31 downto 0) := (others => '0');
+  signal frame_start_p   : std_logic := '0';
+
+  signal n_clks_r        : std_logic_vector(7 downto 0) := (others => '0');
+
+  signal clkgen_active   : std_logic := '0';
+  signal clkgen_busy     : std_logic := '0';
+  signal endat_sck_r     : std_logic := '1';
+
+  -----------------------------------------------------------------------------
+  -- SCK edge detect
+  -----------------------------------------------------------------------------
+  signal endat_sck_d1    : std_logic := '1';
+  signal sck_rise        : std_logic := '0';
+  signal sck_fall        : std_logic := '0';
+
+  -----------------------------------------------------------------------------
+  -- Bit index counter (counts SCK rising edges)
+  -----------------------------------------------------------------------------
+  signal bit_idx_r       : unsigned(7 downto 0) := (others => '0');
+
+  -----------------------------------------------------------------------------
+  -- Timeout support
+  -----------------------------------------------------------------------------
+  -- Count actual SCK rising edges observed during the frame.
+  signal sck_rise_cnt_r  : unsigned(7 downto 0) := (others => '0');
+
+  -- Timeout flags:
+  --  - sck_cnt_err_r: wrong number of SCKs in frame (generated vs expected)
+  --  - start_timeout_r: START bit not observed within 20 SCK bit-times after CMD
+  signal sck_cnt_err_r   : std_logic := '0';
+  signal start_seen_r    : std_logic := '0';
+  signal start_timeout_r : std_logic := '0';
+
+  -----------------------------------------------------------------------------
+  -- Command capture (debug)
+  -----------------------------------------------------------------------------
+  signal cmd_tx_r       : std_logic_vector(9 downto 0) := (others => '0');
+  signal cmd_reg_r      : std_logic_vector(9 downto 0) := (others => '0');
+  signal cmd_valid_r    : std_logic := '0';
+
+  -----------------------------------------------------------------------------
+  -- Captured fields
+  -----------------------------------------------------------------------------
+  signal s_bit_r         : std_logic := '0';
+  signal f1_bit_r        : std_logic := '0';
+
+  signal posn_r          : std_logic_vector(31 downto 0) := (others => '0');
+  signal rx_crc_r        : std_logic_vector(4 downto 0)  := (others => '0');
+  signal calc_crc_r      : std_logic_vector(4 downto 0)  := (others => '0');
+  signal crc_err_r       : std_logic := '0';
+
+  signal posn_valid_r    : std_logic := '0';
+  signal link_up_r       : std_logic := '0';
+  signal frame_done_r    : std_logic := '0';
+
+  -----------------------------------------------------------------------------
+  -- CRC FFs (same structure as endat_slave.vhd)
+  -----------------------------------------------------------------------------
+  signal FF0             : std_logic := '1';
+  signal FF1             : std_logic := '1';
+  signal FF2             : std_logic := '1';
+  signal FF3             : std_logic := '1';
+  signal FF4             : std_logic := '1';
+  signal S_en            : std_logic := '0';
+
+  signal bits_i_r        : integer range 0 to 255 := 25;
+  signal rx_fall_en_r    : std_logic := '1';
+
+  ----------------------------------------------------------------------------
+  -- Vivado ILA Debug Attributes
+  ----------------------------------------------------------------------------
+  attribute mark_debug : string;
+
+  attribute mark_debug of frame_cnt_r      : signal is "true";
+  attribute mark_debug of bit_idx_r        : signal is "true";
+  attribute mark_debug of sck_rise_cnt_r   : signal is "true";
+  attribute mark_debug of sck_cnt_err_r    : signal is "true";
+  attribute mark_debug of start_timeout_r  : signal is "true";
+  attribute mark_debug of start_seen_r     : signal is "true";
+  attribute mark_debug of rx_crc_r         : signal is "true";
+  attribute mark_debug of calc_crc_r       : signal is "true";
+  attribute mark_debug of crc_err_r        : signal is "true";
+  attribute mark_debug of cmd_reg_r        : signal is "true";
+  attribute mark_debug of cmd_valid_r      : signal is "true";
+
+begin
+
+  endat_sck_o  <= endat_sck_r;
+  posn_o       <= posn_r;
+  posn_valid_o <= posn_valid_r;
+  link_up_o    <= link_up_r;
+
+  cmd_o        <= cmd_reg_r;
+  cmd_valid_o  <= cmd_valid_r;
+
+  -----------------------------------------------------------------------------
+  -- Frame start trigger (simple counter)
+  -----------------------------------------------------------------------------
+  p_frame_trig : process(clk_i)
+    variable frame_period_u : unsigned(31 downto 0);
+  begin
+    if rising_edge(clk_i) then
+      if reset_i = '1' then
+        frame_cnt_r   <= (others => '0');
+        frame_start_p <= '0';
+      else
+        frame_start_p <= '0';
+        frame_period_u := unsigned(FRAME_PERIOD_i);
+
+        if frame_period_u = 0 then
+          frame_start_p <= '1';
+        else
+          if frame_cnt_r = frame_period_u then
+            frame_cnt_r   <= (others => '0');
+            frame_start_p <= '1';
+          else
+            frame_cnt_r <= frame_cnt_r + 1;
+          end if;
+        end if;
+      end if;
+    end if;
+  end process;
+
+  -----------------------------------------------------------------------------
+  -- Compute N (total clocks - 1) at each frame start
+  -----------------------------------------------------------------------------
+  p_frame_len : process(clk_i)
+    variable total_clks : integer;
+    variable bits_i     : integer;
+  begin
+    if rising_edge(clk_i) then
+      if reset_i = '1' then
+        n_clks_r     <= (others => '0');
+        bits_i_r     <= 25;
+        rx_fall_en_r <= '1';
+      else
+        if frame_start_p = '1' then
+          bits_i := to_integer(unsigned(BITS));
+          if bits_i < 1 then
+            bits_i := 1;
+          elsif bits_i > 32 then
+            bits_i := 32;
+          end if;
+          bits_i_r <= bits_i;
+
+          if g_rx_falling_edge /= 0 then
+            rx_fall_en_r <= '1';
+          else
+            rx_fall_en_r <= '0';
+          end if;
+
+          -- +1 dummy STOP clock to ensure last CRC bit is never truncated
+          total_clks := C_CMD_BITS + C_TURN_BITS + 1 + 1 + bits_i + C_CRC_BITS + 1;
+          n_clks_r <= std_logic_vector(to_unsigned(total_clks - 1, 8));
+        end if;
+      end if;
+    end if;
+  end process;
+
+  -----------------------------------------------------------------------------
+  -- Clock generator instance
+  -----------------------------------------------------------------------------
+  u_clkgen : entity work.endat_clock_gen
+  generic map (
+    DEAD_PERIOD     => (20000/8)   
+            )
+  port map (
+      clk_i         => clk_i,
+      reset_i       => reset_i,
+      N             => n_clks_r,
+      CLK_PERIOD    => CLK_PERIOD_i,
+      start_i       => frame_start_p,
+      enable_cnt_i  => '1',
+      clock_pulse_o => endat_sck_r,
+      active_o      => clkgen_active,
+      busy_o        => clkgen_busy
+    );
+
+  -----------------------------------------------------------------------------
+  -- Edge detect on generated SCK
+  -----------------------------------------------------------------------------
+  p_sck_edge : process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      if reset_i = '1' then
+        endat_sck_d1 <= '1';
+        sck_rise     <= '0';
+        sck_fall     <= '0';
+      else
+        endat_sck_d1 <= endat_sck_r;
+        sck_rise     <= (not endat_sck_d1) and endat_sck_r;
+        sck_fall     <= endat_sck_d1 and (not endat_sck_r);
+      end if;
+    end if;
+  end process;
+
+  -----------------------------------------------------------------------------
+  -- Main TX/RX
+  -----------------------------------------------------------------------------
+  p_txrx : process(clk_i)
+    -- indices counted in "bit time" units (based on SCK rising edge count)
+    variable sample_idx     : integer;
+    variable base_start_idx : integer;
+    variable recv_start_idx : integer;
+    variable pos_start_idx  : integer;
+    variable crc_start_idx  : integer;
+    variable bits_i         : integer;
+
+    variable crc_count      : integer;
+    variable exp_crc_bit    : std_logic;
+
+    -- CRC intermediate (same as endat_slave.vhd)
+    variable cs1_v          : std_logic;
+    variable cs2_v          : std_logic;
+
+    variable rx_bit         : std_logic;
+
+    variable expected_rises : unsigned(7 downto 0);
+  begin
+    if rising_edge(clk_i) then
+      if reset_i = '1' then
+        bit_idx_r       <= (others => '0');
+        sck_rise_cnt_r  <= (others => '0');
+
+        sck_cnt_err_r   <= '0';
+        start_seen_r    <= '0';
+        start_timeout_r <= '0';
+
+        endat_dat_o     <= '1';
+
+        posn_r          <= (others => '0');
+        rx_crc_r        <= (others => '0');
+        calc_crc_r      <= (others => '0');
+        crc_err_r       <= '0';
+
+        s_bit_r         <= '0';
+        f1_bit_r        <= '0';
+
+        posn_valid_r    <= '0';
+        link_up_r       <= '0';
+        frame_done_r    <= '0';
+
+        cmd_tx_r        <= (others => '0');
+        cmd_reg_r       <= (others => '0');
+        cmd_valid_r     <= '0';
+
+        FF0             <= '1';
+        FF1             <= '1';
+        FF2             <= '1';
+        FF3             <= '1';
+        FF4             <= '1';
+        S_en            <= '0';
+
+      else
+        posn_valid_r <= '0';
+
+        -- Preset per new frame
+        if frame_start_p = '1' then
+          bit_idx_r       <= (others => '0');
+          sck_rise_cnt_r  <= (others => '0');
+
+          sck_cnt_err_r   <= '0';
+          start_seen_r    <= '0';
+          start_timeout_r <= '0';
+
+          -- Present first CMD bit (updated again on first SCK falling edge)
+          endat_dat_o     <= C_MODE_COMMAND(9);
+
+          posn_r          <= (others => '0');
+          rx_crc_r        <= (others => '0');
+          calc_crc_r      <= (others => '0');
+          crc_err_r       <= '0';
+
+          s_bit_r         <= '0';
+          f1_bit_r        <= '0';
+
+          frame_done_r    <= '0';
+
+          cmd_tx_r        <= (others => '0');
+          cmd_valid_r     <= '0';
+
+          -- CRC init (seed again at START bit)
+          FF0             <= '1';
+          FF1             <= '1';
+          FF2             <= '1';
+          FF3             <= '1';
+          FF4             <= '1';
+          S_en            <= '0';
+        end if;
+
+        -----------------------------------------------------------------------
+        -- TX: update output on SCK falling edges (stable for next rising edge)
+        -----------------------------------------------------------------------
+        if (clkgen_active = '1') and (sck_fall = '1') then
+          if to_integer(bit_idx_r) < C_CMD_BITS then
+            -- Drive CMD bit (MSB-first) and capture it into a debug register.
+            endat_dat_o <= C_MODE_COMMAND(9 - to_integer(bit_idx_r));
+            cmd_tx_r(9 - to_integer(bit_idx_r)) <= C_MODE_COMMAND(9 - to_integer(bit_idx_r));
+
+            -- When the last CMD bit has just been driven, latch the full word.
+            if to_integer(bit_idx_r) = (C_CMD_BITS - 1) then
+              cmd_reg_r    <= cmd_tx_r;
+              cmd_reg_r(0) <= C_MODE_COMMAND(0);  -- ensure last-assigned bit is included in same cycle
+              cmd_valid_r  <= '1';
+            end if;
+          else
+            -- Release line (high) after CMD
+            endat_dat_o <= '1';
+          end if;
+        end if;
+
+        -----------------------------------------------------------------------
+        -- Advance bit index + count actual SCK rising edges
+        -----------------------------------------------------------------------
+        if (clkgen_active = '1') and (sck_rise = '1') then
+          bit_idx_r      <= bit_idx_r + 1;
+          sck_rise_cnt_r <= sck_rise_cnt_r + 1;
+        end if;
+
+        -----------------------------------------------------------------------
+        -- RX sampling + START timeout check
+        -----------------------------------------------------------------------
+        if (clkgen_active = '1') then
+          if (rx_fall_en_r = '1' and sck_fall = '1') or (rx_fall_en_r = '0' and sck_rise = '1') then
+
+            bits_i := bits_i_r;
+
+            -- Base START index in "rising-edge bit times" is CMD+TURN (=14).
+            base_start_idx := C_CMD_BITS + C_TURN_BITS;
+
+            if rx_fall_en_r = '1' then
+              -- Falling samples after the rising edge, so use current bit_idx_r
+              sample_idx := to_integer(bit_idx_r);
+
+              -- Shift all phase indices by +1 for FALL sampling
+              recv_start_idx := base_start_idx + 1;   -- START(S)
+            else
+              sample_idx := to_integer(bit_idx_r);
+              recv_start_idx := base_start_idx;       -- START(S)
+            end if;
+
+            pos_start_idx := recv_start_idx + 1 + 1;  -- S + F1 (F2 bypass)
+            crc_start_idx := pos_start_idx + bits_i;  -- after position bits
+
+            rx_bit := endat_dat_i;
+
+            -------------------------------------------------------------------
+            -- Timeout #2: After CMD, if START is not observed within 20 SCKs,
+            -- flag timeout.
+            --
+            -- Definition used here:
+            --   "After sending CMD" -> after CMD(10) bits are done.
+            -- The check is performed in sample_idx (bit-time index).
+            -------------------------------------------------------------------
+            if (start_seen_r = '0') then
+              if sample_idx >= (C_CMD_BITS + 20) then
+                start_timeout_r <= '1';
+              end if;
+            end if;
+
+            -- START bit: seed CRC FFs and enable accumulation
+            if sample_idx = recv_start_idx then
+              s_bit_r <= rx_bit;
+
+              -- START must be '1' for a valid reply
+              if rx_bit = '1' then
+                start_seen_r <= '1';
+              end if;
+
+              FF0  <= '1';
+              FF1  <= '1';
+              FF2  <= '1';
+              FF3  <= '1';
+              FF4  <= '1';
+              S_en <= '1';
+
+            -- F1 bit (included in CRC)
+            elsif sample_idx = (recv_start_idx + 1) then
+              f1_bit_r <= rx_bit;
+
+              cs1_v := (FF4 and S_en) xor (rx_bit and S_en);
+              cs2_v := cs1_v and S_en;
+              FF0 <= cs1_v;
+              FF1 <= FF0 xor cs2_v;
+              FF2 <= FF1;
+              FF3 <= FF2 xor cs2_v;
+              FF4 <= FF3;
+
+            -- Position bits (LSB-first into posn_r, included in CRC)
+            elsif (sample_idx >= pos_start_idx) and (sample_idx < (pos_start_idx + bits_i)) then
+              posn_r(sample_idx - pos_start_idx) <= rx_bit;
+
+              cs1_v := (FF4 and S_en) xor (rx_bit and S_en);
+              cs2_v := cs1_v and S_en;
+              FF0 <= cs1_v;
+              FF1 <= FF0 xor cs2_v;
+              FF2 <= FF1;
+              FF3 <= FF2 xor cs2_v;
+              FF4 <= FF3;
+
+              -- When last position bit captured, drop S_en for CRC serialization
+              if sample_idx = (pos_start_idx + bits_i - 1) then
+                S_en <= '0';
+              end if;
+
+            -- CRC bits: compare to expected (not FF4), store both for monitoring
+            elsif (sample_idx >= crc_start_idx) and (sample_idx < (crc_start_idx + C_CRC_BITS)) then
+              crc_count   := sample_idx - crc_start_idx; -- 0..4
+              exp_crc_bit := not FF4;
+
+              -- Store MSB-first (first CRC bit goes to bit[4])
+              rx_crc_r(4 - crc_count)   <= rx_bit;
+              calc_crc_r(4 - crc_count) <= exp_crc_bit;
+
+              if rx_bit /= exp_crc_bit then
+                crc_err_r <= '1';
+              end if;
+
+              -- Advance FFs like slave ENDAT_CRC (S_en=0 => shift zeros)
+              cs1_v := (FF4 and S_en) xor (rx_bit and S_en);
+              cs2_v := cs1_v and S_en;
+              FF0 <= cs1_v;
+              FF1 <= FF0 xor cs2_v;
+              FF2 <= FF1;
+              FF3 <= FF2 xor cs2_v;
+              FF4 <= FF3;
+
+            else
+              null;
+            end if;
+
+          end if;
+        end if;
+
+        -----------------------------------------------------------------------
+        -- Frame end detect + timeout checks
+        -----------------------------------------------------------------------
+        if (clkgen_active = '0') and (clkgen_busy = '1') then
+          if frame_done_r = '0' then
+            frame_done_r <= '1';
+
+            -- Expected rising edges == generated clocks == N+1
+            expected_rises := unsigned(n_clks_r) + 1;
+
+            if (sck_rise_cnt_r /= expected_rises) or (start_timeout_r = '1') then
+              sck_cnt_err_r <= '1';
+              link_up_r     <= '0';
+              -- posn_valid_r stays '0' on timeout
+            else
+              sck_cnt_err_r <= '0';
+              posn_valid_r  <= '1';
+              link_up_r     <= '1';
+            end if;
+          end if;
+        end if;
+
+        if clkgen_busy = '0' then
+          frame_done_r <= '0';
+        end if;
+
+      end if;
+    end if;
+  end process;
+
+  -----------------------------------------------------------------------------
+  -- Health output (status code)
+  -----------------------------------------------------------------------------
+  p_health : process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      if reset_i = '1' then
+        health_o <= (others => '0');
+      else
+        -- Priority: timeout(1) > protocol(4) > OK(0)
+        if (sck_cnt_err_r = '1') or (start_timeout_r = '1') then
+          health_o <= std_logic_vector(to_unsigned(1, 32));
+        elsif crc_err_r = '1' then
+          health_o <= std_logic_vector(to_unsigned(4, 32));
+        else
+          health_o <= std_logic_vector(to_unsigned(0, 32));
+        end if;
+      end if;
+    end if;
+  end process;
+
+end rtl;
+

--- a/common/hdl/encoders/endat2_sniffer.vhd
+++ b/common/hdl/encoders/endat2_sniffer.vhd
@@ -1,0 +1,871 @@
+
+-- Test model: 
+-- HEIDENHAIN ECN 425 2048
+--   EnDat22
+--   Singleturn 25bit(33,554,432 pos/rev
+--   F2 error 2 (only with EnDat 2.2 commands)
+--
+--
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- endat2_sniffer.vhd
+--
+-- EnDat sniffer (position + CRC) for streams like:
+--   CMD(10) -> START(1) -> F1(1) -> DATA(N bits, typically 25, LSB-first) -> CRC(5)
+--
+-- CRC is computed AFTER capturing the position word, using external module:
+--   work.endat_crc5_vec
+--
+-- CRC is computed over DATA bits only (START/F1/F2 excluded).
+--
+-- CMD sampling mitigation:
+-- - CMD advances on sck_edge_cmd (optionally forced to rising edge)
+-- - CMD data is snapshotted at sck_edge_cmd into dat_edge_cmd_r (with dat_ff1==dat_ff2 guard)
+--
+-- Monitoring:
+-- - cmd_o/cmd_valid_o: latched when posn_valid_r is asserted (frame commit point)
+-- - posn_o: position output (after encoding conversion)
+-- - crc_rx_o: received CRC bits from stream
+-- - crc_calc_o: calculated CRC from position bits
+
+
+entity endat2_sniffer is
+  generic (
+    G_ENDAT2_2        : natural   := 0;
+    DATA_INVERT       : std_logic := '0';
+    SAMPLE_FALL       : std_logic := '1';   -- use 1 for ECN 425 2048
+    IDLE_GAP_CLKS     : natural   := 200;
+    CRC_BYPASS        : natural   := 0;
+    FRAME_STALE_CLKS  : natural    := 0;
+    -- 1 = normal (F1+F2), 0 = bypass F2 (only F1 present in stream)
+    F2_PRESENT        : natural := 0; -- Only EnDat 2.2 commands
+    -- 1 = check command == C_CMD_POS, 0 = bypass command compare (accept any command)
+    CMD_CHECK_EN      : natural := 0;
+    -- 1 = sample CMD(10) on SCK rising edge regardless of SAMPLE_FALL,
+    -- 0 = CMD uses the same selected edge as the rest of the frame.
+    CMD_BRISING_EDGE  : natural := 1;
+    -- CRC bit order when computing CRC from captured position bits:
+    -- 0 = LSB-first (data bit0 -> bitN-1), 1 = MSB-first (bitN-1 -> bit0)
+    CRC_MSB_FIRST     : natural := 0
+  );
+  port (
+    clk_i          : in  std_logic;
+    reset_i        : in  std_logic;
+
+    -- Configuration interface
+    ENCODING       : in  std_logic_vector(1 downto 0);  -- 0 Unsigned Binary, 1 Unsigned Gray, 2 Signed Binary, 3 Signed Gray
+    BITS           : in  std_logic_vector(7 downto 0);  -- Position bits (1..32)
+
+    link_up_o      : out std_logic;
+    health_o       : out std_logic_vector(31 downto 0);
+    error_o        : out std_logic;
+
+    -- Physical ENDat interface
+    endat_sck_i    : in  std_logic;
+    endat_dat_i    : in  std_logic;
+
+    -- Block outputs
+    posn_o         : out std_logic_vector(31 downto 0);
+
+    --
+    -- Debug outputs : Not needed for the Panda block interface
+    -- external monitoring of CMD latched at posn_valid
+    cmd_o          : out std_logic_vector(9 downto 0);
+    cmd_valid_o    : out std_logic;    
+    crc_rx_o       : out std_logic_vector(4 downto 0);   -- CRC received from encoder
+    crc_calc_o     : out std_logic_vector(4 downto 0);   -- CRC calculation result
+    error_count_o  : out std_logic_vector(31 downto 0);  -- CRC error counts
+    posn_valid_o   : out std_logic;                      -- 1clk pulse when posn_o updated
+    frame_ok_o     : out std_logic;                      -- same as posn_valid_o
+    sample_count_o : out std_logic_vector(31 downto 0)   -- increments on each posn_valid_o
+  );
+end entity;
+
+
+architecture rtl of endat2_sniffer is
+
+  constant C_MODE_BITS : natural := 10;
+  constant C_CRC_BITS  : natural := 5;
+  constant C_SEEK_START_TIMEOUT : natural := 255;
+
+  -- Position read command (10-bit)
+  constant C_CMD_POS : std_logic_vector(9 downto 0) := "0000011100"; -- 0x1C
+
+  type t_state is (
+    ST_SYNC,
+    ST_CMD,
+    ST_SEEK_START,
+    ST_F1,
+    ST_F2,
+    ST_POS,
+    ST_CRC_RX,
+    ST_CRC_CALC
+  );
+
+  signal st, st_n : t_state := ST_SYNC;
+
+  -- Synchronize SCK/DAT into clk_i domain
+  signal sck_ff1, sck_ff2 : std_logic := '0';
+  signal dat_ff1, dat_ff2 : std_logic := '0';
+  signal sck_edge_any     : std_logic := '0';
+
+  -- Selected edges:
+  signal sck_edge_gen     : std_logic := '0';  -- general edge (SAMPLE_FALL based)
+  signal sck_edge_cmd     : std_logic := '0';  -- CMD edge (optional rising-only)
+
+  -- DATA snapshot at selected SCK edge
+  signal dat_edge_r       : std_logic := '0';
+
+  -- CMD DATA snapshot at CMD edge
+  signal dat_edge_cmd_r   : std_logic := '0';
+
+  -- Idle gap timer (clk_i domain)
+  signal idle_cnt, idle_cnt_n : unsigned(15 downto 0) := (others => '0');
+  signal gap_seen, gap_seen_n : std_logic := '0';
+
+  -- Counters
+  signal cmd_idx,  cmd_idx_n  : unsigned(3 downto 0) := (others => '0');
+  signal pos_idx,  pos_idx_n  : unsigned(7 downto 0) := (others => '0');
+  signal crc_rx_idx, crc_rx_idx_n : unsigned(2 downto 0) := (others => '0');
+  signal seek_cnt, seek_cnt_n : unsigned(7 downto 0) := (others => '0');
+
+  -- Total SCK selected-edge count per frame (8-bit)
+  signal sclk_cnt, sclk_cnt_n : unsigned(7 downto 0) := (others => '0');
+
+  -- 32-bit error counter (counts failed frames/events; latched => max +1 per frame)
+  signal error_count, error_count_n : unsigned(31 downto 0) := (others => '0');
+
+  -- Latch to ensure one increment per frame
+  signal frame_error_lat, frame_error_lat_n : std_logic := '0';
+
+  -- Flyscan sample counter
+  signal sample_count, sample_count_n : unsigned(31 downto 0) := (others => '0');
+
+  -- 1clk pulse when we commit a good frame (position updated)
+  signal posn_valid_r, posn_valid_r_n : std_logic := '0';
+
+  -- Age counter since last successful commit (clk_i cycles)
+  signal frame_age_cnt, frame_age_cnt_n : unsigned(31 downto 0) := (others => '0');
+
+  -- Config bits clamped to 1..32
+  signal bits_u    : unsigned(7 downto 0);
+  signal bits_clip : unsigned(7 downto 0);
+
+  -- Captured fields
+  signal cmd_r, cmd_r_n       : std_logic_vector(C_MODE_BITS-1 downto 0) := (others => '0');
+
+  -- pos_work is filled LSB-first from the serial stream: pos_work(0) is first received data bit.
+  signal pos_work, pos_work_n : std_logic_vector(31 downto 0) := (others => '0');
+  signal pos_out,  pos_out_n  : std_logic_vector(31 downto 0) := (others => '0');
+
+  -- Received CRC bits (captured from serial stream, MSB-first within the 5-bit field)
+  signal rx_crc_r, rx_crc_r_n : std_logic_vector(4 downto 0) := (others => '0');
+
+  -- CRC module handshake
+  signal crc_start_r, crc_start_r_n : std_logic := '0';
+  signal crc_busy    : std_logic := '0';
+  signal crc_done    : std_logic := '0';
+  signal crc_calc    : std_logic_vector(4 downto 0) := (others => '0');
+  signal crc_msb_first_s : std_logic := '0';
+
+  -- Debug mirror
+  signal cmd_data : std_logic_vector(9 downto 0) := (others => '0');
+
+  -- Status
+  signal link_up_r, link_up_r_n : std_logic := '0';
+  signal err_r, err_r_n         : std_logic := '0';
+
+  -- Health sticky bits (cleared at frame start)
+  signal f1_r, f1_r_n                   : std_logic := '0';
+  signal f2_r, f2_r_n                   : std_logic := '0';
+  signal timeout_err_r, timeout_err_r_n : std_logic := '0';
+  signal crc_err_r, crc_err_r_n         : std_logic := '0';
+
+  ----------------------------------------------------------------------------
+  -- NEW: CMD latch at posn_valid
+  ----------------------------------------------------------------------------
+  signal cmd_lat_r, cmd_lat_r_n       : std_logic_vector(9 downto 0) := (others => '0');
+  signal cmd_valid_r, cmd_valid_r_n   : std_logic := '0';
+
+  ----------------------------------------------------------------------------
+  -- Output encoding conversion (VHDL-2001 compatible)
+  ----------------------------------------------------------------------------
+  signal posn_enc : std_logic_vector(31 downto 0) := (others => '0');
+
+  -- Gray -> Binary converter (MSB-first Gray code)
+  function gray_to_bin(g : std_logic_vector) return std_logic_vector is
+    variable b : std_logic_vector(g'range);
+  begin
+    b(b'high) := g(g'high);
+    for i in b'high-1 downto b'low loop
+      b(i) := b(i+1) xor g(i);
+    end loop;
+    return b;
+  end function;
+
+  function clamp_1_32(x : unsigned(7 downto 0)) return unsigned is
+  begin
+    if x = 0 then
+      return to_unsigned(1, 8);
+    elsif x > to_unsigned(32, 8) then
+      return to_unsigned(32, 8);
+    else
+      return x;
+    end if;
+  end function;
+
+  ----------------------------------------------------------------------------
+  -- Vivado ILA Debug Attributes
+  ----------------------------------------------------------------------------
+--  attribute mark_debug : string;
+
+--  attribute mark_debug of st              : signal is "true";
+--  attribute mark_debug of sck_ff2         : signal is "true";
+--  attribute mark_debug of dat_ff1         : signal is "true";
+--  attribute mark_debug of dat_ff2         : signal is "true";
+--  attribute mark_debug of dat_edge_r      : signal is "true";
+--  attribute mark_debug of dat_edge_cmd_r  : signal is "true";
+--  attribute mark_debug of sck_edge_gen    : signal is "true";
+--  attribute mark_debug of sck_edge_cmd    : signal is "true";
+--  attribute mark_debug of sck_edge_any    : signal is "true";
+
+--  attribute mark_debug of idle_cnt        : signal is "true";
+--  attribute mark_debug of gap_seen        : signal is "true";
+--  attribute mark_debug of cmd_idx         : signal is "true";
+--  attribute mark_debug of pos_idx         : signal is "true";
+--  attribute mark_debug of crc_rx_idx      : signal is "true";
+--  attribute mark_debug of seek_cnt        : signal is "true";
+--  attribute mark_debug of sclk_cnt        : signal is "true";
+
+--  attribute mark_debug of error_count     : signal is "true";
+--  attribute mark_debug of frame_error_lat : signal is "true";
+
+--  attribute mark_debug of sample_count    : signal is "true";
+--  attribute mark_debug of posn_valid_r    : signal is "true";
+--  attribute mark_debug of frame_age_cnt   : signal is "true";
+
+--  attribute mark_debug of cmd_r           : signal is "true";
+--  attribute mark_debug of cmd_data        : signal is "true";
+--  attribute mark_debug of pos_work        : signal is "true";
+--  attribute mark_debug of pos_out         : signal is "true";
+--  attribute mark_debug of rx_crc_r        : signal is "true";
+
+--  attribute mark_debug of link_up_r       : signal is "true";
+--  attribute mark_debug of err_r           : signal is "true";
+
+--  attribute mark_debug of crc_start_r     : signal is "true";
+--  attribute mark_debug of crc_busy        : signal is "true";
+--  attribute mark_debug of crc_done        : signal is "true";
+--  attribute mark_debug of crc_calc        : signal is "true";
+--  attribute mark_debug of crc_msb_first_s : signal is "true";
+
+--  attribute mark_debug of f1_r            : signal is "true";
+--  attribute mark_debug of f2_r            : signal is "true";
+--  attribute mark_debug of timeout_err_r   : signal is "true";
+--  attribute mark_debug of crc_err_r       : signal is "true";
+
+--  attribute mark_debug of cmd_lat_r       : signal is "true";
+--  attribute mark_debug of cmd_valid_r     : signal is "true";
+
+
+
+begin
+  bits_u    <= unsigned(BITS);
+  bits_clip <= clamp_1_32(bits_u);
+
+  cmd_data <= cmd_r;
+
+  -- CRC order select (VHDL-2001 friendly)
+  crc_msb_first_s <= '1' when (CRC_MSB_FIRST /= 0) else '0';
+
+  -- Outputs
+  posn_o         <= posn_enc;
+  link_up_o      <= link_up_r;
+  error_o        <= err_r;
+
+  -- External monitoring
+  cmd_o          <= cmd_lat_r;
+  cmd_valid_o    <= cmd_valid_r;
+
+  crc_rx_o       <= rx_crc_r;
+  crc_calc_o     <= crc_calc;
+
+  error_count_o  <= std_logic_vector(error_count);
+
+  posn_valid_o   <= posn_valid_r;
+  frame_ok_o     <= posn_valid_r;
+  sample_count_o <= std_logic_vector(sample_count);
+
+
+  ----------------------------------------------------------------------------
+  -- Output encoding conversion
+  ----------------------------------------------------------------------------
+  p_pos_encode : process(pos_out, ENCODING, bits_clip)
+    variable vbits    : integer;
+    variable raw_w    : std_logic_vector(31 downto 0);
+    variable bin32    : std_logic_vector(31 downto 0);
+    variable sign_bit : std_logic;
+    variable tmp      : std_logic_vector(31 downto 0);
+    variable i        : integer;
+  begin
+    vbits := to_integer(bits_clip);  -- 1..32
+
+    raw_w := pos_out;
+    if vbits < 32 then
+      for i in 0 to 31 loop
+        if i >= vbits then
+          raw_w(i) := '0';
+        end if;
+      end loop;
+    end if;
+
+    tmp := (others => '0');
+
+    case ENCODING is
+      when "00" => -- Unsigned Binary
+        tmp := raw_w;
+
+      when "01" => -- Unsigned Gray -> Binary
+        bin32 := gray_to_bin(raw_w);
+        tmp   := bin32;
+
+      when "10" => -- Signed Binary, sign-extend
+        tmp := raw_w;
+        sign_bit := raw_w(vbits-1);
+        if vbits < 32 then
+          for i in 0 to 31 loop
+            if i >= vbits then
+              tmp(i) := sign_bit;
+            end if;
+          end loop;
+        end if;
+
+      when others => -- "11" Signed Gray -> Binary then sign-extend
+        bin32 := gray_to_bin(raw_w);
+        tmp   := bin32;
+        sign_bit := bin32(vbits-1);
+        if vbits < 32 then
+          for i in 0 to 31 loop
+            if i >= vbits then
+              tmp(i) := sign_bit;
+            end if;
+          end loop;
+        end if;
+    end case;
+
+    posn_enc <= tmp;
+  end process;
+
+   
+
+p_sync : process(clk_i)
+  variable rise_now : std_logic;
+  variable fall_now : std_logic;
+  variable gen_edge : std_logic;
+  variable cmd_edge : std_logic;
+begin
+  if rising_edge(clk_i) then
+    if reset_i = '1' then
+      -- Clear synchronizers and edge/snapshot outputs
+      sck_ff1        <= '0';
+      sck_ff2        <= '0';
+      dat_ff1        <= '0';
+      dat_ff2        <= '0';
+      sck_edge_any   <= '0';
+      sck_edge_gen   <= '0';
+      sck_edge_cmd   <= '0';
+      dat_edge_r     <= '0';
+      dat_edge_cmd_r <= '0';
+
+    else
+      -- existing body of p_sync (unchanged)
+      sck_ff1 <= endat_sck_i;
+      sck_ff2 <= sck_ff1;
+
+      dat_ff1 <= endat_dat_i;
+      dat_ff2 <= dat_ff1;
+
+      sck_edge_any <= (sck_ff1 xor sck_ff2);
+
+      -- rising/falling in clk_i domain (using ff1/ff2)
+      rise_now := (sck_ff1 and (not sck_ff2));
+      fall_now := ((not sck_ff1) and sck_ff2);
+
+      -- general selected edge (original behavior)
+      if SAMPLE_FALL = '1' then
+        gen_edge := fall_now;
+      else
+        gen_edge := rise_now;
+      end if;
+
+      -- CMD edge select
+      if CMD_BRISING_EDGE /= 0 then
+        cmd_edge := rise_now;
+      else
+        cmd_edge := gen_edge;
+      end if;
+
+      sck_edge_gen <= gen_edge;
+      sck_edge_cmd <= cmd_edge;
+
+      -- Snapshot DATA on the SAME cycle as GENERAL edge detect
+      if gen_edge = '1' then
+        if dat_ff1 = dat_ff2 then
+          dat_edge_r <= (dat_ff1 xor DATA_INVERT);
+        else
+          dat_edge_r <= dat_edge_r;
+        end if;
+      end if;
+
+      -- Snapshot DATA on the SAME cycle as CMD edge detect
+      if cmd_edge = '1' then
+        if dat_ff1 = dat_ff2 then
+          dat_edge_cmd_r <= (dat_ff1 xor DATA_INVERT);
+        else
+          dat_edge_cmd_r <= dat_edge_cmd_r;
+        end if;
+      end if;
+    end if;
+  end if;
+end process;
+
+
+  ----------------------------------------------------------------------------
+  -- Next-state / combinational logic
+  ----------------------------------------------------------------------------
+  p_comb : process(
+    st, cmd_idx, pos_idx, crc_rx_idx, seek_cnt,
+    sclk_cnt, error_count, frame_error_lat,
+    sample_count, posn_valid_r, frame_age_cnt,
+    cmd_r, pos_work, pos_out, rx_crc_r,
+    link_up_r, err_r,
+    idle_cnt, gap_seen,
+    sck_edge_gen, sck_edge_cmd, sck_edge_any, dat_edge_r, dat_edge_cmd_r, bits_clip,
+    crc_done, crc_calc,
+    f1_r, f2_r, timeout_err_r, crc_err_r,
+    crc_start_r,
+    cmd_lat_r
+  )
+    variable v_dat       : std_logic;
+    variable v_pos_bits  : natural;
+    variable age_sat_max : unsigned(31 downto 0);
+    variable v_cmd_ok    : boolean;
+  begin
+    -- Use CMD snapshot only in ST_SYNC/ST_CMD, otherwise use general snapshot
+    if (st = ST_SYNC) or (st = ST_CMD) then
+      v_dat := dat_edge_cmd_r;
+    else
+      v_dat := dat_edge_r;
+    end if;
+
+    v_pos_bits := to_integer(bits_clip);
+    age_sat_max := (others => '1');
+
+    -- Defaults
+    st_n <= st;
+
+    cmd_idx_n     <= cmd_idx;
+    pos_idx_n     <= pos_idx;
+    crc_rx_idx_n  <= crc_rx_idx;
+    seek_cnt_n    <= seek_cnt;
+
+    sclk_cnt_n <= sclk_cnt;
+
+    error_count_n     <= error_count;
+    frame_error_lat_n <= frame_error_lat;
+
+    sample_count_n    <= sample_count;
+    frame_age_cnt_n   <= frame_age_cnt;
+
+    cmd_r_n     <= cmd_r;
+    pos_work_n  <= pos_work;
+    pos_out_n   <= pos_out;
+    rx_crc_r_n  <= rx_crc_r;
+
+    link_up_r_n <= link_up_r;
+    err_r_n     <= err_r;
+
+    idle_cnt_n  <= idle_cnt;
+    gap_seen_n  <= gap_seen;
+
+    crc_start_r_n   <= '0'; -- pulse
+    posn_valid_r_n  <= '0';
+
+    -- Health sticky bits
+    f1_r_n          <= f1_r;
+    f2_r_n          <= f2_r;
+    timeout_err_r_n <= timeout_err_r;
+    crc_err_r_n     <= crc_err_r;
+
+    -- CMD latch defaults
+    cmd_lat_r_n     <= cmd_lat_r;
+    cmd_valid_r_n   <= '0';
+
+    --------------------------------------------------------------------------
+    -- frame_age counter (clk_i domain)
+    --------------------------------------------------------------------------
+    if frame_age_cnt < age_sat_max then
+      frame_age_cnt_n <= frame_age_cnt + 1;
+    end if;
+
+    --------------------------------------------------------------------------
+    -- stale detection (optional)
+    --------------------------------------------------------------------------
+    if FRAME_STALE_CLKS /= 0 then
+      if frame_age_cnt_n >= to_unsigned(FRAME_STALE_CLKS, frame_age_cnt_n'length) then
+        link_up_r_n <= '0';
+      end if;
+    end if;
+
+    --------------------------------------------------------------------------
+    -- idle counter update (any SCK transition)
+    --------------------------------------------------------------------------
+    if sck_edge_any = '1' then
+      idle_cnt_n <= (others => '0');
+    else
+      if idle_cnt < to_unsigned(65535, idle_cnt'length) then
+        idle_cnt_n <= idle_cnt + 1;
+      end if;
+    end if;
+
+    if idle_cnt_n >= to_unsigned(IDLE_GAP_CLKS, idle_cnt_n'length) then
+      gap_seen_n <= '1';
+    end if;
+
+    --------------------------------------------------------------------------
+    -- CRC done handling (clk_i domain)
+    --------------------------------------------------------------------------
+    if st = ST_CRC_CALC then
+      if crc_done = '1' then
+        if CRC_BYPASS = 1 then
+          link_up_r_n   <= '1';
+          err_r_n       <= '0';
+          pos_out_n     <= pos_work;
+
+          sample_count_n  <= sample_count + 1;
+          frame_age_cnt_n <= (others => '0');
+        else
+          if rx_crc_r = crc_calc then
+            link_up_r_n   <= '1';
+            err_r_n       <= '0';
+
+            sample_count_n  <= sample_count + 1;
+            frame_age_cnt_n <= (others => '0');
+          else
+            err_r_n     <= '1';
+            crc_err_r_n <= '1';
+            if frame_error_lat = '0' then
+              error_count_n     <= error_count + 1;
+              frame_error_lat_n <= '1';
+            end if;
+          end if;
+        end if;
+
+        st_n <= ST_SYNC;
+      end if;
+    end if;
+
+    --------------------------------------------------------------------------
+    -- State machine advances:
+    --   - ST_SYNC / ST_CMD use CMD edge (optional rising-only)
+    --   - other states use general selected edge
+    --------------------------------------------------------------------------
+    if ((st = ST_SYNC) or (st = ST_CMD)) then
+      if sck_edge_cmd = '1' then
+        case st is
+
+          when ST_SYNC =>
+            if gap_seen = '1' then
+              gap_seen_n <= '0';
+              idle_cnt_n <= (others => '0');
+
+              frame_error_lat_n <= '0';
+              err_r_n           <= '0';
+
+              f1_r_n          <= '0';
+              f2_r_n          <= '0';
+              timeout_err_r_n <= '0';
+              crc_err_r_n     <= '0';
+
+              cmd_r_n      <= (others => '0');
+              pos_work_n   <= (others => '0');
+              rx_crc_r_n   <= (others => '0');
+
+              seek_cnt_n   <= (others => '0');
+              pos_idx_n    <= (others => '0');
+              crc_rx_idx_n <= (others => '0');
+
+              sclk_cnt_n <= to_unsigned(1, sclk_cnt_n'length);
+
+              cmd_r_n(C_MODE_BITS-1) <= v_dat;
+              cmd_idx_n <= to_unsigned(1, cmd_idx_n'length);
+
+              st_n <= ST_CMD;
+            end if;
+
+          when ST_CMD =>
+            sclk_cnt_n <= sclk_cnt + 1;
+
+            cmd_r_n(C_MODE_BITS-1 - to_integer(cmd_idx)) <= v_dat;
+
+            if to_integer(cmd_idx) = C_MODE_BITS-1 then
+              cmd_idx_n  <= (others => '0');
+              seek_cnt_n <= (others => '0');
+
+              if CMD_CHECK_EN = 0 then
+                v_cmd_ok := true;
+              else
+                v_cmd_ok := (cmd_r_n = C_CMD_POS);
+              end if;
+
+              if v_cmd_ok then
+                st_n <= ST_SEEK_START;
+              else
+                err_r_n <= '1';
+                if frame_error_lat = '0' then
+                  error_count_n     <= error_count + 1;
+                  frame_error_lat_n <= '1';
+                end if;
+                st_n <= ST_SYNC;
+              end if;
+            else
+              cmd_idx_n <= cmd_idx + 1;
+            end if;
+
+          when others =>
+            st_n <= ST_SYNC;
+
+        end case;
+      end if;
+
+    else
+      if sck_edge_gen = '1' then
+        case st is
+
+          when ST_SEEK_START =>
+            sclk_cnt_n <= sclk_cnt + 1;
+
+            if to_integer(seek_cnt) = integer(C_SEEK_START_TIMEOUT) then
+              err_r_n          <= '1';
+              timeout_err_r_n  <= '1';
+              if frame_error_lat = '0' then
+                error_count_n     <= error_count + 1;
+                frame_error_lat_n <= '1';
+              end if;
+              st_n <= ST_SYNC;
+            else
+              seek_cnt_n <= seek_cnt + 1;
+
+              if v_dat = '1' then
+                -- START found (not included in CRC)
+                pos_work_n   <= (others => '0');
+                rx_crc_r_n   <= (others => '0');
+                pos_idx_n    <= (others => '0');
+                crc_rx_idx_n <= (others => '0');
+
+                st_n <= ST_F1;
+              end if;
+            end if;
+
+          when ST_F1 =>
+            sclk_cnt_n <= sclk_cnt + 1;
+            f1_r_n <= v_dat;
+
+            if G_ENDAT2_2 = 1 then
+              st_n <= ST_F2;
+            else
+              f2_r_n <= '0';
+              st_n   <= ST_POS;
+            end if;
+
+          when ST_F2 =>
+            sclk_cnt_n <= sclk_cnt + 1;
+            f2_r_n <= v_dat;
+            st_n   <= ST_POS;
+
+          when ST_POS =>
+            sclk_cnt_n <= sclk_cnt + 1;
+
+            if to_integer(pos_idx) <= 31 then
+              pos_work_n(to_integer(pos_idx)) <= v_dat;
+            end if;
+
+            if to_integer(pos_idx) = integer(v_pos_bits)-1 then
+              pos_idx_n    <= (others => '0');
+              crc_rx_idx_n <= (others => '0');
+              st_n         <= ST_CRC_RX;
+            else
+              pos_idx_n <= pos_idx + 1;
+            end if;
+
+          when ST_CRC_RX =>
+            sclk_cnt_n <= sclk_cnt + 1;
+
+            -- Capture CRC field MSB-first
+            rx_crc_r_n(4 - to_integer(crc_rx_idx)) <= v_dat;
+
+            if to_integer(crc_rx_idx) = C_CRC_BITS-1 then
+              crc_rx_idx_n <= (others => '0');
+
+              -- Kick off parallel CRC calculation (clk_i domain)
+              crc_start_r_n <= '1';
+
+              -- Commit position (this generates posn_valid pulse)
+              posn_valid_r_n <= '1';
+              pos_out_n      <= pos_work;
+
+              st_n           <= ST_CRC_CALC;
+            else
+              crc_rx_idx_n <= crc_rx_idx + 1;
+            end if;
+
+          when ST_CRC_CALC =>
+            null;
+
+          when others =>
+            st_n <= ST_SYNC;
+
+        end case;
+      end if;
+    end if;
+
+    --------------------------------------------------------------------------
+    -- NEW: latch CMD when we assert posn_valid pulse (same frame commit point)
+    --------------------------------------------------------------------------
+    if posn_valid_r_n = '1' then
+      cmd_lat_r_n   <= cmd_r;   -- cmd_r is stable by this point
+      cmd_valid_r_n <= '1';
+    end if;
+
+  end process;
+
+  ----------------------------------------------------------------------------
+  -- Registers
+  ----------------------------------------------------------------------------
+  p_seq : process(clk_i)
+  begin
+    if rising_edge(clk_i) then
+      if reset_i = '1' then
+        st <= ST_SYNC;
+
+        cmd_idx    <= (others => '0');
+        pos_idx    <= (others => '0');
+        crc_rx_idx <= (others => '0');
+        seek_cnt   <= (others => '0');
+
+        sclk_cnt <= (others => '0');
+
+        error_count     <= (others => '0');
+        frame_error_lat <= '0';
+
+        sample_count  <= (others => '0');
+        posn_valid_r  <= '0';
+        frame_age_cnt <= (others => '0');
+
+        cmd_r     <= (others => '0');
+        pos_work  <= (others => '0');
+        pos_out   <= (others => '0');
+        rx_crc_r  <= (others => '0');
+
+        link_up_r <= '0';
+        err_r     <= '0';
+
+        idle_cnt <= (others => '0');
+        gap_seen <= '0';
+
+        crc_start_r <= '0';
+
+        f1_r          <= '0';
+        f2_r          <= '0';
+        timeout_err_r <= '0';
+        crc_err_r     <= '0';
+
+        cmd_lat_r     <= (others => '0');
+        cmd_valid_r   <= '0';
+
+      else
+        st <= st_n;
+
+        cmd_idx    <= cmd_idx_n;
+        pos_idx    <= pos_idx_n;
+        crc_rx_idx <= crc_rx_idx_n;
+        seek_cnt   <= seek_cnt_n;
+
+        sclk_cnt <= sclk_cnt_n;
+
+        error_count     <= error_count_n;
+        frame_error_lat <= frame_error_lat_n;
+
+        sample_count  <= sample_count_n;
+        posn_valid_r  <= posn_valid_r_n;
+        frame_age_cnt <= frame_age_cnt_n;
+
+        cmd_r     <= cmd_r_n;
+        pos_work  <= pos_work_n;
+        pos_out   <= pos_out_n;
+        rx_crc_r  <= rx_crc_r_n;
+
+        link_up_r <= link_up_r_n;
+        err_r     <= err_r_n;
+
+        idle_cnt <= idle_cnt_n;
+        gap_seen <= gap_seen_n;
+
+        crc_start_r <= crc_start_r_n;
+
+        f1_r          <= f1_r_n;
+        f2_r          <= f2_r_n;
+        timeout_err_r <= timeout_err_r_n;
+        crc_err_r     <= crc_err_r_n;
+
+        cmd_lat_r     <= cmd_lat_r_n;
+        cmd_valid_r   <= cmd_valid_r_n;
+      end if;
+    end if;
+  end process;
+
+
+  ----------------------------------------------------------------------------
+  -- External CRC module instance
+  ----------------------------------------------------------------------------
+  u_endat_crc5 : entity work.endat_crc5
+  generic map (
+    G_ENDAT2_2 => G_ENDAT2_2
+  )
+  port map (
+      clk         => clk_i,
+      rst_n       => not reset_i,
+      start_i     => crc_start_r,
+      num_bits_i  => BITS,           -- POSITION bit-length (e.g., 25)
+      data_i      => pos_work,        -- LSB-first position bits (no header)
+      err_f1_i    => f1_r,            -- F1
+      err_f2_i    => f2_r,            -- F2
+      busy_o      => crc_busy,
+      done_o      => crc_done,
+      crc_o       => crc_calc
+    );
+    
+
+  -- Health bit map
+  -- bit0 OK
+  -- bit1 Linkup error (=not CONN)
+  -- bit2 Timeout error
+  -- bit3 CRC error
+  -- bit4 Error bit active (F1 or F2)
+  -- bit5 ENDAT not implemented   : 0
+  -- bit6 Protocol readback error : 0
+  health_o <= (31 downto 7 => '0') &
+              '0' &  -- bit6
+              '0' &  -- bit5
+              (f1_r or f2_r) &  -- bit4
+              crc_err_r &       -- bit3
+              timeout_err_r &   -- bit2
+              (not link_up_r) & -- bit1
+              (link_up_r and (timeout_err_r or crc_err_r or (f1_r or f2_r))); -- bit0
+                  
+end architecture;
+

--- a/common/hdl/encoders/endat_clock_gen.vhd
+++ b/common/hdl/encoders/endat_clock_gen.vhd
@@ -1,0 +1,136 @@
+--------------------------------------------------------------------------------
+--  PandA Motion Project - 2016
+--      Diamond Light Source, Oxford, UK
+--      SOLEIL Synchrotron, GIF-sur-YVETTE, France
+--
+--  Author      : Dr. Isa Uzun (isa.uzun@diamond.ac.uk)
+--------------------------------------------------------------------------------
+--
+--  Description : Generate N clock pulse with CLK_PERIOD and DEAD_PERIOD at
+--                the end of the clock train.
+--                Active flag starts with the first rising-edge of the clock.
+--                Busy flag starts with the falling of clock and end with dead
+--                period.
+--------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library work;
+use work.support.all;
+
+entity endat_clock_gen is
+generic (
+    DEAD_PERIOD     : natural := 125 * 20
+);
+port (
+    clk_i           : in  std_logic;
+    reset_i         : in  std_logic;
+    N               : in  std_logic_vector(7 downto 0);
+    CLK_PERIOD      : in  std_logic_vector(31 downto 0);
+    start_i         : in  std_logic;
+    enable_cnt_i    : in  std_logic;
+    clock_pulse_o   : out std_logic;
+    active_o        : out std_logic;
+    busy_o          : out std_logic
+);
+end endat_clock_gen;
+
+architecture rtl of endat_clock_gen is
+
+-- Signal declarations
+type fsm_state_t is (WAIT_START, SYNC_TO_CLK, GEN_MCLK, DEADTIME);
+signal fsm_state        : fsm_state_t;
+
+signal serial_clk_2x    : std_logic;
+signal serial_clk       : std_logic;
+signal CLK_PERIOD_2x    : std_logic_vector(31 downto 0);
+signal clock_counter    : natural range 0 to (2**N'length -1 );
+signal dead_counter     : natural range 0 to DEAD_PERIOD;
+
+begin
+
+-- Connect outputs
+clock_pulse_o <= serial_clk;
+
+-- Generate Internal SSI Clock (@2x freq) from system clock
+CLK_PERIOD_2x <= '0' & CLK_PERIOD(31 downto 1);
+
+
+serial_clk_presc : entity work.prescaler
+port map (
+    clk_i       => clk_i,
+    reset_i     => reset_i,
+    PERIOD      => CLK_PERIOD_2x,
+    pulse_o     => serial_clk_2x
+);
+
+ssi_fsm_gen : process(clk_i)
+begin
+    if rising_edge(clk_i) then
+        if reset_i = '1' then
+            serial_clk <= '1';
+            clock_counter <= 0;
+            dead_counter <= 0;
+            active_o <= '0';
+            fsm_state <= WAIT_START;
+        else
+            -- SSI Clock Generator FSM
+            case (fsm_state) is
+                -- Wait for SSI frame trigger
+                when WAIT_START =>
+                    serial_clk <= '1';
+                    clock_counter <= 0;
+                    dead_counter <= 0;
+
+                    if (start_i = '1') then
+                        fsm_state <= SYNC_TO_CLK;
+                    end if;
+
+                -- Sync to next internal SSI clock
+                when SYNC_TO_CLK =>
+                    if (serial_clk_2x = '1') then
+                        fsm_state <= GEN_MCLK;
+                        serial_clk <= '0';
+                    end if;
+
+                -- Generate N clock pulses.
+                -- Active flag is asserted with the first-rising edge of
+                -- the serial clock.
+                when GEN_MCLK =>
+                    if (serial_clk_2x = '1') then
+                        active_o <= '1';
+                        serial_clk <= not serial_clk;
+                    end if;
+
+                    -- Keep track of number of BITS received
+                    if (serial_clk_2x = '1' and serial_clk = '0') then
+                        if (enable_cnt_i = '1') then
+                            clock_counter <= clock_counter + 1;
+                        end if;
+                        if (clock_counter = to_integer(unsigned(N)))then
+                            fsm_state <= DEADTIME;
+                            active_o <= '0';
+                        end if;
+                    end if;
+
+                -- Wait for DEADTIME
+                when DEADTIME =>
+                    dead_counter <= dead_counter + 1;
+
+                    if (dead_counter = DEAD_PERIOD - 1) then
+                        fsm_state <= WAIT_START;
+                    end if;
+
+                when others =>
+            end case;
+        end if;
+    end if;
+end process;
+
+-- Serial interface busy
+busy_o <= '0' when (fsm_state = WAIT_START) else '1';
+
+end rtl;
+

--- a/common/hdl/encoders/endat_crc5.vhd
+++ b/common/hdl/encoders/endat_crc5.vhd
@@ -1,0 +1,251 @@
+
+
+
+--Input stream (LSB-first): [F1] + position[bit0..bit24].
+--LFSR seed: 11111.
+--Per-bit update: ex = s4 ⊕ bit_in, then
+--s4' = s3, s3' = s2 ⊕ ex, s2' = s1, s1' = s0 ⊕ ex, s0' = ex.
+--Final step: bitwise complement of the state, read out MSB→LSB to form 5-bit CRC.
+--Polynomial (in this convention): G(x)=x5+x2+1G(x) = x^5 + x^2 + 1G(x)=x5+x2+1.
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- EnDat CRC-5 over a bit vector, LSB-first
+-- LFSR init = 11111, update per bit:
+--   ex = ff(4) XOR bit_in
+--   ff(4) <- ff(3)
+--   ff(3) <- ff(2) XOR ex
+--   ff(2) <- ff(1)
+--   ff(1) <- ff(0) XOR ex
+--   ff(0) <- ex
+-- After all bits, CRC output = NOT ff(4)..NOT ff(0) (MSB..LSB)
+--
+-- G_ENDAT2_2 determines the header length:
+--   0: Include F1 only  (num_bits = position_bits + 1)
+--   1: Include F1 + F2  (num_bits = position_bits + 2)
+--
+-- On start_i, data_reg is constructed internally:
+--   G_ENDAT2_2=0: data_reg <= data_i(30 downto 0) & f1_r           -- LSB = F1
+--   G_ENDAT2_2=1: data_reg <= data_i(29 downto 0) & err_f2_i & err_f1_i  -- LSB = F1, next = F2
+--
+-- data_i carries POSITION bits (LSB-first) only.
+
+entity endat_crc5 is
+  generic (
+    G_ENDAT2_2 : natural := 0  -- 0: include F1 only; 1: include F1 + F2 (EnDat 2.2 framing)
+  );
+  port (
+    clk         : in  std_logic;
+    rst_n       : in  std_logic;
+
+    start_i     : in  std_logic;  -- single-cycle pulse to start
+
+    -- Provide POSITION bit-length only (e.g., 25).
+    -- The module will add +1 (F1) or +2 (F1+F2) internally, based on G_ENDAT2_2.
+    num_bits_i  : in  std_logic_vector(7 downto 0);
+
+    -- POSITION bits LSB-first in data_i.
+    -- F1/F2 are provided on separate ports err_f1_i / err_f2_i and will be prepended internally.
+    data_i      : in  std_logic_vector(31 downto 0);
+
+    -- Header error bits (F1/F2), LSB-first consumption order:
+    --   For G_ENDAT2_2=0: only F1 is used.
+    --   For G_ENDAT2_2=1: F1 is first, then F2.
+    err_f1_i    : in  std_logic;
+    err_f2_i    : in  std_logic;
+
+    busy_o      : out std_logic;  -- asserted while processing bits
+    done_o      : out std_logic;  -- single-cycle pulse when CRC is ready
+    crc_o       : out std_logic_vector(4 downto 0)  -- MSB..LSB after bitwise complement
+  );
+end entity;
+
+architecture rtl of endat_crc5 is
+  -- LFSR state (5 bits), initialized to all-ones (11111).
+  signal ff_r          : std_logic_vector(4 downto 0) := (others => '1');
+
+  -- Latched input data and computed bit-count.
+  signal data_reg      : std_logic_vector(31 downto 0) := (others => '0');
+  signal num_bits_reg  : unsigned(7 downto 0) := (others => '0');
+
+  -- Current bit index (LSB-first), control and output.
+  signal idx_r         : unsigned(7 downto 0) := (others => '0');
+  signal busy_r        : std_logic := '0';
+  signal done_r        : std_logic := '0';
+  signal crc_r         : std_logic_vector(4 downto 0) := (others => '0');
+
+  -- Internal aliases for clarity
+  signal f1_r          : std_logic;
+  signal f2_r          : std_logic;
+begin
+  -- Alias external inputs
+  f1_r <= err_f1_i;
+  f2_r <= err_f2_i;
+
+  busy_o <= busy_r;
+  done_o <= done_r;
+  crc_o  <= crc_r;
+
+  process(clk, rst_n)
+    variable bit_in_v : std_logic;                 -- current input bit
+    variable ex_v     : std_logic;                 -- ex = ff(4) XOR bit_in
+    variable f_next   : std_logic_vector(4 downto 0); -- next LFSR state
+    variable nb_u     : unsigned(7 downto 0);      -- local unsigned copy of num_bits_i
+  begin
+    if rst_n = '0' then
+      -- Asynchronous active-low reset
+      ff_r         <= (others => '1');   -- LFSR init = 11111
+      data_reg     <= (others => '0');
+      num_bits_reg <= (others => '0');
+      idx_r        <= (others => '0');
+      busy_r       <= '0';
+      done_r       <= '0';
+      crc_r        <= (others => '0');
+
+    elsif rising_edge(clk) then
+      -- default: clear done pulse
+      done_r <= '0';
+
+      if busy_r = '0' then
+        -- Idle: wait for start pulse
+        if start_i = '1' then
+          -- Build the working bit vector inside the module (LSB-first):
+          -- HEADER (F1[,F2]) + POSITION bits from data_i
+          if G_ENDAT2_2 = 0 then
+            -- Use 31 bits from data_i (position) and append F1 as LSB: total 32 bits
+            -- Result mapping: data_reg(0) = F1, data_reg(31 downto 1) = data_i(30 downto 0)
+            data_reg <= data_i(30 downto 0) & f1_r;
+          else
+            -- Use 30 bits from data_i (position), append F2 then F1 as LSBs: total 32 bits
+            -- Result mapping: data_reg(0)=F1, data_reg(1)=F2, data_reg(31 downto 2)=data_i(29 downto 0)
+            data_reg <= data_i(29 downto 0) & f2_r & f1_r;
+          end if;
+
+          -- num_bits_i carries POSITION bit-length only.
+          -- Add header bits depending on G_ENDAT2_2:
+          nb_u := unsigned(num_bits_i);
+          if G_ENDAT2_2 = 0 then
+            num_bits_reg <= nb_u + 1;  -- include F1
+          else
+            num_bits_reg <= nb_u + 2;  -- include F1 + F2
+          end if;
+
+          -- Initialize processing
+          idx_r  <= (others => '0');
+          ff_r   <= (others => '1');   -- LFSR init = 11111
+          busy_r <= '1';
+        end if;
+
+      else
+        -- Busy: process one bit per cycle (LSB-first)
+        if to_integer(idx_r) < to_integer(num_bits_reg) then
+          -- Consume current bit from data_reg (LSB-first)
+          bit_in_v := data_reg(to_integer(idx_r));
+
+          -- LFSR update per bit:
+          -- ex = ff(4) XOR bit_in
+          ex_v     := ff_r(4) xor bit_in_v;
+
+          -- next state mapping (matches Python reference):
+          f_next(4) := ff_r(3);
+          f_next(3) := ff_r(2) xor ex_v;
+          f_next(2) := ff_r(1);
+          f_next(1) := ff_r(0) xor ex_v;
+          f_next(0) := ex_v;
+
+          -- Apply next state
+          ff_r <= f_next;
+
+          -- Last bit processed?
+          if idx_r = (num_bits_reg - 1) then
+            busy_r <= '0';
+            done_r <= '1';
+            -- Output CRC: bitwise complement (~) of LFSR, MSB..LSB
+            crc_r  <= (not f_next(4)) & (not f_next(3)) & (not f_next(2)) & (not f_next(1)) & (not f_next(0));
+          else
+            -- Advance to next bit
+            idx_r <= idx_r + 1;
+          end if;
+
+        else
+          -- Safety: if num_bits_reg = 0, finish with complement of initial state
+          busy_r <= '0';
+          done_r <= '1';
+          crc_r  <= (not ff_r(4)) & (not ff_r(3)) & (not ff_r(2)) & (not ff_r(1)) & (not ff_r(0));
+        end if;
+      end if;
+    end if;
+  end process;
+end architecture;
+
+
+
+
+--def endat_crc5_with_f1(position_value: int, f1: int, num_pos_bits: int = 25) -> int:
+--    """
+--    Compute EnDat CRC-5 over a 26-bit LSB-first stream constructed as:
+--      [F1] + [position bit0, bit1, ..., bit24]
+
+--    Conventions:
+--      - LFSR initial state: 11111 (all ones)
+--      - Input order: LSB-first (F1 first, then position bit0 → bit24)
+--      - Final step: bitwise complement of the LFSR state before output
+--      - Output: read MSB→LSB of the complemented state to form a 5-bit integer (0..31)
+
+--    The LFSR update corresponds to the CRC-5 polynomial:
+--      G(x) = x^5 + x^2 + 1
+--    under LSB-first processing with an all-ones seed and final complement.
+
+--    Args:
+--        position_value: Position value as an integer; only the lowest `num_pos_bits` are used.
+--        f1: Fault1 bit (0 or 1); this is processed first (LSB).
+--        num_pos_bits: Number of position bits to process (default: 25).
+
+--    Returns:
+--        5-bit CRC as an integer in the range 0..31.
+--    """
+--    # Use only the lowest `num_pos_bits` of the position and ensure f1 is a single bit
+--    position_value &= (1 << num_pos_bits) - 1
+--    f1 &= 1
+
+--    # ---- LFSR initial state: all ones (11111) ----
+--    # ff[0] is LSB of the register, ff[4] is MSB
+--    ff = [1, 1, 1, 1, 1]
+
+--    def lfsr_update(bit_in: int):
+--        """
+--        Process one input bit using the CRC-5 LFSR update rule.
+
+--        State transition (with ex = s4 XOR bit_in):
+--            s4' = s3
+--            s3' = s2 XOR ex
+--            s2' = s1
+--            s1' = s0 XOR ex
+--            s0' = ex
+--        """
+--        ex = ff[4] ^ bit_in
+--        ff[4] = ff[3]
+--        ff[3] = ff[2] ^ ex
+--        ff[2] = ff[1]
+--        ff[1] = ff[0] ^ ex
+--        ff[0] = ex
+
+--    # 1) Process F1 bit first (LSB in the stream)
+--    lfsr_update(f1)
+
+--    # 2) Process the position bits in LSB-first order: bit0 → bit(num_pos_bits-1)
+--    for i in range(num_pos_bits):
+--        bit = (position_value >> i) & 1
+--        lfsr_update(bit)
+
+--    # ---- Final complement (~) and assemble 5-bit CRC MSB→LSB ----
+--    crc = 0
+--    for i in range(4, -1, -1):
+--        # Complement each bit: output 0 if register bit is 1, output 1 if register bit is 0
+--        crc = (crc << 1) | (0 if ff[i] else 1)
+
+--    return crc & 0x1F  # Ensure result is 5 bits
+    

--- a/common/hdl/encoders/endat_slave.vhd
+++ b/common/hdl/encoders/endat_slave.vhd
@@ -1,0 +1,314 @@
+--
+--
+-- 1/30/26: from George (Faraday Motion Controls)
+--
+-- 1/15/26: Test with the Power PMAC and EnDat 25 bit Encoder configuration
+--          Test with the EnDat master and Sniffer
+--   HEIDENHAIN ECN 425 2048
+--   ECN 425 EnDat 2.2(EnDat22) interface 
+--   Singleturn 25bit(33,554,432 pos/rev), 
+--
+--   added ENDAT_S_SCLKDLY_CNT for adjust delay, default was 5, however with hardware need to set 4
+--   added "crc_calc_reg" for CRC calculation monitoring
+
+
+
+library ieee;
+use ieee.numeric_std.all;
+use ieee.std_logic_1164.all;
+
+library work;
+use work.support.all;
+
+entity endat_slave is
+generic (
+    MAX_DATA_WIDTH      : integer := 32;
+    SYS_CLOCK_FREQ_MHz  : integer := 125;
+    STOP_TIME_uS        : integer := 2;
+    TIMEOUT_mS          : integer := 10;
+    ENDAT_S_SCLKDLY_CNT : integer := 4    -- was 5, Power with PMAC and EnDat encoder it works with 4, total 46 clocks from master
+);
+port (
+    -- Global system and reset interface.
+    clk_i               : in  std_logic;
+    reset_i             : in  std_logic;
+    -- Configuration interface.
+    ENCODING            : in  std_logic_vector(1 downto 0); -- Currently ignored.
+    BITS                : in  std_logic_vector(7 downto 0);
+    enable_i            : in  std_logic;
+    GENERATOR_ERROR     : in  std_logic;
+    health_o            : out std_logic_vector(31 downto 0);
+    -- Block Input and Outputs.
+    posn_i              : in  std_logic_vector(31 downto 0);
+    endat_clk_i         : in  std_logic;
+    endat_data_i        : in  std_logic;
+    endat_data_o        : out std_logic;
+    endat_wr_nrd_o      : out std_logic
+);
+end entity;
+
+
+architecture rtl of endat_slave is
+
+
+    constant STOP_TIME_CYCLES    : integer := STOP_TIME_uS * SYS_CLOCK_FREQ_MHz;
+    constant TIMEOUT_CLK_CYCLES  : integer := TIMEOUT_mS * SYS_CLOCK_FREQ_MHz *1000;
+
+    type endat_state_t is
+    (
+        ENDAT_IDLE,
+        ENDAT_CMD,
+        
+        ENDAT_P,
+        
+        ENDAT_S,
+        ENDAT_F1,
+        ENDAT_DATA,
+        ENDAT_CRC,
+	
+	ENDAT_STOP
+    );
+
+    signal clk_in       : std_logic;
+    signal data_in      : std_logic;
+    signal data_out     : std_logic;
+	signal data_rd      : std_logic;
+    
+    signal clk_prev     : std_logic;
+
+    signal state        : endat_state_t;
+
+    signal cmd_val      : std_logic_vector(5 downto 0);
+    signal data_sr      : std_logic_vector(MAX_DATA_WIDTH downto 0);
+    signal error_flag   : std_logic;
+    signal timeout_flag : std_logic;
+
+    -- Checksum Flipflops
+    signal FF0          : std_logic;
+    signal FF1          : std_logic;
+    signal FF2          : std_logic;
+    signal FF3          : std_logic;
+    signal FF4          : std_logic;
+    signal S            : std_logic;
+    signal cs1          : std_logic;
+    signal cs2          : std_logic;
+    
+    
+    
+    signal crc_calc_reg : std_logic_vector(4 downto 0) := (others => '0');
+  ----------------------------------------------------------------------------
+  -- Vivado ILA Debug Attributes
+  ----------------------------------------------------------------------------
+  attribute mark_debug : string;
+
+  attribute mark_debug of error_flag      : signal is "true";
+  attribute mark_debug of timeout_flag    : signal is "true"; 
+  attribute mark_debug of cmd_val         : signal is "true"; 
+  attribute mark_debug of data_sr         : signal is "true";
+  attribute mark_debug of state           : signal is "true";               
+  attribute mark_debug of crc_calc_reg    : signal is "true";
+  
+  
+begin
+
+-- Data in/out and direction signals...
+-- (Bidirectional switching done in higher level)
+data_in        <= endat_data_i;
+endat_data_o   <= data_out;
+endat_wr_nrd_o <= not data_rd when enable_i = '1' else '0';
+
+-- Health signal...
+-- (0 is OK, 2 is EnDat Command Error, 3 is EnDat Timeout)
+health_o <= std_logic_vector(to_unsigned(3,32)) when timeout_flag = '1' else
+            std_logic_vector(to_unsigned(2,32)) when error_flag = '1' else 
+            std_logic_vector(to_unsigned(0,32)); 
+
+-- Sync clk input to FPGA clock...
+process (clk_i)
+begin
+    if (rising_edge (clk_i)) then
+        clk_in <= endat_clk_i;
+    end if;
+end process;
+
+
+-- Main State Machine...
+process (clk_i)
+    variable bit_count      : integer range 0 to 63 := 0;
+    variable timeout        : integer range 0 to TIMEOUT_CLK_CYCLES := 0;
+    variable clk_high_timer : integer range 0 to STOP_TIME_CYCLES := 0;
+begin
+    if (rising_edge(clk_i)) then
+        
+        -- Detect edge of endat clock...
+        if clk_prev /= clk_in  then
+
+            clk_prev <= clk_in;
+            timeout := 0;
+            timeout_flag <= '0';
+
+            -- process according to rising or falling edge...
+            if clk_in = '0' then
+            
+                case state is       -- FALLING EDGE
+                                      
+                    when ENDAT_IDLE =>
+                        bit_count := 0;
+                        state <= ENDAT_CMD;
+                        data_rd <= '1';
+                        data_sr <= posn_i & '0';
+                        
+                    when ENDAT_CMD =>
+                        if bit_count = 8 then
+                            state <= ENDAT_P;
+                            bit_count := 0;
+                        elsif bit_count = 7 then
+                            if cmd_val(5 downto 0) = "000111" then
+                                error_flag <= '0';
+                            else
+                                error_flag <= '1';
+                            end if;
+                            data_sr(0) <= error_flag;
+                            data_rd <= '0';
+                            data_out <= '0';
+                            bit_count := bit_count + 1;
+                        else
+                            bit_count := bit_count + 1;
+                        end if; 
+                                        
+                    when ENDAT_P =>     null;
+                    when ENDAT_S =>     null;
+                    when ENDAT_F1 =>    null;
+                    when ENDAT_DATA =>  null;
+                    when ENDAT_CRC =>   null;
+                    when ENDAT_STOP =>  null;
+                    when others =>      null;
+                    
+                end case;
+            
+            else                    -- RISING EDGE
+
+                case state is
+
+                    when ENDAT_IDLE =>  null;
+                    
+                    when ENDAT_CMD =>
+                        cmd_val <= cmd_val(4 downto 0) & data_in;
+
+                    when ENDAT_P =>
+                        --if bit_count = 5 then     
+                        if bit_count = ENDAT_S_SCLKDLY_CNT then -- Power PMAC and EnDat encoder test setup  
+                                       
+                            state <= ENDAT_S;
+                        else
+                            bit_count := bit_count +1;
+                        end if;
+                        
+                    when ENDAT_S =>
+                        data_out <= '1';
+                        FF0 <= '1';
+                        FF1 <= '1';
+                        FF2 <= '1';
+                        FF3 <= '1';
+                        FF4 <= '1';
+                        S <= '1';
+                        bit_count := 0;
+                        state <= ENDAT_F1;
+                                                
+                    when ENDAT_F1 =>
+                        data_out <= data_sr(0);
+                        data_sr <= '0' & data_sr(MAX_DATA_WIDTH downto 1);
+                        state <= ENDAT_DATA;
+                        
+                    when ENDAT_DATA =>
+                        --if bit_count = MAX_DATA_WIDTH-1 then
+                        if bit_count = to_integer(unsigned(BITS))-1 then
+                            data_out <= data_sr(0);
+                            S <= '0';
+                            bit_count := 0;
+                            state <= ENDAT_CRC;
+                        else
+                            data_out <= data_sr(0);
+                            data_sr <= '0' & data_sr(MAX_DATA_WIDTH downto 1);
+                            bit_count := bit_count +1;
+                        end if;
+                        
+                    when ENDAT_CRC =>
+                        -- Latch the computed CRC (before the CRC shift-out starts)
+                        if bit_count = 0 then
+                            crc_calc_reg <= (not FF4) & (not FF3) & (not FF2) & (not FF1) & (not FF0);
+                        end if;
+
+                        if bit_count = 5 then
+                            data_out <= '1';
+                            state <= ENDAT_STOP;
+                          --It was (VHDL-2008 style)  
+--                        else
+--                            -- output CRC bit or force CRC error
+--                            data_out <= not FF4 when GENERATOR_ERROR = '0' else '1'; 
+--                            bit_count := bit_count +1;
+--                        end if;
+
+                        else
+                            -- output CRC bit or force CRC error (VHDL-2001 style)
+                            if GENERATOR_ERROR = '0' then
+                                data_out <= not FF4;
+                            else
+                                data_out <= '1';
+                            end if;                    
+                            bit_count := bit_count + 1;
+                        end if;
+
+                    when ENDAT_STOP =>  null;
+
+                    when others =>      null;
+
+                end case;
+                
+                -- Checksum calculation...
+                if (state = ENDAT_F1) or (state = ENDAT_DATA) or (state = ENDAT_CRC) then
+                    FF0 <= cs1;
+                    FF1 <= FF0 xor cs2;
+                    FF2 <= FF1;
+                    FF3 <= FF2 xor cs2;
+                    FF4 <= FF3;
+                end if;
+                
+            end if;
+
+        end if;
+
+        -- Stop Timer... Time how low the clock has been high...
+        if  clk_in = '1' and state /= ENDAT_IDLE then
+            if clk_high_timer = STOP_TIME_CYCLES then
+                state <= ENDAT_IDLE;
+                data_rd <= '0';
+                data_out <= '0';
+            else
+                clk_high_timer := clk_high_timer + 1;
+            end if;
+        else
+            clk_high_timer := 0;
+        end if;
+        
+        
+        -- Power-On Reset or Timeout if no clock edges detected...
+        if reset_i = '1' or timeout = TIMEOUT_CLK_CYCLES then
+            state <= ENDAT_IDLE;
+            data_rd <= '0';
+            data_out <= '0';
+            timeout_flag <= '1';
+        else
+            timeout := timeout + 1;
+        end if;
+        
+    end if;
+
+end process;
+
+-- Checksum intermediate signals...
+cs1 <= (FF4 and S) xor (data_sr(0) and S);
+cs2 <= cs1 and S;
+
+
+end rtl;

--- a/modules/inenc/inenc.block.ini
+++ b/modules/inenc/inenc.block.ini
@@ -85,15 +85,16 @@ type: read enum
 description: Table status
 0: OK
 1: Linkup error (=not CONN)
-2: Timeout error (for BISS, SSI)
-3: CRC error (for BISS)
-4: Error bit active (for BISS)
+2: Timeout error (for ENDAT, BISS, SSI)
+3: CRC error (for ENDAT, BISS)
+4: Error bit active (for ENDAT, BISS)
 5: ENDAT not implemented
 6: Protocol readback error
 
 [VAL]
 type: pos_out
 description: Current position
+
 
 [DCARD_TYPE]
 type: read enum


### PR DESCRIPTION
Added below files for the EnDat encoder modules:
I tested all modules with Power PMAC and HEIDENHAIN ECN 425 2048 encoder: endat2_master.vhd, endat2_sniffer.vhd, endat_slave.vhd 
common/hdl/encoders/encoders.vhd
common/hdl/encoders/endat2_master.vhd
common/hdl/encoders/endat2_sniffer.vhd
common/hdl/encoders/endat_clock_gen.vhd
common/hdl/encoders/endat_crc5.vhd
common/hdl/encoders/endat_slave.vhd
modules/inenc/inenc.block.ini
