### PR TITLE
Don't include template designs in FPGA package

### DIFF
--- a/packaging/make-fpga-ipk.sh
+++ b/packaging/make-fpga-ipk.sh
@@ -37,6 +37,4 @@ mkdir -p "$FPGA_DIR"
 cp -a "$BUILD_DIR/autogen/config_d" "$FPGA_DIR/config_d"
 cp -a "$BUILD_DIR/extensions" "$BUILD_DIR/ipmi.ini" \
     "$BUILD_DIR/FPGA/panda_top.bin" "$FPGA_DIR/"
-mkdir "$FPGA_DIR/template_designs"
-cp "$TOP_DIR/docs/tutorials/"*.json "$FPGA_DIR/template_designs"
 $TOP_DIR/packaging/make-ipk.sh "$IPK_DIR" "$BUILD_DIR/${PACKAGE}_${VERSION}_all.ipk"


### PR DESCRIPTION
They were moved to webcontrol(in meta-panda)