### PR TITLE
lvdsout: Add field to have an estimation of the fine delay resolution

### DIFF
--- a/common/hdl_zynqmp/finedelay2.vhd
+++ b/common/hdl_zynqmp/finedelay2.vhd
@@ -12,6 +12,7 @@ port (
     fine_delay_i : in std_logic_vector(8 downto 0);
     fine_delay_wstb_i : in std_logic;
     fine_delay_compensated_o : out std_logic_vector(8 downto 0);
+    initial_fine_delay_o : out std_logic_vector(8 downto 0);
     signal_i : in std_logic;
     signal_o : out std_logic
 );
@@ -34,6 +35,7 @@ begin
         fine_delay_i => fine_delay_i,
         fine_delay_wstb_i => fine_delay_wstb_i,
         fine_delay_compensated_o => fine_delay_compensated_o,
+        initial_fine_delay_o => initial_fine_delay_o,
         signal_i => signal_oct,
         signal_o => signal_o
     );

--- a/common/hdl_zynqmp/o_finedelay.vhd
+++ b/common/hdl_zynqmp/o_finedelay.vhd
@@ -12,6 +12,7 @@ entity o_finedelay is
         fine_delay_i : in std_logic_vector(8 downto 0);
         fine_delay_wstb_i : in std_logic;
         fine_delay_compensated_o : out std_logic_vector(8 downto 0) := (others => '0');
+        initial_fine_delay_o : out std_logic_vector(8 downto 0) := (others => '0');
         signal_i : in std_logic;
         signal_o : out std_logic
     );
@@ -21,38 +22,57 @@ architecture rtl of o_finedelay is
     signal en_vtc : std_logic := '1';
     signal load : std_logic := '0';
     signal odelay_cnt_in_latch : std_logic_vector(8 downto 0) := (others => '0');
-    type state_t is (IDLE, WAIT_AFTER_DISABLE, PRELOAD, START_LOAD, WAIT_BEFORE_ENABLE);
-    signal state : state_t := IDLE;
-    signal wait_counter : unsigned(3 downto 0) := (others => '1');
+    signal fine_delay_compensated : std_logic_vector(8 downto 0);
+    type state_t is (
+        START, IDLE, WAIT_AFTER_DISABLE, DELAY_LOAD, START_LOAD,
+        WAIT_BEFORE_ENABLE);
+    signal state : state_t := START;
+    signal wait_counter : unsigned(5 downto 0) := (others => '0');
+    constant C_START_WAIT : unsigned(5 downto 0) := to_unsigned(63, 6);
+    constant C_EN_VTC_WAIT : unsigned(5 downto 0) := to_unsigned(10, 6);
 begin
+    fine_delay_compensated_o <= fine_delay_compensated;
+
     process(clk_i)
     begin
         if rising_edge(clk_i) then
             case state is
+                when START =>
+                    if calibration_ready_i then
+                        if wait_counter = C_START_WAIT then
+                            wait_counter <= (others => '0');
+                            initial_fine_delay_o <= fine_delay_compensated;
+                            state <= IDLE;
+                        else
+                            wait_counter <= wait_counter + 1;
+                        end if;
+                    else
+                        wait_counter <= (others => '0');
+                    end if;
                 when IDLE =>
                     load <= '0';
-                    wait_counter <= (others => '1');
+                    wait_counter <= (others => '0');
                     if fine_delay_wstb_i and calibration_ready_i then
                         state <= WAIT_AFTER_DISABLE;
                         en_vtc <= '0';
                     end if;
                 when WAIT_AFTER_DISABLE =>
                     load <= '0';
-                    wait_counter <= wait_counter - 1;
-                    if wait_counter = 0 then
+                    wait_counter <= wait_counter + 1;
+                    if wait_counter = C_EN_VTC_WAIT then
                         odelay_cnt_in_latch <= fine_delay_i;
-                        state <= PRELOAD;
+                        state <= DELAY_LOAD;
                     end if;
-                when PRELOAD =>
+                when DELAY_LOAD =>
                     state <= START_LOAD;
                 when START_LOAD =>
                     load <= '1';
                     state <= WAIT_BEFORE_ENABLE;
-                    wait_counter <= (others => '1');
+                    wait_counter <= (others => '0');
                 when WAIT_BEFORE_ENABLE =>
                     load <= '0';
-                    wait_counter <= wait_counter - 1;
-                    if wait_counter = 0 then
+                    wait_counter <= wait_counter + 1;
+                    if wait_counter = C_EN_VTC_WAIT then
                         en_vtc <= '1';
                         state <= IDLE;
                     end if;
@@ -77,7 +97,7 @@ begin
         RST => '0',
         LOAD => load,
         CNTVALUEIN => odelay_cnt_in_latch,
-        CNTVALUEOUT => fine_delay_compensated_o,
+        CNTVALUEOUT => fine_delay_compensated,
         ODATAIN => signal_i,
         DATAOUT => signal_o
     );

--- a/modules/lvdsout/hdl_zynqmp/lvdsout_block.vhd
+++ b/modules/lvdsout/hdl_zynqmp/lvdsout_block.vhd
@@ -17,6 +17,7 @@ port (
     FINE_DELAY : in std_logic_vector(31 downto 0);
     FINE_DELAY_wstb : in std_logic;
     FINE_DELAY_COMPENSATED : out std_logic_vector(31 downto 0) := (others => '0');
+    INITIAL_ONE_NS : out std_logic_vector(31 downto 0) := (others => '0');
     -- Inputs
     val : in std_logic;
     -- Output pulse
@@ -37,6 +38,7 @@ begin
             fine_delay_i => FINE_DELAY(8 downto 0),
             fine_delay_wstb_i => FINE_DELAY_wstb,
             fine_delay_compensated_o => FINE_DELAY_COMPENSATED(8 downto 0),
+            initial_fine_delay_o => INITIAL_ONE_NS(8 downto 0),
             signal_i => val,
             signal_o => pad_iob
         );

--- a/modules/lvdsout/hdl_zynqmp/lvdsout_top.vhd
+++ b/modules/lvdsout/hdl_zynqmp/lvdsout_top.vhd
@@ -41,6 +41,7 @@ architecture rtl of lvdsout_top is
     signal fine_delay : std32_array(LVDSOUT_NUM-1 downto 0);
     signal fine_delay_wstb : std_logic_vector(LVDSOUT_NUM-1 downto 0);
     signal fine_delay_compensated : std32_array(LVDSOUT_NUM-1 downto 0);
+    signal initial_one_ns : std32_array(LVDSOUT_NUM-1 downto 0);
     signal val : std_logic_vector(LVDSOUT_NUM-1 downto 0);
 begin
     -- Acknowledgement to AXI Lite interface
@@ -67,6 +68,7 @@ begin
             FINE_DELAY => fine_delay(I),
             FINE_DELAY_WSTB => fine_delay_wstb(I),
             FINE_DELAY_COMPENSATED => fine_delay_compensated(I),
+            INITIAL_ONE_NS => initial_one_ns(I),
             -- Memory Bus Interface
             read_strobe_i => read_strobe(I),
             read_address_i => read_address_i(BLK_AW-1 downto 0),
@@ -89,6 +91,7 @@ begin
             FINE_DELAY => fine_delay(I),
             FINE_DELAY_WSTB => fine_delay_wstb(I),
             FINE_DELAY_COMPENSATED => fine_delay_compensated(I),
+            INITIAL_ONE_NS => initial_one_ns(I),
             -- Block inputs
             val => val(I),
             -- Block outputs

--- a/modules/lvdsout/lvdsout_zynqmp.block.ini
+++ b/modules/lvdsout/lvdsout_zynqmp.block.ini
@@ -10,12 +10,17 @@ if-option: fine_delay
 [FINE_DELAY]
 type: param uint 511
 description: Fine delay (range 0-511)
+initial_value: 255
 if-option: fine_delay
 wstb: true
 
 [FINE_DELAY_COMPENSATED]
 type: read uint 511
 description: Fine delay readout considering voltage/time compensation
+
+[INITIAL_ONE_NS]
+type: read uint 511
+description: Initial fine delay readout for a delay of 1ns
 
 [VAL]
 type: bit_mux


### PR DESCRIPTION
The new fieldd contains the fine delay that corresponds to 1ns when the FPGA is loaded.